### PR TITLE
Basic Octopart Zero-Info Plugin

### DIFF
--- a/lib/DDG/Spice/Octopart.pm
+++ b/lib/DDG/Spice/Octopart.pm
@@ -4,9 +4,19 @@ use DDG::Spice;
 
 triggers any => "datasheet";
 
-# no API key; will saturate ratelimiter unless host IPs are whitelisted
 # see: http://octopart.com/api/documentation
-spice to => 'https://www.octopart.com/api/v2/parts/search?callback={{callback}}&limit=3&optimize.hide_offers=1&optimize.hide_specs=1&q=$1'
+sub nginx_conf {
+    my $api_key = $ENV{DDG_SPICE_OCTOPART_APIKEY}; 
+    return unless defined $api_key;
+    $nginx_conf = <<"__END_OF_CONF__";
+
+location ^~ /js/spice/octopart/ {
+    rewrite ^/js/spice/octopart/(.*) /api/v2/parts/search?callback=ddg_spice_octopart&apikey=$api_key&limit=3&optimize.hide_offers=1&optimize.hide_specs=1&q=$1 break;
+    proxy_pass https://www.octopart.com/;
+}
+
+__END_OF_CONF__
+}
 
 handle query_lc => sub {
     if ($_ =~ /^\s*(?:(datasheet))?\s*([\w\-]+)(?:\s(datasheet))?\s*$/i) {

--- a/lib/DDG/Spice/Octopart.pm
+++ b/lib/DDG/Spice/Octopart.pm
@@ -4,10 +4,14 @@ use DDG::Spice;
 
 triggers any => "datasheet";
 
+# no API key; will saturate ratelimiter unless host IPs are whitelisted
+# see: http://octopart.com/api/documentation
+spice to => 'https://www.octopart.com/api/v2/parts/search?callback={{callback}}&limit=3&optimize.hide_offers=1&optimize.hide_specs=1&q=$1'
+
 handle query_lc => sub {
     if ($_ =~ /^\s*(?:(datasheet))?\s*([\w\-]+)(?:\s(datasheet))?\s*$/i) {
         if ($1 or $3) {
-            return qq(/ioctopart/$2/);
+            return $2;
         }
     }
     return;

--- a/lib/DDG/Spice/Octopart.pm
+++ b/lib/DDG/Spice/Octopart.pm
@@ -1,0 +1,16 @@
+package DDG::Spice::Octopart;
+
+use DDG::Spice;
+
+triggers any => "datasheet";
+
+handle query_lc => sub {
+    if ($_ =~ /^\s*(?:(datasheet))?\s*([\w\-]+)(?:\s(datasheet))?\s*$/i) {
+        if ($1 or $3) {
+            return qq(/ioctopart/$2/);
+        }
+    }
+    return;
+};
+
+1;

--- a/share/spice/octopart/nginx.conf
+++ b/share/spice/octopart/nginx.conf
@@ -1,8 +1,0 @@
-        # octopart.com
-        location ^~ /ioctopart/ {
-          # no API key; will saturate ratelimiter unless host IPs are
-          # whitelisted
-          # see: http://octopart.com/api/documentation
-          rewrite ^/ioctopart/(.*) /api/v2/parts/search?callback=nroctopart&limit=3&optimize.hide_offers=1&optimize.hide_specs=1&q=$1 break;
-          proxy_pass https://octopart.com/;
-        }

--- a/share/spice/octopart/nginx.conf
+++ b/share/spice/octopart/nginx.conf
@@ -1,0 +1,8 @@
+        # octopart.com
+        location ^~ /ioctopart/ {
+          # no API key; will saturate ratelimiter unless host IPs are
+          # whitelisted
+          # see: http://octopart.com/api/documentation
+          rewrite ^/ioctopart/(.*) /api/v2/parts/search?callback=nroctopart&limit=3&optimize.hide_offers=1&optimize.hide_specs=1&q=$1 break;
+          proxy_pass https://octopart.com/;
+        }

--- a/share/spice/octopart/readme.txt
+++ b/share/spice/octopart/readme.txt
@@ -1,0 +1,28 @@
+
+Some example 'datasheet' queries:
+    ne555 datasheet
+    atmel avr datasheet
+    datasheet arduino uno
+    UWX1V100MCL1GB datasheet
+    UWX1V100 datasheet
+    blue led datasheet
+    stm32 adc dac ethernet datasheet
+    zigbee transceiver freescale datasheet
+
+Extra info the Octopart API response that could be parsed and displayed:
+    rohs and lead-free attributes
+    product lifecycle status (obsolete, pre-production, active)
+    categorization (aka, type of component)
+    direct free sample links (for some parts)
+
+Potential other triggers:
+    6+ characters of mixed numbers and capitalized letters (often an MPN)
+    popular electronics manufacturer names: atmel, texas instruments, molex, stm, etc
+    "chip"
+    "ic"
+    "component"
+    "specs"
+
+Another possibility is to trigger on distributor name and SKU (eg, "newark
+68T2515") and show part information and a direct link to the distributor's buy
+now page. 

--- a/share/spice/octopart/spice.js
+++ b/share/spice/octopart/spice.js
@@ -1,3 +1,4 @@
+
 function ddg_spice_octopart(resp) {
     
     //console.log(resp);
@@ -16,36 +17,45 @@ function ddg_spice_octopart(resp) {
 
             // header is manufacturer name followed by MPN
             heading = "<b>" + part['manufacturer']['displayname'] + ' ' + part['mpn'] + "</b>";
+            
+            // Plain English sentence lead in [removed, use header instead]
+            //content += "The " + part['mpn'] + " is produced by " + part['manufacturer']['displayname'] + ". ";
 
-            // abstract is octopart-generated short description (up to ~160 characters)
+            // abstract is octopart-generated short description (up to ~160
+            // characters)
             if(part['short_description']) {
-                content += part['short_description'] + '<br><br>';
+                content += " Specs: <i>" + part['short_description'] + "</i>. ";
             }
+
+            // show market price and availability status [andres: edit this]
+            if(part['avg_price'].length > 0) {
+                if(part['avg_price'][0] < 0.01) {
+                    content += "Price below $0.01/each; ";
+                } else {
+                    content += "Price around $" + part['avg_price'][0].toFixed(2) + "/each; ";
+                }
+            } else {
+                content += "Price unknown; ";
+            }
+            content += part['market_status'].split(/:\ /)[1] + " ";
 
             // add top datasheet link if available
             if(part['datasheets'].length > 0) {
                 // replace this PDF favicon with a DDG-local one?
-                content += "<a href=\"" + part['datasheets'][0]['url'] + "\"><img src=\"http://n1.octostatic.com/o3/partsearch/partsearch/images/content/pdf_small.jpg\" style=\"float: left; margin-right: 3px;\"></img> Datasheet</a> | ";
+                content += "[<a href=\"" + part['datasheets'][0]['url'] + "\"><img src=\"http://n1.octostatic.com/o3/partsearch/partsearch/images/content/pdf_small.jpg\" style=\"display: inline; margin-right: 3px; height: 12px;\"></img>Datasheet</a>] ";
             } else {
-                content += "No Datasheet | "
+                content += "[No Datasheet] ";
             }
-
-            // show market price and availability status
-            if(part['avg_price'].length > 0) {
-                content += "Market Price $" + part['avg_price'][0].toFixed(2) + " | ";
-            } else {
-                content += "Market unknown | ";
-            }
-            content += part['market_status'].split(/:\ /)[1]
 
             // if we have a direct manufacturer URL use that, or else a link to
             // their homepage, or else nothing
             if(part['hyperlinks']['manufacturer']) {
-                content += "<br>More info from <a href=\"" + part['hyperlinks']['manufacturer'] + "\">" + part['manufacturer']['displayname'] + "</a>";
+                content += "[<a href=\"" + part['hyperlinks']['manufacturer'] + "\">Manufacturer</a>] ";
             } else if(part['manufacturer']['homepage_url']) {
-                content += "<br><a href=\"" + part['manufacturer']['homepage_url'] + "\">" + part['manufacturer']['displayname'] + " Homepage</a>";
+                content += "[<a href=\"" + part['manufacturer']['homepage_url'] + "\">Manufacturer</a>] ";
             }
 
+            // attach info
             items[i]['h'] = heading;
             items[i]['a'] = content;
 

--- a/share/spice/octopart/spice.js
+++ b/share/spice/octopart/spice.js
@@ -1,4 +1,4 @@
-function nroctopart(resp) {
+function ddg_spice_octopart(resp) {
     
     //console.log(resp);
     var heading = "";

--- a/share/spice/octopart/spice.js
+++ b/share/spice/octopart/spice.js
@@ -1,0 +1,67 @@
+function nroctopart(resp) {
+    
+    //console.log(resp);
+    var heading = "";
+    var content = "";
+    var items = new Array();
+    
+    // validity check
+    if(resp['results'].length > 0) {
+        // may have multiple results; limit parameter set in nginx.conf
+        for(var i=0; i<resp['results'].length; i++) {
+            var part = resp['results'][i]['item'] 
+            items[i] = new Array();
+            heading = ""
+            content = ""
+
+            // header is manufacturer name followed by MPN
+            heading = "<b>" + part['manufacturer']['displayname'] + ' ' + part['mpn'] + "</b>";
+
+            // abstract is octopart-generated short description (up to ~160 characters)
+            if(part['short_description']) {
+                content += part['short_description'] + '<br><br>';
+            }
+
+            // add top datasheet link if available
+            if(part['datasheets'].length > 0) {
+                // replace this PDF favicon with a DDG-local one?
+                content += "<a href=\"" + part['datasheets'][0]['url'] + "\"><img src=\"http://n1.octostatic.com/o3/partsearch/partsearch/images/content/pdf_small.jpg\" style=\"float: left; margin-right: 3px;\"></img> Datasheet</a> | ";
+            } else {
+                content += "No Datasheet | "
+            }
+
+            // show market price and availability status
+            if(part['avg_price'].length > 0) {
+                content += "Market Price $" + part['avg_price'][0].toFixed(2) + " | ";
+            } else {
+                content += "Market unknown | ";
+            }
+            content += part['market_status'].split(/:\ /)[1]
+
+            // if we have a direct manufacturer URL use that, or else a link to
+            // their homepage, or else nothing
+            if(part['hyperlinks']['manufacturer']) {
+                content += "<br>More info from <a href=\"" + part['hyperlinks']['manufacturer'] + "\">" + part['manufacturer']['displayname'] + "</a>";
+            } else if(part['manufacturer']['homepage_url']) {
+                content += "<br><a href=\"" + part['manufacturer']['homepage_url'] + "\">" + part['manufacturer']['displayname'] + " Homepage</a>";
+            }
+
+            items[i]['h'] = heading;
+            items[i]['a'] = content;
+
+            // use the 55px thumbail PNG image if we have one
+            if(part['images'].length > 0) {
+                items[i]['i'] = part['images'][0]['url_55px'];
+            } else {
+                items[i]['i'] = '';
+            }
+
+            // Source name and url for the More at X link.
+            items[i]['s'] = "Octopart";
+            items[i]['u'] = part['detail_url'];
+        }
+        nra(items);
+    } else {
+        //console.log("No Octopart response...");
+    }
+}

--- a/share/spice/octopart/test.html
+++ b/share/spice/octopart/test.html
@@ -1,34 +1,43 @@
 <html>
-<head><title>DDG Zero-info Spice Plugin Test Page</title>
-<!-- Potentially replace the stylesheet link below to a more recent version -->
-<link rel="stylesheet" href="http://duckduckgo.com/s422.css" type="text/css">
-<script type="text/javascript" src="./spice.js"></script>
-</head>
-<body>
-<h1>DDG Zero-info Spice Plugin Test Page</h1>
-
-
-<br><br>
-Zero-info box hidden below this line...
-<div id="zero_click_wrapper" style="display:none;visibility:hidden;">
-    <div id="zero_click">
+  <head><title>DDG Zero-info Spice Plugin Test Page</title>
+    <!-- Potentially replace the stylesheet link below to a more recent version -->
+    <link rel="stylesheet" href="http://duckduckgo.com/s422.css" type="text/css">
+    <script type="text/javascript" src="./spice.js"></script>
+    <style type="text/css">
+      .testlink {
+          cursor:pointer;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>DDG Zero-info Spice Plugin Test Page</h1>
+    <br>
+    <br>
+    <h2>Tests:</h2>
+    <ul>
+      <li><a class="testlink" test_id="0">One result with complete data</a></li>
+      <li><a class="testlink" test_id="1">One result with incomplete data</a></li>
+      <li><a class="testlink" test_id="2">Multiple results</a></li>
+    </ul>
+    <br>
+    <br>
+    <div id="zero_click_wrapper" style="display:none;visibility:hidden;">
+      <div id="zero_click">
         <div id="zero_click_wrapper2">
-            <div id="zero_click_plus_wrapper">
-                <a href="javascript:;" onClick="" id="zero_click_plus">&nbsp;</a>
-            </div>
-            <div id="zero_click_header" style="display:none;"></div>
-            <div id="zero_click_image" style="display:none;"></div>
-            <div id="zero_click_abstract" style="display:none;"></div>
-            <div class="clear">&nbsp;</div>
+          <div id="zero_click_plus_wrapper">
+            <a href="javascript:;" onClick="" id="zero_click_plus">&nbsp;</a>
+          </div>
+          <div id="zero_click_header" style="display:none;"></div>
+          <div id="zero_click_image" style="display:none;"></div>
+          <div id="zero_click_abstract" style="display:none;"></div>
+          <div class="clear">&nbsp;</div>
         </div>
+      </div>
     </div>
-</div>
-
 <script type="text/javascript">
   function nra(items) {
-    console.log(items);
     if(items) {
-        item = items[0];
+        var item = items[0];
         document.getElementById('zero_click_wrapper').style.cssText = "";
         if(item['h']) {
             document.getElementById('zero_click_header').style.cssText = "";
@@ -39,18 +48,56 @@ Zero-info box hidden below this line...
             document.getElementById('zero_click_image').innerHTML = "<img src=\"" + item['i'] + "\"></img>";
         };
         document.getElementById('zero_click_abstract').style.cssText = "";
+        document.getElementById('zero_click_abstract').innerHTML = '';
         if(item['a']) {
             document.getElementById('zero_click_abstract').innerHTML += item['a'];
         };
         if(item['s'] && item['u']) {
             document.getElementById('zero_click_abstract').innerHTML += "<a href=\"" + item['u'] + "\">More at " + item['s'] + "</a>";
         };
-
     };
   };
 </script>
 <!-- Replace the URL below with a direct query to the remote API -->
-<script type="text/javascript" src="http://octopart.com/api/v2/parts/search?callback=ddg_spice_octopart&limit=3&optimize.hide_offers=1&optimize.hide_specs=1&q=atmega"></script>
+<script type="text/javascript">
+  (function(){
+      queries = [
+          'ATMEGA128L-8AU',
+          'MAX232CSETTI3AX232D',
+          'NE555D'
+      ];
 
+      function clickHandler(ev){
+          var target = ev.target || ev.srcElement;
+
+          if (!/testlink/.test(target.className))
+              return;
+
+          var test_id = (target.getAttribute != undefined) ? target.getAttribute('test_id') : target.test_id;
+          test_id = parseInt(test_id);
+
+          var url = "http://octopart.com/api/v2/bom/match?callback=ddg_spice_octopart&limit=3&optimize.hide_offers=1&optimize.hide_specs=1&&optimize.hide_descriptions=1&lines=%5B%7B%22q%22%3A%20%22" + encodeURIComponent(queries[test_id]) + "%22%7D%5D";
+          url += "&_=" + (new Date()).getTime();
+
+          var el = document.createElement('script');
+          el.type = 'text/javascript';
+          el.async = true;
+          el.src = url;
+          var s = document.getElementsByTagName('script')[0];
+          s.parentNode.insertBefore(el, s);
+      }
+
+      function attachEvent(el, t, f){
+          if (el.addEventListener)
+              el.addEventListener(t, f, false);
+          else if (el.attachEvent)
+              el.attachEvent('on' + t, f);
+      }
+
+      var anchors = document.getElementsByTagName('a');
+      for (var i=0; i < anchors.length; i++)
+          attachEvent(anchors[i], 'click', clickHandler);
+  })();
+</script>
 </body>
 </html>

--- a/share/spice/octopart/test.html
+++ b/share/spice/octopart/test.html
@@ -50,7 +50,7 @@ Zero-info box hidden below this line...
   };
 </script>
 <!-- Replace the URL below with a direct query to the remote API -->
-<script type="text/javascript" src="http://octopart.com/api/v2/parts/search?callback=nroctopart&limit=3&optimize.hide_offers=1&optimize.hide_specs=1&q=max232"></script>
+<script type="text/javascript" src="http://octopart.com/api/v2/parts/search?callback=ddg_spice_octopart&limit=3&optimize.hide_offers=1&optimize.hide_specs=1&q=max232"></script>
 
 </body>
 </html>

--- a/share/spice/octopart/test.html
+++ b/share/spice/octopart/test.html
@@ -43,14 +43,14 @@ Zero-info box hidden below this line...
             document.getElementById('zero_click_abstract').innerHTML += item['a'];
         };
         if(item['s'] && item['u']) {
-            document.getElementById('zero_click_abstract').innerHTML += "<br><a href=\"" + item['u'] + "\">More from " + item['s'] + "</a>";
+            document.getElementById('zero_click_abstract').innerHTML += "<a href=\"" + item['u'] + "\">More at " + item['s'] + "</a>";
         };
 
     };
   };
 </script>
 <!-- Replace the URL below with a direct query to the remote API -->
-<script type="text/javascript" src="http://octopart.com/api/v2/parts/search?callback=ddg_spice_octopart&limit=3&optimize.hide_offers=1&optimize.hide_specs=1&q=max232"></script>
+<script type="text/javascript" src="http://octopart.com/api/v2/parts/search?callback=ddg_spice_octopart&limit=3&optimize.hide_offers=1&optimize.hide_specs=1&q=atmega"></script>
 
 </body>
 </html>

--- a/share/spice/octopart/test.html
+++ b/share/spice/octopart/test.html
@@ -1,0 +1,56 @@
+<html>
+<head><title>DDG Zero-info Spice Plugin Test Page</title>
+<!-- Potentially replace the stylesheet link below to a more recent version -->
+<link rel="stylesheet" href="http://duckduckgo.com/s422.css" type="text/css">
+<script type="text/javascript" src="./spice.js"></script>
+</head>
+<body>
+<h1>DDG Zero-info Spice Plugin Test Page</h1>
+
+
+<br><br>
+Zero-info box hidden below this line...
+<div id="zero_click_wrapper" style="display:none;visibility:hidden;">
+    <div id="zero_click">
+        <div id="zero_click_wrapper2">
+            <div id="zero_click_plus_wrapper">
+                <a href="javascript:;" onClick="" id="zero_click_plus">&nbsp;</a>
+            </div>
+            <div id="zero_click_header" style="display:none;"></div>
+            <div id="zero_click_image" style="display:none;"></div>
+            <div id="zero_click_abstract" style="display:none;"></div>
+            <div class="clear">&nbsp;</div>
+        </div>
+    </div>
+</div>
+
+<script type="text/javascript">
+  function nra(items) {
+    console.log(items);
+    if(items) {
+        item = items[0];
+        document.getElementById('zero_click_wrapper').style.cssText = "";
+        if(item['h']) {
+            document.getElementById('zero_click_header').style.cssText = "";
+            document.getElementById('zero_click_header').innerHTML = item['h'];
+        };
+        if(item['i']) {
+            document.getElementById('zero_click_image').style.cssText = "";
+            document.getElementById('zero_click_image').innerHTML = "<img src=\"" + item['i'] + "\"></img>";
+        };
+        document.getElementById('zero_click_abstract').style.cssText = "";
+        if(item['a']) {
+            document.getElementById('zero_click_abstract').innerHTML += item['a'];
+        };
+        if(item['s'] && item['u']) {
+            document.getElementById('zero_click_abstract').innerHTML += "<br><a href=\"" + item['u'] + "\">More from " + item['s'] + "</a>";
+        };
+
+    };
+  };
+</script>
+<!-- Replace the URL below with a direct query to the remote API -->
+<script type="text/javascript" src="http://octopart.com/api/v2/parts/search?callback=nroctopart&limit=3&optimize.hide_offers=1&optimize.hide_specs=1&q=max232"></script>
+
+</body>
+</html>


### PR DESCRIPTION
It looks like the plugin architecture is being re-factored, but I took a stab at an Octopart Zero-Info Spice plugin using the new format.

The perl side of things is untested (and may even have syntax errors) and the behavior probably need to be modified. Best would be triggering an Octopart Spice request when matching on one of several million unique manufacturer part numbers (MPNs), with or without the 'datasheet' keyword.

Our image thumbnails do not have a transparent background. Should we use a CSS border in that case to not clash with the off-white zero-info background?

Any other comments or guidance would be appreciated.
