### PR TITLE
BBC - fix issue #361

### DIFF
--- a/share/spice/bbc/bbc.js
+++ b/share/spice/bbc/bbc.js
@@ -13,6 +13,7 @@ function ddg_spice_bbc(api_result) {
         date_round = 1000 * 60 * 60 * 24,
         inPast = +fulldate < Math.floor(+now / date_round)*date_round,
         header_date,
+        header_service_type,
         re = /today|tomorrow|yesterday|tonight|last/,
         match;
 
@@ -35,9 +36,11 @@ function ddg_spice_bbc(api_result) {
             programmes.push(broadcasts[i]);
     }
 
+    header_service_type = api_result.schedule.service.type == "radio" ? "Radio" : "TV";
+
     Spice.render({
         data           : api_result.schedule,
-        header1        : api_result.schedule.service.title + (api_result.schedule.service.outlet ? " "+api_result.schedule.service.outlet.title : "") + " (TV Schedule for "+header_date+")",
+        header1        : api_result.schedule.service.title + (api_result.schedule.service.outlet ? " "+api_result.schedule.service.outlet.title : "") + " ("+header_service_type+" Schedule for "+header_date+")",
         source_url     : "http://www.bbc.co.uk/"+api_result.schedule.service.key+"/programmes/schedules/"+(api_result.schedule.service.outlet ? api_result.schedule.service.outlet.key+"/" : "")+api_result.schedule.day.date.split("-").join("/"),
         source_name    : 'BBC',
         template_frame : "carousel",


### PR DESCRIPTION
A quick fix for issue #361 by adding a 'header_service_type' variable to the spice JS function which stores the display version of the service type which is either radio or tv. It puts this in place of "TV" in the header. i.e.
instead of this:
![old bbc](https://f.cloud.github.com/assets/2399307/1834411/5720392e-73dc-11e3-8bda-a8cfb604c116.png)
It displays this:
![new bbc](https://f.cloud.github.com/assets/2399307/1834413/5f224e46-73dc-11e3-8fb9-2e5e0b928ac9.png)
It works likewise for TV channels too, and shows 'TV' in place of 'Radio'.
