### PR TITLE
Google Translate Spice

### DIFF
--- a/lib/DDG/Spice/GoogleTranslate.pm
+++ b/lib/DDG/Spice/GoogleTranslate.pm
@@ -1,0 +1,46 @@
+package DDG::Spice::GoogleTranslate;
+
+use DDG::Spice;
+
+spice from => '([^/]+)/?(?:([^/]+)/?(?:([^/]+)|)|)';
+spice to => 'http://translate.google.com/translate_a/t?client=t&amp;text=$1&amp;sl=auto&amp;tl=$2';
+spice wrap_jsonp_callback => 1;
+
+attribution web => ['http://niute.ch','niu tech'];
+
+triggers any => 'in', 'to';
+
+handle remainder => sub {
+	my (%langs) = (
+		'Arabic' => 'ar',
+		'Bulgarian' =>'bg',
+		'Chinese' => 'zh-CN',
+		'Croatian' => 'hr',
+		'Czech' => 'cs',
+		'Danish' => 'da',
+		'Dutch' => 'nl',
+		'English' => 'en',
+		'Finnish' => 'fi',
+		'French' => 'fr',
+		'German' => 'de',
+		'Greek' => 'el',
+		'Hindi' => 'hi',
+		'Italian' => 'it',
+		'Japanese' => 'ja',
+		'Korean' => 'ko',
+		'Norwegian' => 'no',
+		'Polish' => 'pl',
+		'Portuguese' => 'pt',
+		'Romanian' => 'ro',
+		'Russian' => 'ru',
+		'Spanish' => 'es',
+		'Swedish' => 'sv'
+	);
+	my ($countries) = join('|', keys(%langs));
+	if($_ =~ /^(\w+)\s*($countries)$/) {
+		return $1, $langs{$2}; 
+	}
+    return;
+};
+
+1;

--- a/share/spice/google_translate/spice.js
+++ b/share/spice/google_translate/spice.js
@@ -1,0 +1,10 @@
+function ddg_spice_google_translate(json) {
+	if(json.length) {
+		items = [[]];
+		items[0]["a"] = json[0][0][0];
+		items[0]["h"] = "Translation of "+json[0][0][1];
+		items[0]["s"] = "Google Translate";
+		items[0]["u"] = "http://translate.google.com/#auto%7Cen%7C"+encodeURIComponent(json[0][0][1]);
+		nra(items);
+	}
+};


### PR DESCRIPTION
This is Google Translate Spice, triggers for queries like: _[words] in|to [language]_, e.g:
_some words in German
whatever to Polish
zapytanie in English_
It sends a query string and a country code to Google Translate and receives a JSON response.
It's a first version and needs thorough testing.
