### PR TITLE
GitHub: fix repo owner URL in template

### DIFF
--- a/share/spice/github/github_list_item.handlebars
+++ b/share/spice/github/github_list_item.handlebars
@@ -1,6 +1,6 @@
 <li>
     <a href="{{url}}">{{name}}</a>
-    (<a href="ownerURL">{{owner}}</a>{{#if fork}}, fork{{/if}})
+    (<a href="https://github.com/{{owner}}">{{owner}}</a>{{#if fork}}, fork{{/if}})
     {{#if description}}
         - {{description}}
     {{/if}}


### PR DESCRIPTION
Currently [GitHub searches](https://duckduckgo.com/?q=irc+script+github) have links to the invalid https://duckduckgo.com/ownerURL when you click on repo owners.
