### PR TITLE
Use XHTML break tag in Urban_dictionary Spice.

### DIFF
--- a/share/spice/urban_dictionary/urban_dictionary.js
+++ b/share/spice/urban_dictionary/urban_dictionary.js
@@ -9,7 +9,7 @@ function ddg_spice_urban_dictionary(response) {
         return;
 
     var word       = response.list[0].word;
-	var definition = response.list[0].definition.replace(/(\r?\n)+/gi, '<br>');
+	var definition = response.list[0].definition.replace(/(\r?\n)+/gi, '<br/>');
 
     Spice.render({
         data             : { 'definition' : definition },


### PR DESCRIPTION
Change an HTML break tag `<br>` to an XHTML break tag `</br>` in the Urban_dictionary Spice.
