### PR TITLE
CodeSearch spice plugin

### DIFF
--- a/lib/DDG/Spice/CodeSearch.pm
+++ b/lib/DDG/Spice/CodeSearch.pm
@@ -1,0 +1,20 @@
+package DDG::Spice::CodeSearch;
+
+use DDG::Spice;
+
+triggers start => "code", "example";
+
+spice to => 'http://searchco.de/api/jsonp_codesearch_I/?q=$1&callback={{callback}}';
+
+handle remainder => sub {
+    # check if there is anything to search for
+    if ($_ =~ /.+/) {
+        if ($_ =~ qr/^(actionscript|ada|asp|asp\.net|assembly|awk|bc|bourneagainshell|bourneshell|c|cshell|c\/c\+\+header|c\#|c\+\+|cmake|cobol|coldfusion|css|cython|d|dal|dart|dosbatch|dtd|erlang|expect|fortran77|fortran90|fortran95|go|groovy|haskell|html|idl|java|javascript|jsp|kermit|kornshell|lex|lisp|lua|m4|make|matlab|modula3|msbuildscripts|mumps|mxml|nantscripts|objectivec|objectivec\+\+|ocaml|octave|oracleforms|oraclereports|pascal|patrancommandlanguage|perl|php|python|rexx|ruby|rubyhtml|scala|sed|skill|smarty|softbridgebasic|sql|sqldata|tcl\/tk|teamcenterdef|teamcentermet|teamcentermth|vhdl|vimscript|visualbasic|xaml|xml|xsd|xslt|yacc|yaml) .+/i) {
+            return "lang:" . $_;
+        }
+        return $_;
+    }
+    return;
+};
+
+1;

--- a/share/spice/code_search/spice.js
+++ b/share/spice/code_search/spice.js
@@ -1,0 +1,47 @@
+function ddg_spice_code_search(data) {
+
+	var snippet = [[]]; // To store the results
+	var searchterm; // olds the search term
+	var result = '';
+
+	if(data.results.length > 0) {
+		searchterm = data.query;
+		result = data.results[0];
+	
+		var lines = '';
+		for (var key in result.lines) {
+			key = parseInt(key);
+			lines = lines + code_searchFormatLineHTML(result.id, key+1 ,result.lines[key]);
+		}
+			
+		var div = d.createElement('div');
+		var div2 = d.createElement('div');
+		YAHOO.util.Dom.addClass(div2,'zero_click_searchcode');
+		var out = code_searchFormatResultHTML(result,lines);
+			
+		div2.innerHTML = out;
+		div.appendChild(div2);
+			
+		snippet[0]['a'] = div.innerHTML;
+		snippet[0]['h'] = result.filename + ' in ' + result.name;
+		snippet[0]['s'] = 'search[code]';
+		snippet[0]['u'] = 'http://searchco.de/?q='+encodeURIComponent(searchterm)+'&cs=true';
+			
+		
+		// DDG rendering function is nra.
+		nra(snippet);
+	}
+}
+
+// Need to rtrim the line, escape HTML and add newline on the end
+function code_searchRtrimEscapeNewline(line) {
+	return line.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\s+$/,"")+'\r\n';
+}
+
+function code_searchFormatResultHTML(result,lines) {
+	return '<pre>' + lines + '</pre>';
+}
+
+function code_searchFormatLineHTML(id,key,line) {
+	return '<code><a href="http://searchco.de/codesearch/view/' + id + '#' + key + '">' +key + '.</a> ' + code_searchRtrimEscapeNewline(line) + '</code>';
+}


### PR DESCRIPTION
Follows from discussion here, https://github.com/duckduckgo/zeroclickinfo-spice/pull/33 where using "example" or "code" as the prefix trigger will cause it to do a code search but listen for languages as the first keyword first and if so restrict to a language search.

Some example searches,

code c# IsNullOrEmpty
code (else (fuck-up)))
code perl goto
code =~
code <<
code if (( index "<>[](){}:*?+|&^\$.", $initchar) >= 0 )
example lua duckduckgo
