### PR TITLE
fix video.js parsing of .com searches

### DIFF
--- a/share/spice/video/video.js
+++ b/share/spice/video/video.js
@@ -8,7 +8,7 @@ function ddg_spice_video(api_result) {
         cache: true
     });
 
-    var encodedQuery = DDG.get_query_encoded().replace(/(?:youtube|videos?)/i, '');
+    var encodedQuery = DDG.get_query_encoded().replace(/(?:youtube(\.com)?|videos?)/i, '');
     
     // Change the "More at ..." link.
     var change_more = function(obj) {

--- a/t/Video.t
+++ b/t/Video.t
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+ddg_spice_test(
+    [qw( DDG::Spice::Video )],
+    'youtube.com life round here' => test_spice(
+        '/js/spice/video/life%20round%20here',
+        call_type => 'include',
+        caller => 'DDG::Spice::Video',
+    ),
+    'youtube life round here' => test_spice(
+        '/js/spice/video/life%20round%20here',
+        call_type => 'include',
+        caller => 'DDG::Spice::Video',
+    ),
+);
+
+done_testing;
+


### PR DESCRIPTION
After an accidental search, I noticed that we're not properly parsing video
queries of the form 'youtube.com foo', only discarding 'youtube' and leaving
'.com' in the title. At first I thought it was an error in the trigger handler,
so I wrote a test (we needed one anyway) but it turns out it's just the js
that's got it wrong. Anyway, this fixes that :-)

see https://duckduckgo.com/?q=youtube.com+life+round+here
