### PR TITLE
news (newscred): story.source is independently useful without story.auth...

### DIFF
--- a/share/spice/news/news.js
+++ b/share/spice/news/news.js
@@ -26,8 +26,10 @@ function ddg_spice_news(api_result) {
             story.source = story.author || "Topsy";
             break;
             case "NewsCred":
-            if(story.source && story.author) {
-		story.source = story.source + " by " + story.author;
+            if(story.source) {
+		if(story.author) {
+		    story.source = story.source + " by " + story.author;
+		}
 	    } else {
 		story.source = "NewsCred";
 	    }


### PR DESCRIPTION
...or.

@jagtalon @moollaza 
