### PR TITLE
BBC IA: Fix bad string ification of times

### DIFF
--- a/share/spice/bbc/bbc.js
+++ b/share/spice/bbc/bbc.js
@@ -67,17 +67,13 @@ Handlebars.registerHelper("time", function() {
         end = new Date(this.end);
 
     function standard_time(time) {
-        var hour = time.getHours(), ampm = time.getHours() < 12 ? "AM" : "PM";
-        if(hour > 12) {
-            hour -= 12;
-        } else if(hour == 0) {
+        var hour = time.getHours() % 12,
+            ampm = hour < 12 ? "AM" : "PM";
+        if(hour == 0) {
             hour = 12;
         }
-        var min = time.getMinutes();
-        if(min < 10) {
-            min = "0" + min;
-        }
-        return hour + ":" + min + ampm;
+        var min = ((time.getMinutes() > 9) ? time.getMinutes() : "0" + time.getMinutes());
+        return hour + ":" + min + (time.getHours() > 12 ? "PM" : "AM");
     }
 
     return standard_time(start) + " - " + standard_time(end);


### PR DESCRIPTION
Here's what the problematic time stringification looks like:
![Bad time string](https://f.cloud.github.com/assets/2399307/2430905/cdfaa53a-ad0b-11e3-892e-d8de361e1f86.png)
It seems to double the minutes when they're over 9 and turn 12 AM into 1 AM and 12 PM into 1 PM. Here's what the same guide looks like in this updated version:
![Good time string](https://f.cloud.github.com/assets/2399307/2430936/f80ce318-ad0d-11e3-8716-7a4c5b91143e.png)
I've changed it to show midnight as 0 AM (this can be changed easily) and to keep the minutes and hours unmodified.
