### PR TITLE
BBC IA: Fix aggressive comma deletion by using raw subtitle

### DIFF
--- a/share/spice/bbc/bbc.js
+++ b/share/spice/bbc/bbc.js
@@ -1,3 +1,4 @@
+
 function ddg_spice_bbc(api_result) {
     var query = DDG.get_query(),
         broadcasts = api_result.schedule.day.broadcasts,
@@ -95,7 +96,11 @@ Handlebars.registerHelper("duration", function() {
 
 // Find the series URL and return it, or if it is not part of a series return the normal url
 Handlebars.registerHelper("programme_url", function() {
-    return "http://www.bbc.co.uk/programmes/"+(this.programme.programme ? this.programme.programme : this.programme).pid;
+    var programme = this.programme;
+    while(programme.programme != null && programme.programme.pid != null) {
+        programme = programme.programme;
+    }
+    return "http://bbc.co.uk/" + (programme.pid == null ? "" : "programmes/"+programme.pid);
 });
 
 

--- a/share/spice/bbc/bbc_details.handlebars
+++ b/share/spice/bbc/bbc_details.handlebars
@@ -1,13 +1,13 @@
 <p>
 	{{#if programme.is_available_mediaset_pc_sd}}
-		<a class="button" href="http://www.bbc.co.uk/iplayer/episode/{{programme.pid}}" alt="{programme.media.availability}}">Watch Now</a>
+		<a class="button" href="http://www.bbc.co.uk/iplayer/episode/{{programme.pid}}" title="{{programme.media.availability}}">Watch Now</a>
 	{{/if}}
 
 	<span>
 		<a href="{{programme_url}}">{{programme.display_titles.title}}</a>{{#if programme.display_titles.subtitle}}:
-		<a href="http://www.bbc.co.uk/programmes/{{programme.pid}}">
+		{{#if programme.pid}}<a href="http://www.bbc.co.uk/programmes/{{programme.pid}}">{{/if}}
 			<span>{{programme.display_titles.subtitle}}</span>
-		</a>
+		{{#if programme.pid}}</a>{{/if}}
 		{{/if}}
 	</span>
 </p>


### PR DESCRIPTION
Now it uses the raw subtitle provided by BBC.
So instead of displaying the subtitle like this:
![old bbc](https://f.cloud.github.com/assets/2399307/1840370/4448ebe2-7491-11e3-8758-976a602d23a0.png)
It displays it like this:
![new bbc](https://f.cloud.github.com/assets/2399307/1840375/4901bbe6-7491-11e3-84c0-7de3f7d5db47.png)
This has various advantages and disadvantages. It takes away the enforced 'Series, Episode' format in place of whatever format the BBC chooses. This fixes the aggressice comma deletion issue and will avoid future issues with parsing the subtitle.
