### PR TITLE
use strict, properly parenthesize, and refactor Forecast Spice.

### DIFF
--- a/share/spice/forecast/forecast.js
+++ b/share/spice/forecast/forecast.js
@@ -1,39 +1,6 @@
 function ddg_spice_forecast(r) {
   "use strict";
 
-  // Taken from
-  //   https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf
-  if (!Array.prototype.indexOf) {
-    Array.prototype.indexOf = function (searchElement, fromIndex) {
-      if ( this === undefined || this === null ) {
-        throw new TypeError( '"this" is null or not defined' );
-      }
-
-      var length = this.length >>> 0; // Hack to convert object.length to a UInt32
-
-      fromIndex = +fromIndex || 0;
-
-      if (Math.abs(fromIndex) === Infinity) {
-        fromIndex = 0;
-      }
-
-      if (fromIndex < 0) {
-        fromIndex += length;
-        if (fromIndex < 0) {
-          fromIndex = 0;
-        }
-      }
-
-      for (;fromIndex < length; fromIndex++) {
-        if (this[fromIndex] === searchElement) {
-          return fromIndex;
-        }
-      }
-
-      return -1;
-    };
-  }
-
   // Exit if we've got a bad forecast
   if(!r || !r.hourly || !r.hourly.data || !r.daily || !r.daily.data || !r.flags['ddg-location']) {
     return;
@@ -112,7 +79,7 @@ function ddg_spice_forecast(r) {
       icon = 'sleet';
     }
     icon = icon.replace(/-/g, '_');
-    if (available_skycon_icons.indexOf(icon) === -1) {
+    if ($.inArray(icon, available_skycon_icons) === -1) {
       icon = 'cloudy';
     }
     return icon;


### PR DESCRIPTION
This branch has some changes to the Forecast Spice, including `"use strict";`, proper parenthesization for blocks (rather than, e.g., `if (foo) bar`), and some fixes to make the code more readable and concise.
