### PR TITLE
SoundCloud plugin for displaying music players

### DIFF
--- a/lib/DDG/Spice/SoundCloud.pm
+++ b/lib/DDG/Spice/SoundCloud.pm
@@ -1,0 +1,30 @@
+
+package DDG::Spice::SoundCloud;
+
+use DDG::Spice;
+
+description "Displays SoundCloud Players";
+name "SoundCloud";
+primary_example_queries "soundcloud Jetski Safari Like a Lie";
+secondary_example_queries "sc kavinsky";
+topics "entertainment", "music";
+category "entertainment";
+code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/SoundCloud.pm";
+attribution web => ['http://jordanscales.com', 'Jordan Scales'],
+            email => ['scalesjordan@gmail.com', 'Jordan Scales'],
+            github => ['http://github.com/prezjordan', 'prezjordan'],
+            twitter => ['http://twitter.com/prezjordan', '@prezjordan'];
+status "enabled";
+
+spice to => 'http://api.soundcloud.com/tracks.json?client_id={{ENV{DDG_SPICE_SOUNDCLOUD_APIKEY}}}&q=$1&limit=1&callback={{callback}}';
+spice is_cached => 0;
+
+triggers start => "sc", "soundcloud";
+
+handle remainder => sub {
+    return if $_ eq '';
+    return $_ if defined $_;
+    return;
+};
+
+1;

--- a/share/spice/sound_cloud/spice.js
+++ b/share/spice/sound_cloud/spice.js
@@ -1,0 +1,40 @@
+function ddg_spice_sound_cloud(sc) {
+  var snippet,iframe,res;
+  
+  // validity check
+  if (sc.length && sc[0].uri && sc[0].title && sc[0].user && sc[0].user.username && sc[0].permalink_url) {
+    // rename for readability
+    res = sc[0];
+
+    // snippet shown in 0-click
+    snippet = d.createElement('span');
+
+    // create embedded soundcloud player
+    iframe = d.createElement('iframe');
+    iframe.setAttribute('width', '100%');
+    iframe.setAttribute('height', '166');
+    iframe.setAttribute('scrolling', 'no');
+    iframe.setAttribute('frameborder', 'no');
+    iframe.setAttribute('src', 'https://w.soundcloud.com/player/?url=' + encodeURI(res.uri));
+
+    // append iframe to snippet
+    snippet.appendChild(iframe);
+
+    items = new Array();
+    items[0] = new Array();
+    items[0]['a'] = snippet;
+
+    // set the header to the SoundCloud title
+    items[0]['h'] = res.title;
+
+    // source name and url for the More at X link.
+    items[0]['s'] = 'SoundCloud';
+    items[0]['u'] = res.permalink_url;
+
+    // sorce no compression.
+    items[0]['f'] = 1;
+
+    // the rendering function is nra.
+    nra(items);
+  }
+}


### PR DESCRIPTION
Using a search endpoint for the SoundCloud API, this spice plugin fetches the best-matched track for a given query starting with "soundcloud" or "sc" and displays its player.

![Screen Shot 2012-12-19 at 8 35 39 PM](https://f.cloud.github.com/assets/287268/23501/9b15e870-4a45-11e2-9686-b1093e29c844.png)

Examples:
- **sc Kill Paris - Tender Love**
- **soundcloud kavinsky protovision**

Note: `spice to =>` references `{{ENV{DDG_SPICE_SOUNDCLOUD_APIKEY}}}`. An API Key (Client ID) can be acquired on the [SoundCloud Developers](soundcloud.com/you/apps) page.

Regards,
Jordan
http://jordanscales.com
