### PR TITLE
[Indeed.com jobs spice plugin] based on GithubJobs.pm plugin

### DIFF
--- a/lib/DDG/Spice/IndeedJobs.pm
+++ b/lib/DDG/Spice/IndeedJobs.pm
@@ -1,0 +1,39 @@
+package DDG::Spice::IndeedJobs;
+# ABSTRACT: Search for jobs on Indeed.
+# Reviews DDG_SPICE_INDEED_JOBS_PUBLISHER environment variable
+# https://ads.indeed.com/jobroll/xmlfeed
+
+use DDG::Spice;
+
+primary_example_queries "java jobs";
+secondary_example_queries "perl jobs in san francisco";
+description "Indeed jobs";
+name "Indeed Jobs";
+code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/IndeedJobs.pm";
+topics "special_interest";
+category  "reference";
+attribution github => ['https://github.com/parker','parker'],
+            twitter => ['http://twitter.com/pseidel','pseidel'];
+
+triggers any => "job", "jobs";
+
+spice to => 'http://api.indeed.com/ads/apisearch?publisher={{ENV{DDG_SPICE_INDEED_JOBS_PUBLISHER}}}&v=2&useragent=DuckDuckGo&userip=1.2.3.4&q=$1&l=$2&co=$3&format=json&callback={{callback}}';
+spice from => '([^/]+)/(.*?)/([^/]*)';
+spice proxy_cache_valid   => "418 1d";
+
+
+handle query => sub {
+    my $country = 'US';
+    if($loc->country_code) {
+        $country = $loc->country_code;
+    }
+    my $spice_location = $loc->city . ', ' . $loc->region_name;
+    if (/(?:\s*(?:i\s+|we\s+)?(?:need|want|deserve|seek|get)\s+(?:an?\s+)?)?(?:(.+)\s+)?(?:jobs?|work|employment|internship)(?:\s+(?:in|near\s+)?\s*(.+))?$/i) {
+        my $query = $1 || ' ';
+        my $location = $2 || $spice_location || ' ';
+        return $query, $location, $country;
+    }
+	return;
+};
+
+1;

--- a/share/spice/indeed_jobs/indeed_jobs.css
+++ b/share/spice/indeed_jobs/indeed_jobs.css
@@ -1,0 +1,6 @@
+.spice_indeed_job a { 
+    display: block; 
+}
+.spice_indeed_job_time {
+    color: #808080;
+}

--- a/share/spice/indeed_jobs/indeed_jobs.css
+++ b/share/spice/indeed_jobs/indeed_jobs.css
@@ -1,6 +1,3 @@
-.spice_indeed_job a { 
-    display: block; 
-}
 .spice_indeed_job_time {
     color: #808080;
 }

--- a/share/spice/indeed_jobs/indeed_jobs.handlebars
+++ b/share/spice/indeed_jobs/indeed_jobs.handlebars
@@ -1,4 +1,4 @@
 <div class="spice_indeed_job">
