### PR TITLE
Added next button to xkcd spice which advances to next xkcd comic.

### DIFF
--- a/share/spice/xkcd/xkcd.handlebars
+++ b/share/spice/xkcd/xkcd.handlebars
@@ -2,3 +2,6 @@
 {{#previousNum num}}
 	<a href="/?q=xkcd+{{num}}">Prev</a>
 {{/previousNum}}
+{{#nextNum num}}
+	<a href="/?q=xkcd+{{num}}">Next</a>
+{{/nextNum}}

--- a/share/spice/xkcd/xkcd.js
+++ b/share/spice/xkcd/xkcd.js
@@ -17,3 +17,7 @@ Handlebars.registerHelper("previousNum", function(num, options) {
         return options.fn({num: num - 1});
     }
 });
+
+Handlebars.registerHelper("nextNum", function(num, options) {
+    return options.fn({num: num + 1});
+});


### PR DESCRIPTION
Nothing special in terms of styling, but it fixes the bug. If the user is on the most recent comic and clicks next, they will search for xkcd and a comic number which doesn't exist, which will just return normal results, and no instant answer.
