### PR TITLE
Bighuge plus10

### DIFF
--- a/share/spice/big_huge/spice.js
+++ b/share/spice/big_huge/spice.js
@@ -15,7 +15,6 @@ function ddg_spice_big_huge_varinym(json, mode, heading, complete, modifier, con
   if (json) {
     var forms = {};
     var wc = 0;
-    console.log(mode + " " + content);
 
     forms['noun']      = 'Nouns';
     forms['verb']      = 'Verbs';


### PR DESCRIPTION
Additions to the BigHuge plugin.

In response to an email from @moollaza, this branch has the added feature: if a synonyms search results in less than 10 terms, it will also try to include similar and related terms as well. 
