### PR TITLE
IsItUp regex rewritten

### DIFF
--- a/lib/DDG/Spice/IsItUp.pm
+++ b/lib/DDG/Spice/IsItUp.pm
@@ -4,26 +4,34 @@ use DDG::Spice;
 
 spice is_cached => 0;
 
-triggers query_lc => qr/^((?:is\s|))([0-9a-z\-]+)(?:(\.[a-z]{2,4})|)\s(?:up|down|working)/;
+triggers query_lc => qr/^((?:is\s|))([0-9a-z\-]+(?:\.[0-9a-z\-]+)*?)(?:(\.[a-z]{2,4})|)\s(?:up|down|working)/;
 
 spice to => 'http://isitup.org/$1.json?callback={{callback}}';
 
 handle matches => sub {
-    # could also be done in 1 line with: return $1 ? ($3 ? $2.$3 : $2.'.com') : ($3 ? $2.$3 : $2);
 
+    my $regex_domain = qr/\.(c(?:o(?:m|op)?|at?|[iykgdmnxruhcfzvl])|o(?:rg|m)|n(?:et?|a(?:me)?|[ucgozrfpil])|e(?:d?u|[gechstr])|i(?:n(?:t|fo)?|[stqldroem])|m(?:o(?:bi)?|u(?:seum)?|i?l|[mcyvtsqhaerngxzfpwkd])|g(?:ov|[glqeriabtshdfmuywnp])|b(?:iz?|[drovfhtaywmzjsgbenl])|t(?:r(?:avel)?|[ncmfzdvkopthjwg]|e?l)|k[iemygznhwrp]|s[jtvberindlucygkhaozm]|u[gymszka]|h[nmutkr]|r[owesu]|d[kmzoej]|a(?:e(?:ro)?|r(?:pa)?|[qofiumsgzlwcnxdt])|p(?:ro?|[sgnthfymakwle])|v[aegiucn]|l[sayuvikcbrt]|j(?:o(?:bs)?|[mep])|w[fs]|z[amw]|f[rijkom]|y[eut]|qa)$/;
+    
     if ($3) {
-	# return the domain and the root url
-	return $2.$3;
-    }
+        my $root_url = $2;
+        my $domain = $3;
+	    # return the domain and the root url if the domain is valid
+        if ($domain =~ $regex_domain){
+	        return $root_url.$domain;
+        }
+    } 
     else {
-	# append .com only if "is" is in the query and there's no other domain given
-	if ($1) {
-	    return $2 . '.com';
-	}
-	# otherwise just return without '.com' -- stops false positives from showing zci
-	else {
-	    return $2;
-	}
+	    # append .com only if "is" is in the query and there's no other domain given
+	    if ($1) {
+	        return $2 . '.com';
+	    }
+	    # otherwise just return without '.com' -- stops false positives from showing zci
+	    else {
+            # check for domain name in the end
+            if ($2 =~ $regex_domain) {
+	            return $2;
+            }
+	    }
     }
     return;
 };


### PR DESCRIPTION
To solve problems with IsItUp (pointed out [here](http://twitter.com/_0wl/status/199493176162131968) and [here](https://twitter.com/#!/ianchanning/status/200235196358983680)) I rewrote the regex for this Spice.

It uses simillar approach as #24 but also tries to check for a valid domain name.

Examples

```
is ideas.duckduckhack.com up
bbc.co.uk working?
```

But won't work for

```
bbc.ddg working?
duckduckgo up?
```
