### PR TITLE
Add Maven Spice metadata.

### DIFF
--- a/lib/DDG/Spice/Maven.pm
+++ b/lib/DDG/Spice/Maven.pm
@@ -11,7 +11,7 @@ triggers startend => "maven", "mvn";
 name "Maven";
 source "Maven Central Repository";
 icon_url "http://search.maven.org/favicon.ico";
-description "Search packages available on the Maven Central Repository."
+description "Search packages available on the Maven Central Repository.";
 primary_example_queries "maven pegasus";
 secondary_example_queries "mvn mod4j";
 


### PR DESCRIPTION
This pull request adds metadata to the Maven Spice so that it can be displayed on the [Goodies Page](https://duckduckgo.com/goodies).
