### PR TITLE
Amazon - fixed load_more call (wrong property name)

### DIFF
--- a/share/spice/amazon/amazon.js
+++ b/share/spice/amazon/amazon.js
@@ -84,7 +84,7 @@ function ddg_spice_amazon(api_response) {
 function ddg_spice_amazon_wait_for_render(api_response) {
     if (ddg_spice_amazon_carousel_add_items) {
         window.setTimeout(function() {
-            ddg_spice_amazon_carousel_add_items(api_response.items);
+            ddg_spice_amazon_carousel_add_items(api_response.results);
         }, 500);
     }
 }


### PR DESCRIPTION
//cc @yegg @russellholt 

This fixes Amazon's delayed loading of the 2nd page of results. Now they actually come through :)

https://moollaza.duckduckgo.com/?q=man+with+the+golden+helmet
(give it a sec, you'll see them come in..)
