### PR TITLE
Forecast (caching): cache by default if it's not a generic query.

### DIFF
--- a/lib/DDG/Spice/Forecast.pm
+++ b/lib/DDG/Spice/Forecast.pm
@@ -26,7 +26,7 @@ handle query_lc => sub {
 
     # Don't cache generic queries due to
     # variations in the users location.
-    if (grep {lc($query) eq $_} @triggers) {
+    if (grep {$query eq $_} @triggers) {
 	spice is_cached => 0;
     }
 


### PR DESCRIPTION
I was curious about caching directive in the handle sub.  Looks like it works.

@yegg @jagtalon @moollaza
