### PR TITLE
Removed "call_type => 'include'" from test files

### DIFF
--- a/t/Airlines.t
+++ b/t/Airlines.t
@@ -9,12 +9,10 @@ ddg_spice_test(
     [qw( DDG::Spice::Airlines )],
     'aa 102' => test_spice(
         '/js/spice/airlines/AA/102',
-        call_type => 'include',
         caller => 'DDG::Spice::Airlines',
     ),
     '102 aa' => test_spice(
     	'/js/spice/airlines/AA/102',
-    	call_type => 'include',
     	caller => 'DDG::Spice::Airlines',
     )
 );

--- a/t/AlternativeTo.t
+++ b/t/AlternativeTo.t
@@ -9,7 +9,6 @@ ddg_spice_test(
     [qw( DDG::Spice::AlternativeTo )],
     'alternative to windows' => test_spice(
         '/js/spice/alternative_to/windows/all/',
-        call_type => 'include',
         caller => 'DDG::Spice::AlternativeTo'
     ),
 );

--- a/t/Amazon.t
+++ b/t/Amazon.t
@@ -15,7 +15,6 @@ ddg_spice_test(
     map {(
         "amazon $_" => test_spice(
             '/js/spice/amazon/' . join('%20', split /\s+/, $_),
-            call_type => 'include',
             caller => 'DDG::Spice::Amazon'
         ),
     )} @queries

--- a/t/Aur.t
+++ b/t/Aur.t
@@ -9,17 +9,14 @@ ddg_spice_test(
     [qw( DDG::Spice::Aur )],
     'aur powermate' => test_spice(
         '/js/spice/aur/powermate',
-        call_type => 'include',
         caller => 'DDG::Spice::Aur'
     ),
     'archlinux package powermate' => test_spice(
         '/js/spice/aur/powermate',
-        call_type => 'include',
         caller => 'DDG::Spice::Aur'
     ),
     'arch package powermate' => test_spice(
         '/js/spice/aur/powermate',
-        call_type => 'include',
         caller => 'DDG::Spice::Aur'
     ),
 );

--- a/t/Automeme.t
+++ b/t/Automeme.t
@@ -9,7 +9,6 @@ ddg_spice_test(
     [qw( DDG::Spice::Automeme )],
     'random meme' => test_spice(
         '/js/spice/automeme/',
-        call_type => 'include',
         caller => 'DDG::Spice::Automeme',
         is_unsafe => 1
     ),

--- a/t/Betterific.t
+++ b/t/Betterific.t
@@ -9,27 +9,22 @@ ddg_spice_test(
     [qw( DDG::Spice::Betterific )],
     'betterific' => test_spice(
         '/js/spice/betterific/',
-        call_type => 'include',
         caller => 'DDG::Spice::Betterific',
     ),
     'betterif golf' => test_spice(
         '/js/spice/betterific/golf',
-        call_type => 'include',
         caller => 'DDG::Spice::Betterific',
     ),
     'betterific golf' => test_spice(
         '/js/spice/betterific/golf',
-        call_type => 'include',
         caller => 'DDG::Spice::Betterific',
     ),
     'betterif golf balls' => test_spice(
         '/js/spice/betterific/golf%20balls',
-        call_type => 'include',
         caller => 'DDG::Spice::Betterific',
     ),
     'betterific golf balls' => test_spice(
         '/js/spice/betterific/golf%20balls',
-        call_type => 'include',
         caller => 'DDG::Spice::Betterific',
     )
 );

--- a/t/Bible.t
+++ b/t/Bible.t
@@ -9,7 +9,6 @@ ddg_spice_test(
     [qw( DDG::Spice::Bible )],
     'james 1:26' => test_spice(
         '/js/spice/bible/james%201%3A26',
-        call_type => 'include',
         caller => 'DDG::Spice::Bible'
     ),
 );

--- a/t/Bootic.t
+++ b/t/Bootic.t
@@ -9,17 +9,14 @@ ddg_spice_test(
     [qw( DDG::Spice::Aur )],
     'aur powermate' => test_spice(
         '/js/spice/aur/powermate',
-        call_type => 'include',
         caller => 'DDG::Spice::Aur'
     ),
     'archlinux package powermate' => test_spice(
         '/js/spice/aur/powermate',
-        call_type => 'include',
         caller => 'DDG::Spice::Aur'
     ),
     'arch package powermate' => test_spice(
         '/js/spice/aur/powermate',
-        call_type => 'include',
         caller => 'DDG::Spice::Aur'
     ),
 );

--- a/t/Canistreamit.t
+++ b/t/Canistreamit.t
@@ -9,7 +9,6 @@ ddg_spice_test(
     [qw( DDG::Spice::Canistreamit )],
     'stream the wire' => test_spice(
         '/js/spice/canistreamit/the%20wire',
-        call_type => 'include',
         caller => 'DDG::Spice::Canistreamit'
     ),
 );

--- a/t/ChuckNorris.t
+++ b/t/ChuckNorris.t
@@ -9,13 +9,11 @@ ddg_spice_test(
     [qw( DDG::Spice::ChuckNorris )],
     'chuck norris facts' => test_spice(
         '/js/spice/chuck_norris/',
-        call_type => 'include',
         caller => 'DDG::Spice::ChuckNorris',
         is_unsafe => 1
     ),
     'chuck norris jokes' => test_spice(
         '/js/spice/chuck_norris/',
-        call_type => 'include',
         caller => 'DDG::Spice::ChuckNorris',
         is_unsafe => 1
     ),

--- a/t/CodeSearch.t
+++ b/t/CodeSearch.t
@@ -9,7 +9,6 @@ ddg_spice_test(
     [qw( DDG::Spice::CodeSearch )],
     'perl code' => test_spice(
         '/js/spice/code_search/lang%3Aperl%20',
-        call_type => 'include',
         caller => 'DDG::Spice::CodeSearch'
     ),
 );

--- a/t/Congress.t
+++ b/t/Congress.t
@@ -9,7 +9,6 @@ ddg_spice_test(
     [qw( DDG::Spice::Congress )],
     'ny representatives' => test_spice(
         '/js/spice/congress/house/ny',
-        call_type => 'include',
         caller => 'DDG::Spice::Congress'
     ),
 );

--- a/t/CouponMountain.t
+++ b/t/CouponMountain.t
@@ -14,7 +14,7 @@ my %q = (
 ddg_spice_test(
   [qw( DDG::Spice::CouponMountain)],
   map {
-    $_ => test_spice('/js/spice/coupon_mountain/'.$q{$_},	caller => 'DDG::Spice::CouponMountain')
+    $_ => test_spice('/js/spice/coupon_mountain/'.$q{$_}, caller => 'DDG::Spice::CouponMountain')
   } keys %q,
 );
 

--- a/t/DNS.t
+++ b/t/DNS.t
@@ -9,27 +9,22 @@ ddg_spice_test(
     [qw( DDG::Spice::DNS )],
     'mx record dylansserver.com' => test_spice(
         '/js/spice/dns/MX/dylansserver.com',
-        call_type => 'include',
         caller => 'DDG::Spice::DNS'
     ),
     'dns records dylansserver.com' => test_spice(
         '/js/spice/dns/ANY/dylansserver.com',
-        call_type => 'include',
         caller => 'DDG::Spice::DNS'
     ),
     'any dns records dylansserver.com' => test_spice(
         '/js/spice/dns/ANY/dylansserver.com',
-        call_type => 'include',
         caller => 'DDG::Spice::DNS'
     ),
     'dig dylansserver.com' => test_spice(
         '/js/spice/dns/ANY/dylansserver.com',
-        call_type => 'include',
         caller => 'DDG::Spice::DNS'
     ),
     'dig ns dylansserver.com' => test_spice(
         '/js/spice/dns/NS/dylansserver.com',
-        call_type => 'include',
         caller => 'DDG::Spice::DNS'
     ),
     'a record by foo' => undef,

--- a/t/DetectLang.t
+++ b/t/DetectLang.t
@@ -10,7 +10,6 @@ ddg_spice_test(
 	[ qw(DDG::Spice::DetectLang) ],
 	'detect language something' => test_spice(
 		'/js/spice/detect_lang/something',
-		call_type => 'include',
 		caller    => 'DDG::Spice::DetectLang'
 	)
 );

--- a/t/Dictionary.t
+++ b/t/Dictionary.t
@@ -11,17 +11,14 @@ ddg_spice_test(
     )],
     'define superfluous' => test_spice(
         '/js/spice/dictionary/definition/superfluous',
-        call_type => 'include',
         caller => 'DDG::Spice::Dictionary::Definition'
     ),
     'meaning of test' => test_spice(
         '/js/spice/dictionary/definition/test',
-        call_type => 'include',
         caller => 'DDG::Spice::Dictionary::Definition'
     ),
     'define define' => test_spice(
         '/js/spice/dictionary/definition/define',
-        call_type => 'include',
         caller => 'DDG::Spice::Dictionary::Definition'
     ),
 );

--- a/t/Drinks.t
+++ b/t/Drinks.t
@@ -9,7 +9,6 @@ ddg_spice_test(
     [qw( DDG::Spice::Drinks )],
     'how to make a white russian' => test_spice(
         '/js/spice/drinks/white%20russian',
-        call_type => 'include',
         caller => 'DDG::Spice::Drinks'
     ),
 );

--- a/t/Expatistan.t
+++ b/t/Expatistan.t
@@ -9,7 +9,6 @@ ddg_spice_test(
     [qw( DDG::Spice::Expatistan )],
     'cost of living in nyc' => test_spice(
         '/js/spice/expatistan/cost%20of%20living%20in%20nyc',
-        call_type => 'include',
         caller => 'DDG::Spice::Expatistan'
     ),
 );

--- a/t/Forecast.t
+++ b/t/Forecast.t
@@ -18,13 +18,11 @@ ddg_spice_test(
     ) => test_spice(
         # "/js/spice/forecast/${\$loc->latitude}%2C${\$loc->longitude}",
         "/js/spice/forecast/" . uri_escape_utf8(${\$loc->loc_str}),
-        call_type => 'include',
         caller => 'DDG::Spice::Forecast',
         is_cached => 0
     ),
     'weather for Troy, NY' => test_spice(
     	'/js/spice/forecast/troy%2C%20ny',
-    	call_type => 'include',
     	caller => 'DDG::Spice::Forecast',
         is_cached => 0
     )

--- a/t/Forvo.t
+++ b/t/Forvo.t
@@ -9,7 +9,6 @@ ddg_spice_test(
     [qw( DDG::Spice::Forvo )],
     'pronounce duck' => test_spice(
         '/js/spice/forvo/duck/empty',
-        call_type => 'include',
         caller => 'DDG::Spice::Forvo',
     ),
 );

--- a/t/GameInfo.t
+++ b/t/GameInfo.t
@@ -9,12 +9,10 @@ ddg_spice_test(
     [qw( DDG::Spice::GameInfo )],
     'game homesick' => test_spice(
         '/js/spice/game_info/homesick',
-        call_type => 'include',
         caller => 'DDG::Spice::GameInfo',
     ),
     'unreal games' => test_spice(
         '/js/spice/game_info/unreal',
-        call_type => 'include',
         caller => 'DDG::Spice::GameInfo',
     ),
 );

--- a/t/Github.t
+++ b/t/Github.t
@@ -9,12 +9,10 @@ ddg_spice_test(
     [qw( DDG::Spice::Github )],
     'github zeroclickinfo' => test_spice(
         '/js/spice/github/zeroclickinfo',
-        call_type => 'include',
         caller => 'DDG::Spice::Github'
     ),
     'zeroclickinfo github' => test_spice(
         '/js/spice/github/zeroclickinfo',
-        call_type => 'include',
         caller => 'DDG::Spice::Github'
     ),
 );

--- a/t/GithubJobs.t
+++ b/t/GithubJobs.t
@@ -9,7 +9,6 @@ ddg_spice_test(
     [qw( DDG::Spice::GithubJobs )],
     'perl jobs in nyc' => test_spice(
         '/js/spice/github_jobs/perl-nyc',
-        call_type => 'include',
         caller => 'DDG::Spice::GithubJobs'
     ),
 );

--- a/t/GooglePlus.t
+++ b/t/GooglePlus.t
@@ -9,7 +9,6 @@ ddg_spice_test(
     [qw( DDG::Spice::GooglePlus )],
     'g+ dax' => test_spice(
         '/js/spice/google_plus/dax',
-        call_type => 'include',
         caller => 'DDG::Spice::GooglePlus'
     ),
 );

--- a/t/Gravatar.t
+++ b/t/Gravatar.t
@@ -9,7 +9,6 @@ ddg_spice_test(
     [qw( DDG::Spice::Gravatar )],
     'gravatar dax@duckduckgo.com' => test_spice(
         '/js/spice/gravatar/58b5a3d8684cc10b5687a81549c94de2',
-        call_type => 'include',
         caller => 'DDG::Spice::Gravatar'
     ),
 );

--- a/t/Guidebox.t
+++ b/t/Guidebox.t
@@ -11,19 +11,16 @@ ddg_spice_test(
     # TV series    
     'free episodes of NCIS' => test_spice(
         '/js/spice/guidebox/getid/NCIS',
-        call_type => 'include',
         caller => 'DDG::Spice::Guidebox::Getid'
     ),
 
     'free episodes of Dexter' => test_spice(
         '/js/spice/guidebox/getid/Dexter',
-        call_type => 'include',
         caller => 'DDG::Spice::Guidebox::Getid'
     ),
 
     'recent episodes The Big Bang Theory' => test_spice(
         '/js/spice/guidebox/getid/The%20Big%20Bang%20Theory',
-        call_type => 'include',
         caller => 'DDG::Spice::Guidebox::Getid'
     ),
 );

--- a/t/HackerNews.t
+++ b/t/HackerNews.t
@@ -9,7 +9,6 @@ ddg_spice_test(
     [qw( DDG::Spice::HackerNews )],
     'hn duckduckgo' => test_spice(
         '/js/spice/hacker_news/duckduckgo',
-        call_type => 'include',
         caller => 'DDG::Spice::HackerNews'
     ),
 );

--- a/t/Hayoo.t
+++ b/t/Hayoo.t
@@ -9,7 +9,6 @@ ddg_spice_test(
     [qw( DDG::Spice::Hayoo )],
     'hayoo Prelude.map' => test_spice(
         '/js/spice/hayoo/Prelude.map',
-        call_type => 'include',
         caller => 'DDG::Spice::Hayoo'
     ),
 );

--- a/t/HqTemp.t
+++ b/t/HqTemp.t
@@ -9,7 +9,6 @@ ddg_spice_test(
     [qw( DDG::Spice::HqTemp )],
     'temperature at duckduckgo' => test_spice(
         '/js/spice/hq_temp/',
-        call_type => 'include',
         caller => 'DDG::Spice::HqTemp'
     ),
 );

--- a/t/Imdb.t
+++ b/t/Imdb.t
@@ -9,7 +9,6 @@ ddg_spice_test(
     [qw( DDG::Spice::Imdb )],
     'imdb mighty ducks' => test_spice(
         '/js/spice/imdb/mighty%20ducks',
-        call_type => 'include',
         caller => 'DDG::Spice::Imdb'
     ),
 );

--- a/t/IsItUp.t
+++ b/t/IsItUp.t
@@ -10,12 +10,10 @@ ddg_spice_test(
     [qw( DDG::Spice::IsItUp )],
     'is duckduckgo.com up?' => test_spice(
         '/js/spice/is_it_up/duckduckgo.com',
-        call_type => 'include',
         caller => 'DDG::Spice::IsItUp',
     ),
     'is http://duckduckgo.com up?' => test_spice(
         '/js/spice/is_it_up/duckduckgo.com',
-        call_type => 'include',
         caller => 'DDG::Spice::IsItUp',
     ),
     # unfortunately, the isitup.com api does not

--- a/t/KhanAcademy.t
+++ b/t/KhanAcademy.t
@@ -9,12 +9,10 @@ ddg_spice_test(
     [qw( DDG::Spice::KhanAcademy )],
     'khan calculus' => test_spice(
         '/js/spice/khan_academy/calculus',
-        call_type => 'include',
         caller => 'DDG::Spice::KhanAcademy'
     ),
     'khan academy trigonometry' => test_spice(
         '/js/spice/khan_academy/trigonometry',
-        call_type => 'include',
         caller => 'DDG::Spice::KhanAcademy'
     ),
 );

--- a/t/LeakDB.t
+++ b/t/LeakDB.t
@@ -9,17 +9,14 @@ ddg_spice_test(
     [qw( DDG::Spice::LeakDB )],
     'leakdb edbd1887e772e13c251f688a5f10c1ffbb67960d' => test_spice(
         '/js/spice/leak_db/edbd1887e772e13c251f688a5f10c1ffbb67960d',
-        call_type => 'include',
         caller => 'DDG::Spice::LeakDB'
     ),
     'leakdb secretpassword' => test_spice(
         '/js/spice/leak_db/secretpassword',
-        call_type => 'include',
         caller => 'DDG::Spice::LeakDB'
     ),
     'hashme password' => test_spice(
         '/js/spice/leak_db/password',
-        call_type => 'include',
         caller => 'DDG::Spice::LeakDB'
     ),
     'leakdb' => undef,

--- a/t/Maven.t
+++ b/t/Maven.t
@@ -9,27 +9,22 @@ ddg_spice_test(
     [qw( DDG::Spice::Maven )],
     'mvn guice' => test_spice(
         '/js/spice/maven/guice',
-        call_type => 'include',
         caller => 'DDG::Spice::Maven',
     ),
     'maven guice' => test_spice(
         '/js/spice/maven/guice',
-        call_type => 'include',
         caller => 'DDG::Spice::Maven',
     ),
     'guice mvn' => test_spice(
         '/js/spice/maven/guice',
-        call_type => 'include',
         caller => 'DDG::Spice::Maven',
     ),
     'guice maven' => test_spice(
         '/js/spice/maven/guice',
-        call_type => 'include',
         caller => 'DDG::Spice::Maven',
     ),
     'mvn commons collections' => test_spice(
         '/js/spice/maven/commons%20collections',
-        call_type => 'include',
         caller => 'DDG::Spice::Maven',
     ),
 );

--- a/t/MetaCPAN.t
+++ b/t/MetaCPAN.t
@@ -17,7 +17,6 @@ ddg_spice_test(
 	[ qw(DDG::Spice::MetaCPAN) ],
 	map { "$_ App::DuckPAN" => test_spice(
 		'/js/spice/meta_cpan/App%3A%3ADuckPAN',
-		call_type => 'include',
 		caller => 'DDG::Spice::MetaCPAN',
         )
     }, @triggers,

--- a/t/Movie.t
+++ b/t/Movie.t
@@ -9,7 +9,6 @@ ddg_spice_test(
     [qw( DDG::Spice::Movie )],
     'movie mighty ducks' => test_spice(
         '/js/spice/movie/mighty%20ducks',
-        call_type => 'include',
         caller => 'DDG::Spice::Movie'
     ),
     'asus rt-66nu' => undef

--- a/t/Npm.t
+++ b/t/Npm.t
@@ -9,7 +9,6 @@ ddg_spice_test(
 	[qw( DDG::Spice::Npm )],
 	'npm underscore' => test_spice(
 		'/js/spice/npm/underscore',
-		call_type => 'include',
 		caller => 'DDG::Spice::Npm',
 	),
 );

--- a/t/Octopart.t
+++ b/t/Octopart.t
@@ -9,12 +9,10 @@ ddg_spice_test(
     [qw( DDG::Spice::Octopart )],
     'atmega datasheet' => test_spice(
         '/js/spice/octopart/atmega',
-        call_type => 'include',
         caller => 'DDG::Spice::Octopart'
     ),
     'ne555 specs' => test_spice(
         '/js/spice/octopart/ne555',
-        call_type => 'include',
         caller => 'DDG::Spice::Octopart'
     ),
 );

--- a/t/RandNums.t
+++ b/t/RandNums.t
@@ -10,12 +10,10 @@ ddg_spice_test(
 	[ qw(DDG::Spice::RandNums) ],
 	'random nums' => test_spice(
 		'/js/spice/rand_nums/1/100',
-		call_type => 'include',
 		caller    => 'DDG::Spice::RandNums',
 	),
 	'random numbers 1 50' => test_spice(
 		'/js/spice/rand_nums/1/50',
-		call_type => 'include',
 		caller    => 'DDG::Spice::RandNums',
 	),
 );

--- a/t/RandWord.t
+++ b/t/RandWord.t
@@ -9,7 +9,6 @@ ddg_spice_test(
     [qw( DDG::Spice::RandWord )],
     'random word' => test_spice(
         '/js/spice/rand_word/0-100',
-        call_type => 'include',
         caller => 'DDG::Spice::RandWord',
     ),
 );

--- a/t/RedditSearch.t
+++ b/t/RedditSearch.t
@@ -9,7 +9,6 @@ ddg_spice_test(
     [qw( DDG::Spice::RedditSearch )],
     'reddit duckduckgo' => test_spice(
         '/js/spice/reddit_search/duckduckgo',
-        call_type => 'include',
         caller => 'DDG::Spice::RedditSearch'
     ),
 );

--- a/t/RedditSubSearch.t
+++ b/t/RedditSubSearch.t
@@ -9,7 +9,6 @@ ddg_spice_test(
     [qw( DDG::Spice::RedditSubSearch )],
     '/r/duckduckgo' => test_spice(
         '/js/spice/reddit_sub_search/duckduckgo',
-        call_type => 'include',
         caller => 'DDG::Spice::RedditSubSearch'
     ),
 );

--- a/t/Rhymes.t
+++ b/t/Rhymes.t
@@ -9,27 +9,22 @@ ddg_spice_test(
     [qw( DDG::Spice::Rhymes )],
     'what rhymes with duck' => test_spice(
         '/js/spice/rhymes/duck',
-        call_type => 'include',
         caller => 'DDG::Spice::Rhymes',
     ),
     'what words rhymes with quack?' => test_spice(
         '/js/spice/rhymes/quack',
-        call_type => 'include',
         caller => 'DDG::Spice::Rhymes',
     ),
     'dax rhymes with?' => test_spice(
         '/js/spice/rhymes/dax',
-        call_type => 'include',
         caller => 'DDG::Spice::Rhymes',
     ),
     'Rhyme LIST' => test_spice(
         '/js/spice/rhymes/list',
-        call_type => 'include',
         caller => 'DDG::Spice::Rhymes',
     ),
     'words that rhyme with rhyme' => test_spice(
         '/js/spice/rhymes/rhyme',
-        call_type => 'include',
         caller => 'DDG::Spice::Rhymes',
     ),
     'rhymes' => undef,

--- a/t/RubyGems.t
+++ b/t/RubyGems.t
@@ -9,12 +9,10 @@ ddg_spice_test(
     [qw( DDG::Spice::RubyGems )],
     'cucumber rubygem' => test_spice(
         '/js/spice/ruby_gems/cucumber',
-        call_type => 'include',
         caller => 'DDG::Spice::RubyGems'
     ),
     'ruby xml' => test_spice(
         '/js/spice/ruby_gems/xml',
-        call_type => 'include',
         caller => 'DDG::Spice::RubyGems'
     ),
 );

--- a/t/SEPTA.t
+++ b/t/SEPTA.t
@@ -18,7 +18,6 @@ ddg_spice_test(
             . (join '%20', map { ucfirst } split /\s+/, $_)
             . '/'
             . (join '%20', map { ucfirst } split /\s+/, $queries{$_}),
-            call_type => 'include',
             caller => 'DDG::Spice::SEPTA'
         ),
         "next train to $_ from $queries{$_}" => test_spice(
@@ -26,7 +25,6 @@ ddg_spice_test(
             . (join '%20', map { ucfirst } split /\s+/, $queries{$_})
             . '/'
             . (join '%20', map { ucfirst } split /\s+/, $_),
-            call_type => 'include',
             caller => 'DDG::Spice::SEPTA'
         ),
     )} keys %queries

--- a/t/SearchCode.t
+++ b/t/SearchCode.t
@@ -9,7 +9,6 @@ ddg_spice_test(
     [qw( DDG::Spice::CodeSearch )],
     'perl code' => test_spice(
         '/js/spice/code_search/lang%3Aperl%20',
-        call_type => 'include',
         caller => 'DDG::Spice::CodeSearch'
     ),
 );

--- a/t/Shorten.t
+++ b/t/Shorten.t
@@ -9,17 +9,14 @@ ddg_spice_test(
     [qw( DDG::Spice::Shorten )],
     'short url http://www.duckduckgo.com/about.html' => test_spice(
         '/js/spice/shorten/http%3A%2F%2Fwww.duckduckgo.com%2Fabout.html',
-        call_type => 'include',
         caller => 'DDG::Spice::Shorten'
     ),
     'shorten http://www.duckduckgo.com/about.html' => test_spice(
         '/js/spice/shorten/http%3A%2F%2Fwww.duckduckgo.com%2Fabout.html',
-        call_type => 'include',
         caller => 'DDG::Spice::Shorten'
     ),
     'url shorten http://www.duckduckgo.com/about.html' => test_spice(
         '/js/spice/shorten/http%3A%2F%2Fwww.duckduckgo.com%2Fabout.html',
-        call_type => 'include',
         caller => 'DDG::Spice::Shorten'
     ),
 );

--- a/t/Smbc.t
+++ b/t/Smbc.t
@@ -9,17 +9,14 @@ ddg_spice_test(
     [qw( DDG::Spice::Smbc )],
     'smbc' => test_spice(
         '/js/spice/smbc/',
-        call_type => 'include',
         caller => 'DDG::Spice::Smbc',
     ),
     'today\'s smbc' => test_spice(
         '/js/spice/smbc/',
-        call_type => 'include',
         caller => 'DDG::Spice::Smbc',
     ),
     'todays smbc comic' => test_spice(
         '/js/spice/smbc/',
-        call_type => 'include',
         caller => 'DDG::Spice::Smbc',
     ),
 );

--- a/t/Snow.t
+++ b/t/Snow.t
@@ -21,14 +21,12 @@ ddg_spice_test(
     ) => test_spice(
         '/js/spice/snow/'
         .'M%C3%B6nchengladbach%2C%20%20Nordrhein-Westfalen%2C%20%20Germany',
-        call_type => 'include',
         caller => 'DDG::Spice::Snow',
     ),
     # The DDG::Request is used in place of a query string, and isn't necessary
     # to be used with every test passed to ddg_spice_test.
     'is it snowing in new york?' => test_spice(
     	'/js/spice/snow/new%20york',
-    	call_type => 'include',
     	caller => 'DDG::Spice::Snow',
     )
 );

--- a/t/SoundCloud.t
+++ b/t/SoundCloud.t
@@ -9,12 +9,10 @@ ddg_spice_test(
     [qw( DDG::Spice::SoundCloud )],
     'soundcloud ray bradbury' => test_spice(
         '/js/spice/sound_cloud/ray%20bradbury',
-        call_type => 'include',
         caller => 'DDG::Spice::SoundCloud',
     ),
     'sc kavinsky' => test_spice(
         '/js/spice/sound_cloud/kavinsky',
-        call_type => 'include',
         caller => 'DDG::Spice::SoundCloud',
     ),
 );

--- a/t/Thesaurus.t
+++ b/t/Thesaurus.t
@@ -9,37 +9,30 @@ ddg_spice_test(
     [qw( DDG::Spice::Thesaurus )],
     'synonym for search' => test_spice(
         '/js/spice/thesaurus/search/synonym',
-        call_type => 'include',
         caller => 'DDG::Spice::Thesaurus'
     ),
     'synonym forget' => test_spice(
         '/js/spice/thesaurus/forget/synonym',
-        call_type => 'include',
         caller => 'DDG::Spice::Thesaurus'
     ),
     'synonyms for forget' => test_spice(
         '/js/spice/thesaurus/forget/synonym',
-        call_type => 'include',
         caller => 'DDG::Spice::Thesaurus'
     ),
     'antonyms for forget' => test_spice(
         '/js/spice/thesaurus/forget/antonym',
-        call_type => 'include',
         caller => 'DDG::Spice::Thesaurus'
     ),
     'similar words to expose' => test_spice(
         '/js/spice/thesaurus/expose/similar',
-        call_type => 'include',
         caller => 'DDG::Spice::Thesaurus'
     ),
     'related words to corruption' => test_spice(
         '/js/spice/thesaurus/corruption/related',
-        call_type => 'include',
         caller => 'DDG::Spice::Thesaurus'
     ),
     'beautiful thesaurus' => test_spice(
         '/js/spice/thesaurus/beautiful/synonym',
-        call_type => 'include',
         caller => 'DDG::Spice::Thesaurus'
     ),
 );

--- a/t/TodayInHistory.t
+++ b/t/TodayInHistory.t
@@ -9,12 +9,10 @@ ddg_spice_test(
     [qw( DDG::Spice::TodayInHistory )],
     'today in history' => test_spice(
         '/js/spice/today_in_history/',
-        call_type => 'include',
         caller => 'DDG::Spice::TodayInHistory',
     ),
     'this day in history' => test_spice(
         '/js/spice/today_in_history/',
-        call_type => 'include',
         caller => 'DDG::Spice::TodayInHistory',
     ),
 );

--- a/t/Tumblr.t
+++ b/t/Tumblr.t
@@ -9,7 +9,6 @@ ddg_spice_test(
     [qw( DDG::Spice::Tumblr )],
     'tumblr ducks' => test_spice(
         '/js/spice/tumblr/ducks',
-        call_type => 'include',
         caller => 'DDG::Spice::Tumblr'
     ),
 );

--- a/t/UrbanDictionary.t
+++ b/t/UrbanDictionary.t
@@ -10,7 +10,6 @@ ddg_spice_test(
     'urban dictionary cool' => test_spice(
         '/js/spice/urban_dictionary/cool',
         is_unsafe => 1,
-        call_type => 'include',
         caller => 'DDG::Spice::UrbanDictionary'
     ),
 );

--- a/t/Xkcd.t
+++ b/t/Xkcd.t
@@ -23,7 +23,6 @@ ddg_spice_test(
         # This is the Spice calltype. It's almost always set to 'include',
         # except for some special cases like FlashVersion which don't make a
         # normal API call.
-        call_type => 'include',
         # This is the Spice that should be triggered by the query.
         caller => 'DDG::Spice::Xkcd',
     ),
@@ -32,7 +31,6 @@ ddg_spice_test(
     # another that is tested for this Spice.
     'xkcd' => test_spice(
         '/js/spice/xkcd/',
-        call_type => 'include',
         caller => 'DDG::Spice::Xkcd',
     ),
 );


### PR DESCRIPTION
/cc @nospampleasemam @nilnilnil 

Executed `find t/ -type f -exec sed "/call_type => 'include',/d" {} \;`, manually verified changes as well.

Seems that https://github.com/duckduckgo/duckduckgo/pull/41 isn't actually necessary?
