### PR TITLE
Integration of the openSNP-API - find information on Single Nucleotide Polymorphisms

### DIFF
--- a/lib/DDG/Spice/OpenSNP.pm
+++ b/lib/DDG/Spice/OpenSNP.pm
@@ -4,11 +4,12 @@ use DDG::Spice;
 
 spice to => 'http://opensnp.org/snps/json/annotation/$1.json';
 spice is_cached => 0;
+spice wrap_jsonp_callback => 1;
 
 triggers query_lc  => qr/(^rs[^\s]+)$/;
 
 handle matches => sub {
-    return @_ if @_;
+    return $_ if $_;
     return;
 };
 

--- a/lib/DDG/Spice/OpenSNP.pm
+++ b/lib/DDG/Spice/OpenSNP.pm
@@ -12,5 +12,6 @@ handle query_nowhitespace => sub {
     return $_ if $_;
     return;
 };
-
+attribution github => ['https://github.com/drsnuggles','Philipp Bayer'],
+               twitter => ['https://twitter.com/PhilippBayer'];
 1;

--- a/lib/DDG/Spice/OpenSNP.pm
+++ b/lib/DDG/Spice/OpenSNP.pm
@@ -6,7 +6,7 @@ spice to => 'http://opensnp.org/snps/json/annotation/$1.json';
 spice is_cached => 0;
 spice wrap_jsonp_callback => 1;
 
