### PR TITLE
Minor changes to Forecast styling, especially on mobile.

### DIFF
--- a/share/spice/forecast/forecast.css
+++ b/share/spice/forecast/forecast.css
@@ -27,7 +27,8 @@
 
 #spice_forecast #fe_current_icon {
   display: block;
-  position:absolute;
+  position: absolute;
+  top: -4px;
   left: 50%;
   width: 80px;
   height: 80px;
@@ -66,13 +67,18 @@
 }
 
 #spice_forecast .fe_currently .fe_summary {
-  margin-top: 8px;
   font-size: 18px;
+  line-height: 1.3em;
   font-weight: bold;
+  margin-top: 8px;
+}
+#spice_forecast .fe_currently .fe_summary.fe_small {
+  font-size: 15px;
 }
 
 #spice_forecast .fe_currently .fe_wind {
   font-size: 14px;
+  margin-top: 4px;
 }
 
 #spice_forecast .fe_daily {
@@ -111,6 +117,7 @@
   font-size: 12px;
   border-radius: 200px;
   background-color: #333;
+  white-space: nowrap;
 }
 
 #spice_forecast .fe_daily .fe_day .fe_high_temp {
@@ -157,7 +164,7 @@
         height:auto;
     }
     #spice_forecast .fe_currently {
-        width:80%;
+        width:100%;
         position:relative;
         display:block;
         margin:auto;
@@ -166,14 +173,29 @@
     }
 
     #spice_forecast #fe_current_icon {
-        right:0;
+        right: 0;
+        top: -8px;
     }
 
-    #spice_forecast .fe_currently .fe_summary {
-        text-align:center;
+    #spice_forecast .fe_currently .fe_top {
+      position: relative;
+      left: 6px;
+      width: 200px;
+      margin: 0 auto;
     }
-    #spice_forecast .fe_currently .fe_wind {
-        text-align:center;
+    
+    #spice_forecast .fe_daily .fe_day .fe_temp_bar {
+      width: 15px;
+    }
+    
+    #spice_forecast .fe_daily .fe_day .fe_label {
+      font-size: 13px;
+    }
+    
+    #spice_forecast .fe_daily .fe_icon {
+      width: 22px;
+      height: 22px;
+      margin-top: 2px;
     }
 
     #spice_forecast .fe_daily {
@@ -193,5 +215,6 @@
     #spice_forecast .fe_alert {
         /* bottom:4.2em; */
         position:static;
+        margin: 10px 0;
     }
 }

--- a/share/spice/forecast/forecast.handlebars
+++ b/share/spice/forecast/forecast.handlebars
@@ -1,7 +1,9 @@
 <div class="fe_forecast">
   <div class="fe_currently">
-    <canvas id="fe_current_icon" width="160" height="160" style="width:80px; height:80px"></canvas>
-    <div class="fe_temp"></div>
+    <div class="fe_top">
+      <img id="fe_current_icon" width="160" height="160" style="width:80px; height:80px" />
+      <div class="fe_temp"></div>
+    </div>
     <div class="fe_summary"></div>
     <div class="fe_wind"></div>
   </div>

--- a/share/spice/forecast/forecast.js
+++ b/share/spice/forecast/forecast.js
@@ -102,6 +102,12 @@ function ddg_spice_forecast(r) {
       temp_str += ' <span class="fe_feelslike">Feels like '+Math.round(f.currently.apparentTemperature)+'&deg;'+'</span>'
     
     $container.find('.fe_currently .fe_temp').html(temp_str)
+    
+    if(current_summary.length > 45)
+      $container.find('.fe_currently .fe_summary').addClass('fe_small')
+    else
+      $container.find('.fe_currently .fe_summary').removeClass('fe_small')
+    
     $container.find('.fe_currently .fe_summary').html(current_summary)
     
     if(f.currently.windSpeed) {
@@ -128,7 +134,7 @@ function ddg_spice_forecast(r) {
     var $day_template = $(
         '<div class="fe_day"> \
           <span class="fe_label">MON</span> \
-          <canvas class="fe_icon" width="52" height="52" style="width:26px; height:26px" /> \
+          <canvas class="fe_icon" /> \
           <div class="fe_temp_bar"> \
             <span class="fe_high_temp">72&deg;</span> \
             <span class="fe_low_temp">50&deg;</span> \
@@ -187,8 +193,21 @@ function ddg_spice_forecast(r) {
       return
     }
     
-    var alert = f.alerts[0]
-    $('<a target="_blank"></a>').html('<span class="fe_icon">&#9873;</span> '+alert.title).attr('href', alert.uri).appendTo($alert)
+    var alert_message
+    for(var i = 0; i < f.alerts.length; i++) {
+      if(f.alerts[i].title.match(/Special Weather Statement/i) ||
+         f.alerts[i].title.match(/Advisory/i) ||
+         f.alerts[i].title.match(/Statement/i))
+        continue
+      
+      alert_message = f.alerts[i]
+      break
+    }
+
+    if(!alert_message)
+      return
+    
+    $('<a target="_blank"></a>').html('<span class="fe_icon">&#9873;</span> '+alert_message.title).attr('href', alert_message.uri).appendTo($alert)
     
     $container.addClass('alert')
     $alert.show()


### PR DESCRIPTION
I tweaked a few things:

1) I bumped up the icon a few pixels, as it wasn't aligned properly with the current temperature.
2) I improved the styling on mobile. The temperature bars were too fat and close together, and the current temperature / icon alignment was a little bit off.
3) I'm excluding a few classes of NOAA weather alerts. The Forecast API tends to go a little overboard with the messages it'll deliver, so I excluded some minor non-emergency weather statements to prevent clutter.
