### PR TITLE
Synonyms2

### DIFF
--- a/lib/DDG/Spice/BigHuge.pm
+++ b/lib/DDG/Spice/BigHuge.pm
@@ -4,7 +4,7 @@ package DDG::Spice::BigHuge;
 use DDG::Spice;
 
 spice from => '([^/]+)/?(?:([^/]+)/?(?:([^/]+)|)|)';
-spice to => 'http://words.bighugelabs.com/api/2/{{ENV{BHUGE_KEY}}}/$1/json?callback=ddg_spice_$2';
+spice to => 'http://words.bighugelabs.com/api/2/{{ENV{BHUGE_KEY}}}/$1/json?callback=ddg_spice_bighuge_$2';
 
 triggers startend => "synonyms", "synonym", "antonyms", "antonym", "related", "similar";
 

--- a/share/spice/big_huge/spice.js
+++ b/share/spice/big_huge/spice.js
@@ -1,17 +1,17 @@
-function ddg_spice_antonym(antonyms) {
-  ddg_spice_varinym(antonyms, 'ant', 'Antonyms of ');
+function ddg_spice_bighuge_antonym(antonyms) {
+  ddg_spice_bighuge_varinym(antonyms, 'ant', 'Antonyms of ');
 }
-function ddg_spice_related(related) {
-  ddg_spice_varinym(related, 'rel', 'Related to ');
+function ddg_spice_bighuge_related(related) {
+  ddg_spice_bighuge_varinym(related, 'rel', 'Related to ');
 }
-function ddg_spice_similar(similar) {
-  ddg_spice_varinym(similar, 'sim', 'Similar to ');
+function ddg_spice_bighuge_similar(similar) {
+  ddg_spice_bighuge_varinym(similar, 'sim', 'Similar to ');
 }
-function ddg_spice_synonym(synonyms) {
-  ddg_spice_varinym(synonyms, 'syn', 'Synonyms of ');
+function ddg_spice_bighuge_synonym(synonyms) {
+  ddg_spice_bighuge_varinym(synonyms, 'syn', 'Synonyms of ');
 }
 
-function ddg_spice_varinym(json, mode, heading) {
+function ddg_spice_bighuge_varinym(json, mode, heading) {
   if (json) {
     var content = '';
     var forms = {};


### PR DESCRIPTION
an updated version of the previously opened pull request: https://github.com/duckduckgo/zeroclickinfo-spice/pull/28

i have replaced the eval function as @moollaza suggested and have taken all notes as far as i can see. the only thing i am unsure about is that the variable -- rq -- was at first suggested to me to be the full search string -- but in the last commit it was written out as simply --  decodeURI(rq) after the url, which suggests to me that it would be the actual search term by itself, so i have followed suit in assumption, though my testing environment doesn't know rq. 
