### PR TITLE
fix Twitter test

### DIFF
--- a/t/Twitter.t
+++ b/t/Twitter.t
@@ -6,11 +6,11 @@ use Test::More;
 use DDG::Test::Spice;
 
 ddg_spice_test(
-    [qw( DDG::Spice::Twitter )],
+    [qw( DDG::Spice::Twitter::User )],
     'twitter duckduckgo' => test_spice(
-        '/js/spice/twitter/duckduckgo',
+        '/js/spice/twitter/user/duckduckgo',
         call_type => 'include',
-        caller => 'DDG::Spice::Twitter'
+        caller => 'DDG::Spice::Twitter::User'
     ),
 );
 


### PR DESCRIPTION
Currently the Twitter test is using the non-existent `DDG::Spice::Twitter` module, instead of `DDG::Spice::Twitter::User`, and thus fails. This patch fixes it.

The script should probably be updated to test the `DDG::Spice::Twitter::Locate` module too, but I have no idea how it works.