-triggers query_lc  => qr/(^rs[^\s]+)$/;
+triggers query_lc  => qr/(^rs[0-9]+)$/;
 
 handle matches => sub {
     return $_ if $_;

--- a/lib/DDG/Spice/OpenSNP.pm
+++ b/lib/DDG/Spice/OpenSNP.pm
@@ -3,6 +3,7 @@ package DDG::Spice::OpenSNP;
 use DDG::Spice;
 
 spice to => 'http://opensnp.org/snps/json/annotation/$1.json';
+spice is_cached => 0;
 
 triggers query_lc  => qr/(^rs[^\s]+)$/;
 

--- a/lib/DDG/Spice/OpenSNP.pm
+++ b/lib/DDG/Spice/OpenSNP.pm
@@ -1,0 +1,14 @@
+package DDG::Spice::OpenSNP;
+
+use DDG::Spice;
+
+spice to => 'http://opensnp.org/snps/json/annotation/$1.json';
+
+triggers query_lc  => qr/(^rs[^\s]+)$/;
+
+handle matches => sub {
+    return @_ if @_;
+    return;
+};
+
+1;

--- a/lib/DDG/Spice/OpenSNP.pm
+++ b/lib/DDG/Spice/OpenSNP.pm
@@ -3,7 +3,7 @@ package DDG::Spice::OpenSNP;
 use DDG::Spice;
 
 spice to => 'http://opensnp.org/snps/json/annotation/$1.json';
-spice is_cached => 0;
+spice is_cached => 1;
 spice wrap_jsonp_callback => 1;
 
 triggers query_lc  => qr/(^rs[0-9]+)$/;

--- a/lib/DDG/Spice/OpenSNP.pm
+++ b/lib/DDG/Spice/OpenSNP.pm
@@ -8,7 +8,7 @@ spice wrap_jsonp_callback => 1;
 
 triggers query_lc  => qr/(^rs[0-9]+)$/;
 
-handle matches => sub {
+handle query_nowhitespace => sub {
     return $_ if $_;
     return;
 };

--- a/share/spice/open_snp/open_snp.js
+++ b/share/spice/open_snp/open_snp.js
@@ -1,0 +1,16 @@
+function ddg_spice_opensnp(ir) {
+    var out = '';
+
+    if ( ir['snp'] ) {
+        out = ir['chromosome'];
+    }
+    if (out) {
+        items = new Array();
+        items[0] = new Array();
+        items[0]['a'] = out;
+        items[0]['h'] = '';
+        items[0]['u'] = ir['source_url'];
+        items[0]['s'] = 'openSNP';
+        nra(items);
+    }
+}

--- a/share/spice/open_snp/spice.js
+++ b/share/spice/open_snp/spice.js
@@ -19,9 +19,9 @@ function ddg_spice_open_snp(ir) {
             if ( annotations['plos'] ) {
                 plos_papers = annotations['plos'].length;
             }
-            snippet += '<br/>There are ' + mendeley_papers + ' papers at Mendeley and ' + plos_papers + ' papers at PLOS available on this SNP.<br/>';
+            snippet += '<br/>There are ' + mendeley_papers + ' papers at <a href="http://www.mendeley.com/research-papers/search/?query=' + snp_name + '">Mendeley</a> and ' + plos_papers + ' papers at <a href="http://www.plosone.org/search/advancedSearch.action?noSearchFlag=true&query=' + snp_name + '">PLOS</a> available on this SNP.<br/>';
             if ( annotations['snpedia'] ) {
-                snippet += '<br/>SNPedia has the following:<br/>';
+                snippet += '<br/><a href="http://www.snpedia.com/index.php/' + snp_name + '">SNPedia</a> has the following summary:<br/>';
                 for ( var i = 0; i < annotations['snpedia'].length; i++ ) {
                     snippet += annotations['snpedia'][i]['url'].split('/')[4] + ': ' + annotations['snpedia'][i]['summary'] + '<br/>';
                 }

--- a/share/spice/open_snp/spice.js
+++ b/share/spice/open_snp/spice.js
@@ -6,23 +6,35 @@ function ddg_spice_open_snp(ir) {
         var snp_position = ir['snp']['position'];
         var snp_chromosome = ir['snp']['chromosome'];
 
-        var snippet = 'Position: ';
-        snippet += snp_position + '<br/>';
-        snippet += 'Chromosome: ' + snp_chromosome + '<br/>';
+        var snippet = '<i>Chromosome:</i> ';
+        snippet += snp_chromosome + '<br/>';
+        snippet += '<i>Position:</i> ' + snp_position + '<br/>';
+
         // Do we have annotations?
         if (ir['snp']['annotations']) {
             var annotations = ir['snp']['annotations'];
-            var mendeley_papers = 0;
-            var plos_papers = 0;
+            // Mendeley-annotation
+            var mendeley_snippet = '<br/>';
             if ( annotations['mendeley'] ){
-                mendeley_papers = annotations['mendeley'].length;
+                mendeley_length = annotations['mendeley'].length;
+                var first_paper = annotations['mendeley'][0];
+                var time = first_paper['publication_year'];
+                mendeley_snippet += 'First paper:<br/>' + first_paper['author'] + '<i>et al.</i>, ' + time + ': <i>' + first_paper['title'] + '</i>. [<a href="' + first_paper['url'] + '">Link</a>]<br/>';
             }
+
+            // PLOS-annotation
+            var plos_snippet = '<br/>';
             if ( annotations['plos'] ) {
-                plos_papers = annotations['plos'].length;
+                plos_length = annotations['plos'].length;
+                var first_paper = annotations['plos'][0];
+                time = new Date(first_paper['publication_date']).getFullYear();
+                plos_snippet += 'First paper:<br/> ' + first_paper['author'] + ' <i>et al.</i>, ' + time +  ': <i>' + first_paper['title'] + '</i>. [<a href="' + first_paper['url'] + '">Link</a>]<br/>';
             }
-            snippet += '<br/>There are ' + mendeley_papers + ' papers at <a href="http://www.mendeley.com/research-papers/search/?query=' + snp_name + '">Mendeley</a> and ' + plos_papers + ' papers at <a href="http://www.plosone.org/search/advancedSearch.action?noSearchFlag=true&query=' + snp_name + '">PLOS</a> available on this SNP.<br/>';
+
+            // SNPedia-annotation - add to main-snippet
             if ( annotations['snpedia'] ) {
-                snippet += '<br/><a href="http://www.snpedia.com/index.php/' + snp_name + '">SNPedia</a> has the following summary:<br/>';
+                snippet += '<br/>Annotations at <a href="http://www.snpedia.com/index.php/' + snp_name + '">SNPedia</a>:<br/>'
+                var snpedia_length = annotations['snpedia'].length;
                 for ( var i = 0; i < annotations['snpedia'].length; i++ ) {
                     snippet += annotations['snpedia'][i]['url'].split('/')[4] + ': ' + annotations['snpedia'][i]['summary'] + '<br/>';
                 }
@@ -30,12 +42,24 @@ function ddg_spice_open_snp(ir) {
             }
         }
 
-        items = new Array();
-        items[0] = new Array();
+        items = [ [], [], [], [] ];
         items[0]['a'] = snippet;
-        items[0]['h'] = 'Information on SNP <b>' + snp_name + '</b> at openSNP.org';
-        items[0]['s'] = 'openSNP.org'
-        items[0]['u'] = 'http://openSNP.org/snps/' + ir['snp']['name'] + '#papers';
+        items[0]['h'] = 'SNP <b>' + snp_name + '</b> at openSNP.org';
+        items[0]['force_big_header'] = 1;
+        items[0]['s'] = 'openSNP.org';
+        items[0]['u'] = 'http://openSNP.org/snps/' + ir['snp']['name'];
+        if ( mendeley_snippet != '<br/>' ) {
+            items[1]['a'] = mendeley_snippet;
+            items[1]['t'] = 'Mendeley-papers: ' + mendeley_length;
+            items[1]['s'] = 'Mendeley';
+            items[1]['u'] = 'http://www.mendeley.com/research-papers/search/?query=' + snp_name;
+        }
+        if ( plos_snippet != '<br/>' ) {
+            items[2]['a'] = plos_snippet;
+            items[2]['t'] = 'PLOS-papers: ' + plos_length;
+            items[2]['s'] = 'PLOS';
+            items[2]['u'] = 'http://www.plosone.org/search/advancedSearch.action?noSearchFlag=true&query=' + snp_name;
+        }
         nra(items);
     }
 }

--- a/share/spice/open_snp/spice.js
+++ b/share/spice/open_snp/spice.js
@@ -1,10 +1,13 @@
 function ddg_spice_open_snp(ir) {
+    'use strict';
     // did the API return information?
     if ( ir['snp'] ) {
 
         var snp_name = ir['snp']['name'];
         var snp_position = ir['snp']['position'];
         var snp_chromosome = ir['snp']['chromosome'];
+        var first_paper = "";
+        var time;
 
         var snippet = '<i>Chromosome:</i> ';
         snippet += snp_chromosome + '<br/>';
@@ -16,22 +19,22 @@ function ddg_spice_open_snp(ir) {
             // Mendeley-annotation
             var annotations_snippet = '<br/>';
             var mendeley_length = 0;
-            var plos_length = 0;
-            if ( annotations['mendeley'][0]){
+            if ( annotations['mendeley'][0] ){
                 mendeley_length = annotations['mendeley'].length;
-                var first_paper = annotations['mendeley'][0];
-                var time = first_paper['publication_year'];
-                annotations_snippet += '<br/>' + first_paper['author'] + ' <i>et al.</i>, ' + time + ': <i>' + '<a href="' +  first_paper['url'] + '">' + first_paper['title'] + '</a></i>. [<a href="http://www.mendeley.com/research-papers/search/?query=' + snp_name + '">' + (parseInt(mendeley_length)-1) + ' more papers at Mendeley</a>]<br/>';
+                first_paper = annotations['mendeley'][0];
+                time = first_paper['publication_year'];
+                annotations_snippet += '<br/>' + first_paper['author'] + ' <i>et al.</i>, ' + time + ': <i>' + '<a href="' +  first_paper['url'] + '">' + first_paper['title'] + '</a></i>. [<a href="http://www.mendeley.com/research-papers/search/?query=' + snp_name + '">' + (parseInt(mendeley_length, 10)-1) + ' more papers at Mendeley</a>]<br/>';
             }
 
             // PLOS-annotation
+            var plos_length = 0;
             if ( annotations['plos'][0]  ) {
                 plos_length = annotations['plos'].length;
-                var first_paper = annotations['plos'][0];
+                first_paper = annotations['plos'][0];
                 time = new Date(first_paper['publication_date']).getFullYear();
-                annotations_snippet += '<br/>' + first_paper['author'] + ' <i>et al.</i>, ' + time +  ': <i><a href="' + first_paper['url'] + '">'+ first_paper['title'] + '</i></a>. [<a href="http://www.plosone.org/search/advancedSearch.action?noSearchFlag=true&query=' + snp_name + '">'  + (parseInt(plos_length)-1) + ' more papers at PLOS</a>]<br/>';
+                annotations_snippet += '<br/>' + first_paper['author'] + ' <i>et al.</i>, ' + time +  ': <i><a href="' + first_paper['url'] + '">'+ first_paper['title'] + '</i></a>. [<a href="http://www.plosone.org/search/advancedSearch.action?noSearchFlag=true&query=' + snp_name + '">'  + (parseInt(plos_length, 10)-1) + ' more papers at PLOS</a>]<br/>';
             }
-
+            var pgp_length = 0;
             // Personal Genome Project
             if ( annotations['pgp_annotations'][0]) {
                 pgp_length = annotations['pgp_annotations'].length;
@@ -42,10 +45,11 @@ function ddg_spice_open_snp(ir) {
             }
 
             // Genome.gov
+            var genomegov_length = 0;
             if ( annotations['genome_gov_publications'][0]  ) {
                 genomegov_length = annotations['genome_gov_publications'].length;
-                var first_paper = annotations['genome_gov_publications'][0];
-                var time = first_paper['publication_date'].split("/")[2];
+                first_paper = annotations['genome_gov_publications'][0];
+                time = first_paper['publication_date'].split("/")[2];
                 var url = first_paper['pubmed_link'];
                 var title = first_paper['title'];
                 annotations_snippet += '<br/>' + first_paper['first_author'] + ' <i>et al.</i>, ' + time + ': <a href="' + url + '">' + title + '</a>[<a href="https://www.genome.gov/26525384#searchForm">' + genomegov_length + ' more papers at Genome.gov</a>]<br/>';
@@ -53,15 +57,16 @@ function ddg_spice_open_snp(ir) {
 
             // SNPedia-annotation - add to main-snippet
             if ( annotations['snpedia'][0] ) {
-                snippet += '<br/>Annotations at <a href="http://www.snpedia.com/index.php/' + snp_name + '">SNPedia</a>:<br/>'
+                snippet += '<br/>Annotations at <a href="http://www.snpedia.com/index.php/' + snp_name + '">SNPedia</a>:<br/>';
                 var snpedia_length = annotations['snpedia'].length;
-                for ( var i = 0; i < annotations['snpedia'].length; i++ ) {
+                var i;
+                for ( i = 0; i < annotations['snpedia'].length; i++ ) {
                     snippet += annotations['snpedia'][i]['url'].split('/')[4] + ': ' + annotations['snpedia'][i]['summary'] + '<br/>';
                 }
             }
         }
 
-        items = [ [], [] ];
+        var items = [ [], [] ];
         items[0]['a'] = snippet;
         items[0]['h'] = 'SNP <b>' + snp_name + '</b> at openSNP.org';
         items[0]['force_big_header'] = 1;

--- a/share/spice/open_snp/spice.js
+++ b/share/spice/open_snp/spice.js
@@ -14,21 +14,22 @@ function ddg_spice_open_snp(ir) {
         if (ir['snp']['annotations']) {
             var annotations = ir['snp']['annotations'];
             // Mendeley-annotation
-            var mendeley_snippet = '<br/>';
+            var annotations_snippet = '<br/><br/>';
+            var mendeley_length = 0;
+            var plos_length = 0;
             if ( annotations['mendeley'] ){
                 mendeley_length = annotations['mendeley'].length;
                 var first_paper = annotations['mendeley'][0];
                 var time = first_paper['publication_year'];
-                mendeley_snippet += 'First paper:<br/>' + first_paper['author'] + '<i>et al.</i>, ' + time + ': <i>' + first_paper['title'] + '</i>. [<a href="' + first_paper['url'] + '">Link</a>]<br/>';
+                annotations_snippet += '<b>Mendeley:</b> ' + first_paper['author'] + ' <i>et al.</i>, ' + time + ': <i>' + '<a href="' +  first_paper['url'] + '">' + first_paper['title'] + '</a></i>. [<a href="http://www.mendeley.com/research-papers/search/?query=' + snp_name + '">' + (parseInt(mendeley_length)-1) + ' more papers at Mendeley</a>]<br/><br/>';
             }
 
             // PLOS-annotation
-            var plos_snippet = '<br/>';
             if ( annotations['plos'] ) {
                 plos_length = annotations['plos'].length;
                 var first_paper = annotations['plos'][0];
                 time = new Date(first_paper['publication_date']).getFullYear();
-                plos_snippet += 'First paper:<br/> ' + first_paper['author'] + ' <i>et al.</i>, ' + time +  ': <i>' + first_paper['title'] + '</i>. [<a href="' + first_paper['url'] + '">Link</a>]<br/>';
+                annotations_snippet += '<b>PLOS:</b> ' + first_paper['author'] + ' <i>et al.</i>, ' + time +  ': <i><a href="' + first_paper['url'] + '">'+ first_paper['title'] + '</i></a>. [<a href="http://www.plosone.org/search/advancedSearch.action?noSearchFlag=true&query=' + snp_name + '">'  + (parseInt(plos_length)-1) + ' more papers at PLOS</a>]<br/><br/>';
             }
 
             // SNPedia-annotation - add to main-snippet
@@ -42,23 +43,15 @@ function ddg_spice_open_snp(ir) {
             }
         }
 
-        items = [ [], [], [], [] ];
+        items = [ [], [] ];
         items[0]['a'] = snippet;
         items[0]['h'] = 'SNP <b>' + snp_name + '</b> at openSNP.org';
         items[0]['force_big_header'] = 1;
         items[0]['s'] = 'openSNP.org';
         items[0]['u'] = 'http://openSNP.org/snps/' + ir['snp']['name'];
-        if ( mendeley_snippet != '<br/>' ) {
-            items[1]['a'] = mendeley_snippet;
-            items[1]['t'] = 'Mendeley-papers: ' + mendeley_length;
-            items[1]['s'] = 'Mendeley';
-            items[1]['u'] = 'http://www.mendeley.com/research-papers/search/?query=' + snp_name;
-        }
-        if ( plos_snippet != '<br/>' ) {
-            items[2]['a'] = plos_snippet;
-            items[2]['t'] = 'PLOS-papers: ' + plos_length;
-            items[2]['s'] = 'PLOS';
-            items[2]['u'] = 'http://www.plosone.org/search/advancedSearch.action?noSearchFlag=true&query=' + snp_name;
+        if ( annotations_snippet != '<br/><br/>' ) {
+            items[1]['a'] = annotations_snippet;
+            items[1]['t'] = 'Further annotations';
         }
         nra(items);
     }

--- a/share/spice/open_snp/spice.js
+++ b/share/spice/open_snp/spice.js
@@ -1,14 +1,10 @@
-function ddg_spice_opensnp(ir) {
-    var snippet = '';
+function ddg_spice_open_snp(ir) {
     // did the API return information?
-    if ( ir['snp'] ) {
-        items = new Array();
-        items[0] = new Array();
-        snippet = ir['snp'];
-        items[0]['a'] = snippet;
-        items[0]['h'] = 'test_title';
-        items[0]['u'] = ir['source_url'];
-        items[0]['s'] = 'openSNP';
-        nra(items);
-    }
+    items = new Array();
+    items[0] = new Array();
+    items[0]['a'] = ir['snp']['name'];
+    items[0]['h'] = 'SNP-annotation at openSNP.org';
+    items[0]['u'] = ir['source_url'];
+    items[0]['s'] = 'openSNP.org/snps/' + ir['snp']['name'];
+    nra(items);
 }

--- a/share/spice/open_snp/spice.js
+++ b/share/spice/open_snp/spice.js
@@ -69,6 +69,8 @@ function ddg_spice_open_snp(ir) {
         items[0]['u'] = 'http://openSNP.org/snps/' + ir['snp']['name'];
         if ( annotations_snippet != '<br/>' ) {
             items[1]['a'] = annotations_snippet + '<br/>';
+            items[1]['s'] = 'openSNP.org';
+            items[1]['u'] = 'http://openSNP.org/snps/' + ir['snp']['name'];
             items[1]['t'] = 'Further annotations';
         }
         nra(items);

--- a/share/spice/open_snp/spice.js
+++ b/share/spice/open_snp/spice.js
@@ -1,18 +1,12 @@
 function ddg_spice_opensnp(ir) {
-    var snippet, div;
-
-    // did the API return an error?
-    if ( ir['error'] ) {
-        return;
-    }
-
+    var snippet = '';
     // did the API return information?
     if ( ir['snp'] ) {
-        out = ir['chromosome'];
         items = new Array();
         items[0] = new Array();
-        items[0]['a'] = ir;
-        items[0]['h'] = '';
+        snippet = ir['snp'];
+        items[0]['a'] = snippet;
+        items[0]['h'] = 'test_title';
         items[0]['u'] = ir['source_url'];
         items[0]['s'] = 'openSNP';
         nra(items);

--- a/share/spice/open_snp/spice.js
+++ b/share/spice/open_snp/spice.js
@@ -1,10 +1,11 @@
 function ddg_spice_open_snp(ir) {
     // did the API return information?
-    var table;
     if ( ir['snp'] ) {
+
         var snp_name = ir['snp']['name'];
         var snp_position = ir['snp']['position'];
         var snp_chromosome = ir['snp']['chromosome'];
+
         var snippet = 'Position: ';
         snippet += snp_position + '<br/>';
         snippet += 'Chromosome: ' + snp_chromosome + '<br/>';
@@ -27,7 +28,6 @@ function ddg_spice_open_snp(ir) {
                 }
                 snippet += '<br/>';
             }
-
         }
 
         items = new Array();

--- a/share/spice/open_snp/spice.js
+++ b/share/spice/open_snp/spice.js
@@ -1,13 +1,17 @@
 function ddg_spice_opensnp(ir) {
-    var out = '';
+    var snippet, div;
 
+    // did the API return an error?
+    if ( ir['error'] ) {
+        return;
+    }
+
+    // did the API return information?
     if ( ir['snp'] ) {
         out = ir['chromosome'];
-    }
-    if (out) {
         items = new Array();
         items[0] = new Array();
-        items[0]['a'] = out;
+        items[0]['a'] = ir;
         items[0]['h'] = '';
         items[0]['u'] = ir['source_url'];
         items[0]['s'] = 'openSNP';

--- a/share/spice/open_snp/spice.js
+++ b/share/spice/open_snp/spice.js
@@ -11,17 +11,21 @@ function ddg_spice_open_snp(ir) {
         // Do we have annotations?
         if (ir['snp']['annotations']) {
             var annotations = ir['snp']['annotations'];
+            var mendeley_papers = 0;
+            var plos_papers = 0;
             if ( annotations['mendeley'] ){
-                snippet += '<br/>There is Mendeley-annotation available!<br/>';
+                mendeley_papers = annotations['mendeley'].length;
             }
-            if (annotations['snpedia']) {
+            if ( annotations['plos'] ) {
+                plos_papers = annotations['plos'].length;
+            }
+            snippet += '<br/>There are ' + mendeley_papers + ' papers at Mendeley and ' + plos_papers + ' papers at PLOS available on this SNP.<br/>';
+            if ( annotations['snpedia'] ) {
                 snippet += '<br/>SNPedia has the following:<br/>';
                 for ( var i = 0; i < annotations['snpedia'].length; i++ ) {
                     snippet += annotations['snpedia'][i]['url'].split('/')[4] + ': ' + annotations['snpedia'][i]['summary'] + '<br/>';
                 }
-            }
-            if (annotations['plos']) {
-                snippet += '<br/>There is PLOS-annotation available!<br/>';
+                snippet += '<br/>';
             }
 
         }
@@ -31,7 +35,7 @@ function ddg_spice_open_snp(ir) {
         items[0]['a'] = snippet;
         items[0]['h'] = 'Information on SNP <b>' + snp_name + '</b> at openSNP.org';
         items[0]['s'] = 'openSNP.org'
-        items[0]['u'] = 'http://openSNP.org/snps/' + ir['snp']['name'];
+        items[0]['u'] = 'http://openSNP.org/snps/' + ir['snp']['name'] + '#papers';
         nra(items);
     }
 }

--- a/share/spice/open_snp/spice.js
+++ b/share/spice/open_snp/spice.js
@@ -1,10 +1,37 @@
 function ddg_spice_open_snp(ir) {
     // did the API return information?
-    items = new Array();
-    items[0] = new Array();
-    items[0]['a'] = ir['snp']['name'];
-    items[0]['h'] = 'SNP-annotation at openSNP.org';
-    items[0]['u'] = ir['source_url'];
-    items[0]['s'] = 'openSNP.org/snps/' + ir['snp']['name'];
-    nra(items);
+    var table;
+    if ( ir['snp'] ) {
+        var snp_name = ir['snp']['name'];
+        var snp_position = ir['snp']['position'];
+        var snp_chromosome = ir['snp']['chromosome'];
+        var snippet = 'Position: ';
+        snippet += snp_position + '<br/>';
+        snippet += 'Chromosome: ' + snp_chromosome + '<br/>';
+        // Do we have annotations?
+        if (ir['snp']['annotations']) {
+            var annotations = ir['snp']['annotations'];
+            if ( annotations['mendeley'] ){
+                snippet += '<br/>There is Mendeley-annotation available!<br/>';
+            }
+            if (annotations['snpedia']) {
+                snippet += '<br/>SNPedia has the following:<br/>';
+                for ( var i = 0; i < annotations['snpedia'].length; i++ ) {
+                    snippet += annotations['snpedia'][i]['url'].split('/')[4] + ': ' + annotations['snpedia'][i]['summary'] + '<br/>';
+                }
+            }
+            if (annotations['plos']) {
+                snippet += '<br/>There is PLOS-annotation available!<br/>';
+            }
+
+        }
+
+        items = new Array();
+        items[0] = new Array();
+        items[0]['a'] = snippet;
+        items[0]['h'] = 'Information on SNP <b>' + snp_name + '</b> at openSNP.org';
+        items[0]['s'] = 'openSNP.org'
+        items[0]['u'] = 'http://openSNP.org/snps/' + ir['snp']['name'];
+        nra(items);
+    }
 }

--- a/share/spice/open_snp/spice.js
+++ b/share/spice/open_snp/spice.js
@@ -14,32 +14,50 @@ function ddg_spice_open_snp(ir) {
         if (ir['snp']['annotations']) {
             var annotations = ir['snp']['annotations'];
             // Mendeley-annotation
-            var annotations_snippet = '<br/><br/>';
+            var annotations_snippet = '<br/>';
             var mendeley_length = 0;
             var plos_length = 0;
-            if ( annotations['mendeley'] ){
+            if ( annotations['mendeley'][0]){
                 mendeley_length = annotations['mendeley'].length;
                 var first_paper = annotations['mendeley'][0];
                 var time = first_paper['publication_year'];
-                annotations_snippet += '<b>Mendeley:</b> ' + first_paper['author'] + ' <i>et al.</i>, ' + time + ': <i>' + '<a href="' +  first_paper['url'] + '">' + first_paper['title'] + '</a></i>. [<a href="http://www.mendeley.com/research-papers/search/?query=' + snp_name + '">' + (parseInt(mendeley_length)-1) + ' more papers at Mendeley</a>]<br/><br/>';
+                annotations_snippet += '<br/>' + first_paper['author'] + ' <i>et al.</i>, ' + time + ': <i>' + '<a href="' +  first_paper['url'] + '">' + first_paper['title'] + '</a></i>. [<a href="http://www.mendeley.com/research-papers/search/?query=' + snp_name + '">' + (parseInt(mendeley_length)-1) + ' more papers at Mendeley</a>]<br/>';
             }
 
             // PLOS-annotation
-            if ( annotations['plos'] ) {
+            if ( annotations['plos'][0]  ) {
                 plos_length = annotations['plos'].length;
                 var first_paper = annotations['plos'][0];
                 time = new Date(first_paper['publication_date']).getFullYear();
-                annotations_snippet += '<b>PLOS:</b> ' + first_paper['author'] + ' <i>et al.</i>, ' + time +  ': <i><a href="' + first_paper['url'] + '">'+ first_paper['title'] + '</i></a>. [<a href="http://www.plosone.org/search/advancedSearch.action?noSearchFlag=true&query=' + snp_name + '">'  + (parseInt(plos_length)-1) + ' more papers at PLOS</a>]<br/><br/>';
+                annotations_snippet += '<br/>' + first_paper['author'] + ' <i>et al.</i>, ' + time +  ': <i><a href="' + first_paper['url'] + '">'+ first_paper['title'] + '</i></a>. [<a href="http://www.plosone.org/search/advancedSearch.action?noSearchFlag=true&query=' + snp_name + '">'  + (parseInt(plos_length)-1) + ' more papers at PLOS</a>]<br/>';
+            }
+
+            // Personal Genome Project
+            if ( annotations['pgp_annotations'][0]) {
+                pgp_length = annotations['pgp_annotations'].length;
+                var first_annotation = annotations['pgp_annotations'][0];
+                var gene = first_annotation['gene'];
+                var impact = first_annotation['impact'];
+                annotations_snippet += '<br/>Gene: ' + gene + ', impact: ' + impact + ' [More at <a href="">Personal Genome Project</a>]<br/>';
+            }
+
+            // Genome.gov
+            if ( annotations['genome_gov_publications'][0]  ) {
+                genomegov_length = annotations['genome_gov_publications'].length;
+                var first_paper = annotations['genome_gov_publications'][0];
+                var time = first_paper['publication_date'].split("/")[2];
+                var url = first_paper['pubmed_link'];
+                var title = first_paper['title'];
+                annotations_snippet += '<br/>' + first_paper['first_author'] + ' <i>et al.</i>, ' + time + ': <a href="' + url + '">' + title + '</a>[<a href="https://www.genome.gov/26525384#searchForm">' + genomegov_length + ' more papers at Genome.gov</a>]<br/>';
             }
 
             // SNPedia-annotation - add to main-snippet
-            if ( annotations['snpedia'] ) {
+            if ( annotations['snpedia'][0] ) {
                 snippet += '<br/>Annotations at <a href="http://www.snpedia.com/index.php/' + snp_name + '">SNPedia</a>:<br/>'
                 var snpedia_length = annotations['snpedia'].length;
                 for ( var i = 0; i < annotations['snpedia'].length; i++ ) {
                     snippet += annotations['snpedia'][i]['url'].split('/')[4] + ': ' + annotations['snpedia'][i]['summary'] + '<br/>';
                 }
-                snippet += '<br/>';
             }
         }
 
@@ -49,8 +67,8 @@ function ddg_spice_open_snp(ir) {
         items[0]['force_big_header'] = 1;
         items[0]['s'] = 'openSNP.org';
         items[0]['u'] = 'http://openSNP.org/snps/' + ir['snp']['name'];
-        if ( annotations_snippet != '<br/><br/>' ) {
-            items[1]['a'] = annotations_snippet;
+        if ( annotations_snippet != '<br/>' ) {
+            items[1]['a'] = annotations_snippet + '<br/>';
             items[1]['t'] = 'Further annotations';
         }
         nra(items);

--- a/t/OpenSNP.t
+++ b/t/OpenSNP.t
@@ -1,0 +1,17 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+ddg_spice_test(
+    [qw( DDG::Spice::OpenSNP )],
+    'rs12' => test_spice(
+        '/js/spice/open_snp/rs12',
+        caller => 'DDG::Spice::OpenSNP',
+        is_cached => 0
+    ),
+    "I am not a SNP" => undef,
+);
+done_testing;

--- a/t/OpenSNP.t
+++ b/t/OpenSNP.t
@@ -13,5 +13,6 @@ ddg_spice_test(
         is_cached => 0
     ),
     "I am not a SNP" => undef,
+    "rsiamnotaSNP" => undef,
 );
 done_testing;


### PR DESCRIPTION
I added support for search of Single Nucleotide Polymorphisms (SNPs) ([Wikipedia](en.wikipedia.org/wiki/Single-nucleotide_polymorphism)) based on the openSNP.org JSON API.

The openSNP-API lists all information that PLOS, Mendeley and SNPedia have stored on that relevant SNP. The SNPedia-table is reproduced because it's short and easy to understand for laymen. PLOS and Mendeley might report too many papers so I just put the counter for these into the output, plus links to the sources. 

All search-terms starting with "rs" followed by _n_ numbers without any letters are assumed to be SNP-names, for example `rs1234` triggers, while `rsWhyHelloThere` does not.

To do: Right now the output is based on ugly string-concatenation, not really sure how to "properly" do that using JS.

Any feedback greatly appreciated, this is my first proper time working with JavaScript.

Here's an example with a properly annotated SNP: http://i.imgur.com/Gypy3.png
