### PR TITLE
fixed urban dictionary click-through

### DIFF
--- a/share/spice/urban_dictionary/urban_dictionary.js
+++ b/share/spice/urban_dictionary/urban_dictionary.js
@@ -14,7 +14,7 @@ function ddg_spice_urban_dictionary(response) {
     Spice.render({
         data             : { 'definition' : definition },
         header1          : word + " (Urban Dictionary)",
-        source_url       : 'http://www.urbandictionary.com/define.php?term=' + definition.word,
+        source_url       : 'http://www.urbandictionary.com/define.php?term=' + word,
         source_name      : 'Urban Dictionary',
         template_normal  : 'urban_dictionary',
         force_big_header : true,


### PR DESCRIPTION
"More at Urban Dictionary" link should now go to the definition for the queried word, rather than urban dictionary's definition for "undefined"

fixes #329
