### PR TITLE
Firefox Add-ons plugin for DuckDuckGo

### DIFF
--- a/lib/DDG/Spice/FirefoxAddons.pm
+++ b/lib/DDG/Spice/FirefoxAddons.pm
@@ -1,0 +1,28 @@
+package DDG::Spice::FirefoxAddons;
+
+use DDG::Spice;
+
+triggers any => "firefox";
+
+spice to => 'https://services.addons.mozilla.org/en-US/firefox/api/1.5/search/$1/all/1';
+spice wrap_string_callback => 1;
+
+primary_example_queries "manage firefox tabs";
+secondary_example_queries "firefox addon manager";
+description "Firefox Add-ons";
+name "FirefoxAddons";
+icon_url "/i/addons.mozilla.org.ico";
+source "Mozilla|AMO";
+code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/FirefoxAddons.pm";
+topics  "geek";
+category  "software";
+
+attribution github => ['https://github.com/CIAvash','Siavash'],
+  twitter => ['https://twitter.com/CIAvash','CIAvash'],
+  web => ['http://potatozone.com','PotatoZone'];
+
+handle remainder => sub {
+  return $_;
+};
+
+1;

--- a/share/spice/firefox_addons/spice.js
+++ b/share/spice/firefox_addons/spice.js
@@ -1,0 +1,34 @@
+function ddg_spice_firefox_addons(xmlString) {
+    var items = [[]];
+    var xml = parseXml(xmlString);
+    var name = xml.getElementsByTagName('name')[0];
+    var summary = xml.getElementsByTagName('summary')[0];
+    var icon = xml.getElementsByTagName('icon')[0];
+    var url = xml.getElementsByTagName('learnmore')[0];
+    items[0]['h'] = name.textContent || name.innerText;
+    items[0]['a'] = summary.textContent || summary.innerText;
+    items[0]['i'] = icon.textContent || icon.innerText;
+    items[0]['s'] = 'Firefox Add-ons';
+    items[0]['u'] = url.textContent || url.innerText;
+    items[0]['force_big_header'] = 1;
+    items[0]["force_space_after"] = 1;
+    nra(items);
+}
+
+var parseXml;
+
+if (typeof window.DOMParser != "undefined") {
+    parseXml = function(xmlStr) {
+        return ( new window.DOMParser() ).parseFromString(xmlStr, "application/xml");
+    };
+} else if (typeof window.ActiveXObject != "undefined" &&
+           new window.ActiveXObject("Microsoft.XMLDOM")) {
+    parseXml = function(xmlStr) {
+        var xmlDoc = new window.ActiveXObject("Microsoft.XMLDOM");
+        xmlDoc.async = "false";
+        xmlDoc.loadXML(xmlStr);
+        return xmlDoc;
+    };
+} else {
+    throw new Error("No XML parser found");
+}


### PR DESCRIPTION
Plugin functionality: Shows a Firefox add-on based on the search query

Plugin data source (API): [The generic AMO API](https://developer.mozilla.org/en-US/docs/addons.mozilla.org_%28AMO%29_API_Developers%27_Guide/The_generic_AMO_API)

Example queries: "firefox" triggers this plugin anywhere in the search query

Have you done any cross-browser testing?
On Firefox and Chromium.

Which plugins does supercede/overlap?
Probably FirefoxAboutConfig
https://github.com/duckduckgo/zeroclickinfo-fathead/blob/master/lib/DDG/Fathead/FirefoxAboutConfig.pm

Is this plugin connected to an Ideas.DuckDuckHack or Duck.co thread?
https://duckduckhack.uservoice.com/forums/5168-ideas-for-duckduckgo-instant-answer-plugins/suggestions/3876906-firefox-add-ons
