### PR TITLE
Changes to Bootic plugin.

### DIFF
--- a/lib/DDG/Spice/Bootic.pm
+++ b/lib/DDG/Spice/Bootic.pm
@@ -5,7 +5,7 @@ use DDG::Spice;
 
 triggers any => 'bootic';
 
-spice to => 'http://www.bootic.com/cgi-bin/api/search/products?output=json&callback={{callback}}&pretty_name=1&limit=5&q=$1';
+spice to => 'http://www.bootic.com/cgi-bin/api/search/products?output=json&callback={{callback}}&pretty_name=1&limit=5&smart=1&q=$1';
 
 handle remainder => sub {
 	return $_;

--- a/share/spice/bootic/spice.js
+++ b/share/spice/bootic/spice.js
@@ -50,7 +50,7 @@ function ddg_spice_bootic( products )
 
 	var query = '';
 	if ( products.input_query ) {
-		query = '?q=' + encodeURIComponent( products.input_query );
+		query = '?initial=1&q=' + encodeURIComponent( products.input_query );
 	}
 
 	var items = new Array();


### PR DESCRIPTION
Hi guys.

I would like to propose some changes. The change to spics.js file is very simple and it fixes the display of the query string.

The second one reintroduces more keywords, again. The main difference now is that keywords other than 'bootic' will trigger strict search. That is, the results are limited to a very limited number of queries, only allows the ones that we know are valid. For now it includes: watch, watches, air purifier, stroller, baby toy, vacuum cleaner. The list is maintained internally by Bootic. All the other queries will return nothing in strict mode.
Non-strict mode is enabled if any of the keywords is 'bootic'.

I hope this change can be accepted. Thank you!
