### PR TITLE
Use Video model for videos spice

### DIFF
--- a/share/spice/videos/videos.js
+++ b/share/spice/videos/videos.js
@@ -8,6 +8,8 @@ function ddg_spice_videos(apiResult) {
 
         data: apiResult.results,
 
+        model: 'Video',
+
         meta: {
             next: apiResult.next,
             searchTerm: apiResult.query


### PR DESCRIPTION
This is needed with changes made for video privacy. It's why some of the video details are missing on bttf right now.

cc @russellholt