-    <a style="display:block" href="{{url}}">{{jobtitle}}</a>
+    <div><a style="display:block" href="{{url}}">{{jobtitle}}</a></div>
     {{#if company }}<span class="spice_indeed_job_company">{{company}}</span>{{/if}}{{#if formattedLocation}}{{#if company}} - {{/if}}<span class="spice_indeed_job_location">{{formattedLocation}}</span>{{/if}} - <span class="spice_indeed_job_time">{{formattedRelativeTime}}</span>
 </div>

--- a/share/spice/indeed_jobs/indeed_jobs.handlebars
+++ b/share/spice/indeed_jobs/indeed_jobs.handlebars
@@ -1,0 +1,4 @@
+<div class="spice_indeed_job">
+    <a style="display:block" href="{{url}}">{{jobtitle}}</a>
+    {{#if company }}<span class="spice_indeed_job_company">{{company}}</span>{{/if}}{{#if formattedLocation}}{{#if company}} - {{/if}}<span class="spice_indeed_job_location">{{formattedLocation}}</span>{{/if}} - <span class="spice_indeed_job_time">{{formattedRelativeTime}}</span>
+</div>

--- a/share/spice/indeed_jobs/indeed_jobs.handlebars
+++ b/share/spice/indeed_jobs/indeed_jobs.handlebars
@@ -1,4 +1,4 @@
 <div class="spice_indeed_job">
-    <div><a style="display:block" href="{{url}}">{{jobtitle}}</a></div>
+    <div><a href="{{url}}">{{jobtitle}}</a></div>
     {{#if company }}<span class="spice_indeed_job_company">{{company}}</span>{{/if}}{{#if formattedLocation}}{{#if company}} - {{/if}}<span class="spice_indeed_job_location">{{formattedLocation}}</span>{{/if}} - <span class="spice_indeed_job_time">{{formattedRelativeTime}}</span>
 </div>

--- a/share/spice/indeed_jobs/indeed_jobs.js
+++ b/share/spice/indeed_jobs/indeed_jobs.js
@@ -1,0 +1,31 @@
+function ddg_spice_indeed_jobs(api_result) {
+    if (api_result.results.length == 0) return;
+    
+    var jobs = api_result.results,
+        query = DDG.get_query(),
+        q = api_result.query || '',
+        loc = api_result.location || '',
+        re = /^http:\/\/([a-z.]+)\//,
+        rematch = api_result.results[0].url.match(re),
+        www_domain = rematch ? rematch[0] : "http://www.indeed.com/";
+    Spice.render({
+        data             : api_result,
+        header1          : query + " from Indeed",
+        source_url       : www_domain + 'jobs?q='
+                            + encodeURIComponent(q)
+                            + "&l=" +  encodeURIComponent(loc),
+        source_name      : 'Indeed',
+        spice_name      : 'indeed',
+
+        template_frame   : 'list',
+        template_options: {
+            items: api_result.results,
+            template_item: "indeed_jobs",
+            show: 4,
+	        max: 10,
+            type: 'ul'
+        },
+        force_big_header : true,
+        force_no_fold    : true
+    });
+}

--- a/t/IndeedJobs.t
+++ b/t/IndeedJobs.t
@@ -1,0 +1,58 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+ddg_spice_test(
+    [qw( DDG::Spice::IndeedJobs )],
+    'perl jobs in    Austin, TX' => test_spice(
+        '/js/spice/indeed_jobs/perl/Austin%2C%20TX/US',
+        call_type => 'include',
+        caller => 'DDG::Spice::IndeedJobs'
+    ),
+    'perl job in nyc' => test_spice(
+        '/js/spice/indeed_jobs/perl/nyc/US',
+        call_type => 'include',
+        caller => 'DDG::Spice::IndeedJobs'
+    ),
+    'perl jobs' => test_spice(
+        '/js/spice/indeed_jobs/perl/Phoenixville%2C%20Pennsylvania/US',
+        call_type => 'include',
+        caller => 'DDG::Spice::IndeedJobs'
+    ),
+    'perl job' => test_spice(
+        '/js/spice/indeed_jobs/perl/Phoenixville%2C%20Pennsylvania/US',
+        call_type => 'include',
+        caller => 'DDG::Spice::IndeedJobs'
+    ),
+    'jobs in austin' => test_spice(
+        '/js/spice/indeed_jobs/%20/austin/US',
+        call_type => 'include',
+        caller => 'DDG::Spice::IndeedJobs'
+    ),
+    'jobs near austin' => test_spice(
+        '/js/spice/indeed_jobs/%20/austin/US',
+        call_type => 'include',
+        caller => 'DDG::Spice::IndeedJobs'
+    ),
+    'jobs' => test_spice(
+        '/js/spice/indeed_jobs/%20/Phoenixville%2C%20Pennsylvania/US',
+        call_type => 'include',
+        caller => 'DDG::Spice::IndeedJobs'
+    ),
+    'I want java job in Austin' => test_spice(
+        '/js/spice/indeed_jobs/java/Austin/US',
+        call_type => 'include',
+        caller => 'DDG::Spice::IndeedJobs'
+    ),
+    'I want a job in Austin' => test_spice(
+        '/js/spice/indeed_jobs/%20/Austin/US',
+        call_type => 'include',
+        caller => 'DDG::Spice::IndeedJobs'
+    )
+);
+
+done_testing;
+


### PR DESCRIPTION
**What does your instant answer do?**
Provides job search via Indeed.com API
https://dukgo.com/ideas/idea/767/indeed-com-jobs-spice-plugin

**What problem does your instant answer solve (Why is it better than organic links)?**
Organic links do not contain individual job postings.

**What is the data source for your instant answer? (Provide a link if possible)**
Indeed.com - http://www.indeed.com
https://ads.indeed.com/jobroll/xmlfeed

**Why did you choose this data source?**
Indeed is the number 1 Job Search site in the US
http://blog.indeed.com/2013/02/14/independent-study-indeed-1-external-source-of-hire/

**Are there any other alternative (better) data sources?**
Alternatives:
- GitHub Jobs
- [Stackoverflow Careers Api](http://meta.stackoverflow.com/questions/158005/stackoverflow-careers-api)
- [LinkedIn Jobs Api](https://developer.linkedin.com/apis)
- [SimplyHired Api](http://www.simplyhired.com/a/publishers/overview)

**What are some example queries that trigger this instant answer?**
perl jobs in Austin, TX
jobs in Austin, TX
jobs
perl jobs
I want java job in Austin

**Which communities will this instant answer be especially useful for? (gamers, book lovers, etc)**
Users looking for a job

**Is this instant answer connected to an [Ideas.DuckDuckHack](https://duckduckhack.uservoice.com/forums/5168-ideas-for-duckduckgo-instant-answer-plugins) or [Duck.co](http://duck.co/) thread?**
https://dukgo.com/ideas/idea/758/jobs-search-via-indeed-com

**Which existing instant answers will this one supersede/overlap with?**
GithubJobs.pm
The current implementation uses the same triggers and regular expression from GithubJobs.pm

The GitHub Jobs api could be modified to only look for programming specific jobs using keywords like "perl, java, javascript, C#, programming, etc".

**Are you having any problems? Do you need our help with anything?**

I could not figure out why GitHub Jobs superseded the IndeedJobs instant answer when both triggered results.

**Required environment variable**
- _DDG_SPICE_INDEED_JOBS_PUBLISHER_ - should contain the publisher number for Indeed's Api. You can register via https://ads.indeed.com/jobroll/xmlfeed
## Checklist

Please place a ✔ where appropriate.

```
[✔] Added metadata and attribution information
[✔] Wrote test file and added to t/ directory
[✔] Verified that instant answer adheres to design guidelines(https://github.com/duckduckgo/duckduckgo-documentation/blob/master/duckduckhack/styleguides/design_styleguide.md)
[] Tested cross-browser compatibility

    Please let us know which browsers/devices you've tested on:
    - Windows 8
        [] Google Chrome   
        [] Firefox         
        [] Opera           
        [] IE 10           

    - Windows 7
        [] Google Chrome   
        [] Firefox         
        [] Opera           
        [] IE 8            
        [] IE 9            
        [] IE 10           

    - Windows XP
        [] IE 7            
        [] IE 8            

    - Mac OSX
        [✔] Google Chrome   
        [✔] Firefox         
        [] Opera           
        [✔] Safari          

    - iOS (iPhone)
        [] Safari Mobile   
        [] Google Chrome   
        [] Opera           

    - iOS (iPad)
        [] Safari Mobile   
        [] Google Chrome   
        [] Opera            

    - Android
        [] Firefox         
        [] Native Browser  
        [] Google Chrome   
        [] Opera
```
