### PR TITLE
Hackage spice

### DIFF
--- a/lib/DDG/Spice/Hackage.pm
+++ b/lib/DDG/Spice/Hackage.pm
@@ -1,0 +1,25 @@
+package DDG::Spice::Hackage;
+# ABSTRACT: Search for information about Hackage packages
+
+use DDG::Spice;
+
+triggers any => "hackage", "haskell";
+spice to => 'http://localhost:8000/packages/$1.jsonp';
+
+primary_example_queries "hackage containers";
+description "Haskell packages";
+name "Hackage";
+code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/Hackage.pm";
+topics "programming";
+category "programming";
+attribution github => ["https://github.com/nomeata", "Joachim Breitner"],
+            web => ["http://www.joachim-breitner.de", "Joachim Breitner"],
+            email => ['mail@joachim-breitner.de', "Joachim Breitner"];
+
+
+handle remainder => sub {
+    return $_ if defined $_;
+    return;   
+};
+
+1;

--- a/lib/DDG/Spice/Hackage.pm
+++ b/lib/DDG/Spice/Hackage.pm
@@ -4,7 +4,7 @@ package DDG::Spice::Hackage;
 use DDG::Spice;
 
 triggers any => "hackage", "haskell";
-spice to => 'http://localhost:8000/packages/$1.jsonp';
+spice to => 'http://www.typeful.net/~tbot/hackage/packages/$1/$1.jsonp';
 
 primary_example_queries "hackage containers";
 description "Haskell packages";

--- a/share/spice/hackage/spice.js
+++ b/share/spice/hackage/spice.js
@@ -1,0 +1,50 @@
+function hackageDataCallback(re) {    
+    var pkgName = re['packageDescription']['package']['pkgName'];
+    var pkgVersion = re['packageDescription']['package']['pkgVersion'];
+    var synopsis = re['packageDescription']['synopsis'];
+    //var description = re['packageDescription']['description'];
+    var author = re['packageDescription']['author'];
+    var homepage = re['packageDescription']['homepage'];
+    var license = re['packageDescription']['license'];
+
+    synopsis = synopsis.replace(/\.$/,"");
+
+    var library = re['condLibrary'];
+    var executable = re['condExecutables'];
+
+    var type;
+    if (library && (executable.length > 0)) {
+	    type = "library and program";
+    } else if (executable.length > 0) {
+	    type = "program";
+    } else if (library) {
+	    type = "library";
+    } else {
+	    type = "something";
+    }    
+
+    var url = "http://hackage.haskell.org/package/" + pkgName;
+
+    items = new Array();
+    items[0] = new Array();
+    items[0]["a"] = h(synopsis) + "<br/>";
+    if (author) {
+    	items[0]["a"] += "by " + h(author) + "<br/>";
+    }
+    if (license) {
+    	items[0]["a"] += h(license) + " &bull; ";
+    }
+    if (homepage) {
+    	items[0]["a"] += "<a href=\"" + h(homepage) + "\">Homepage</a> &bull; ";
+    }
+    items[0]["h"] = "The haskell " + h(type) + " »" + h(pkgName) + "« version " + h(pkgVersion);
+    items[0]["s"] = "Hackage";
+    items[0]["u"] = url;
+        
+    nra(items);
+};
+
+function h(txt) {
+        return txt.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+


### PR DESCRIPTION
This is a code preview, the data source is not yet online (waiting for https://github.com/sol/hackage-jsonp/pull/3). Then, this gives a nice short overview about the hackage package of the given name.

BTW, is there a way to avoid the „more at ...“ link and format that part directly?
