### PR TITLE
pushing steam sales instant answer

### DIFF
--- a/lib/DDG/Spice/SteamSales.pm
+++ b/lib/DDG/Spice/SteamSales.pm
@@ -1,0 +1,25 @@
+package DDG::Spice::SteamSales;
+# ABSTRACT: Fetch featured games on sale at Steam store.
+
+use DDG::Spice;
+
+name "SteamSales";
+source "http://store.steampowered.com";
+description "Get featured games on sale at Steam store";
+primary_example_queries "steam store sale";
+category "special";
+topics "gaming","entertainment";
+icon_url "/i/store.steampowered.com.ico";
+code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/SteamSales.pm";
+attribution github => ["https://github.com/killerfish", "Usman Raza"],
+            twitter => ["https://twitter.com/f1shie", "Usman Raza"];
+
+triggers startend => "steam sale", "steam sales", "steam store", "steam special", "steam offers", "steam specials", "steam offer";
+
+spice to => 'http://store.steampowered.com/api/featured';
+spice wrap_jsonp_callback => 1;
+
+handle remainder => sub {
+	return $_;
+};	
+1;

--- a/share/spice/steam_sales/steam_sales.handlebars
+++ b/share/spice/steam_sales/steam_sales.handlebars
@@ -1,0 +1,1 @@
+<div><img src="{{small_capsule_image}}" align="top" margin="30" height="30" width="70" style="margin-bottom:5px"</img>{{name}}</div>

--- a/share/spice/steam_sales/steam_sales.js
+++ b/share/spice/steam_sales/steam_sales.js
@@ -1,0 +1,53 @@
+function ddg_spice_steam_sales(api_result) {
+    "use strict"
+
+    if (!api_result) {
+        return;
+    }
+	 
+    Array.prototype.contains = function(v) {
+        for(var i = 0; i < this.length; i++) {
+            if(this[i].name == v) return true;
+        }
+        return false;
+    };
+
+    var results = [];
+    for(var i = 0; i < api_result.large_capsules.length; i++) {
+        if(api_result.large_capsules[i].discounted != false) { 
+	    results.push(api_result.large_capsules[i]);
+	}
+    }
+    for(var i = 0; i < api_result.featured_win.length; i++) {
+	if((api_result.featured_win[i].discounted != false) && !(results.contains(api_result.featured_win[i].name))) {
+	    results.push(api_result.featured_win[i]);
+	}
+    }
+    for(var i = 0; i < api_result.featured_mac.length; i++) {
+	if((api_result.featured_mac[i].discounted != false) && !(results.contains(api_result.featured_mac[i].name))) {
+	    results.push(api_result.featured_mac[i]);
+	}
+    }
+
+    Spice.render({
+        data              : results,
+	source_name       : "Official Steam Store",
+	source_url        : "http://store.steampowered.com",
+	spice_name        : 'steam_sales',
+	template_frame    : "carousel",
+	header1           : "Steam Game Offers",
+	template_options  : {
+	    items: results,
+	    template_item: 'steam_sales',
+	    template_detail: 'steam_sales_details',
+	    li_height:  90,
+	},
+	force_no_fold     : true,
+	force_big_header  : true
+    });
+};
+
+Handlebars.registerHelper('conv', function(cents) {
+    var dollars = cents/100;
+    return dollars;
+});

--- a/share/spice/steam_sales/steam_sales_details.handlebars
+++ b/share/spice/steam_sales/steam_sales_details.handlebars
@@ -1,0 +1,1 @@
+<div><b>{{name}}</b><br/>Original Price: ${{conv original_price}}       Discounted Price: ${{conv final_price}}        Savings: <font color="red">{{discount_percent}}%</font></div>

--- a/t/SteamSales.t
+++ b/t/SteamSales.t
@@ -1,0 +1,17 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+ddg_spice_test(
+    [qw( DDG::Spice::SteamSales )],
+    'steam sales' => test_spice(
+	'/js/spice/steam_sales/',
+        call_type => 'include',
+        caller => 'DDG::Spice::SteamSales'
+    ),
+);
+
+done_testing;


### PR DESCRIPTION
**What does your instant answer do?**
Fetch featured games on sales at Steam Store

**What problem does your instant answer solve (Why is it better than organic links)?**
Get to instantly know best Steam offers

**What is the data source for your instant answer? (Provide a link if possible)**
Official Steam Store (http://store.steampowered.com/)

**Why did you choose this data source?**
Steam has its own official api

**Are there any other alternative (better) data sources?**
No

**What are some example queries that trigger this instant answer?**
steam sale, steam offers

**Which communities will this instant answer be especially useful for? (gamers, book lovers, etc)**
gamers

**Is this instant answer connected to a DuckDuckHack [instant answer idea](https://duck.co/ideas)?**
Yes, https://duck.co/ideas/idea/976/steam-sales

**Which existing instant answers will this one supersede/overlap with?**
Steamdb 

**Are you having any problems? Do you need our help with anything?**

****Note:** Please attach a screenshot for new instant answer pull requests, and for pull requests which modify the look/design of existing instant answers.
## Checklist

Please place an 'X' where appropriate.

```
[X] Added metadata and attribution information
[X] Wrote test file and added to t/ directory
[X] Verified that instant answer adheres to design guidelines(https://github.com/duckduckgo/duckduckgo-documentation/blob/master/duckduckhack/styleguides/design_styleguide.md)
[X] Tested cross-browser compatability

    Please let us know which browsers/devices you've tested on:
    - Windows 8
        [] Google Chrome   
        [] Firefox         
        [] Opera           
        [] IE 10           

    - Windows 7
        [] Google Chrome   
        [] Firefox         
        [] Opera           
        [] IE 8            
        [] IE 9            
        [] IE 10           

    - Windows XP
        [] IE 7            
        [] IE 8            

    - Mac OSX
        [X] Google Chrome   
        [X] Firefox         
        [] Opera           
        [] Safari          

    - iOS (iPhone)
        [] Safari Mobile   
        [] Google Chrome   
        [] Opera           

    - iOS (iPad)
        [] Safari Mobile   
        [] Google Chrome   
        [] Opera            

    - Android
        [] Firefox         
        [] Native Browser  
        [] Google Chrome   
        [] Opera
```
