### PR TITLE
Remove ingredients hack from recipes

### DIFF
--- a/share/spice/recipes/recipes.handlebars
+++ b/share/spice/recipes/recipes.handlebars
@@ -4,9 +4,7 @@
 	</div>
 	<div class="tile__body">
 		<h6 class="tile__title">{{ellipsis recipeName 26}}</h6>
-        {{#if showIngredientsOnTile}}
-            <p class="tile__ingredients opt hide--mob">{{ellipsis ingredientString 56}}</p>
-        {{/if}}
+        <p class="tile__ingredients opt hide--mob">{{ellipsis ingredientString 56}}</p>
 		<div class="tile__rating  one-line">
 			{{{starRating rating}}}
             <span class="tile__source  one-line">{{ellipsis sourceDisplayName 19}}</span>

--- a/share/spice/recipes/recipes.js
+++ b/share/spice/recipes/recipes.js
@@ -40,10 +40,6 @@ function ddg_spice_recipes(res) {
                 var searchTermContainsRecipe = rq.match(/recipe/i),
                     len = item.ingredients.length;
 
-                if(searchTermContainsRecipe){
-                    m.showIngredientsOnTile = true;
-                }
-
                 m.ingredientString = item.ingredients.join(", ");
                 m.ingredientDetails = item.ingredients.map(function(ingredient,i) {
                     var refinedTerm = (searchTermContainsRecipe) ? query.replace(/ recipe/i,' ' + ingredient + ' recipe') : query + ' ' + ingredient,
@@ -62,9 +58,7 @@ function ddg_spice_recipes(res) {
                 });
 
                 // normalization: description for item, ingredientString for custom detail template
-                if (m.showIngredientsOnTile) {
-                    m.description = m.ingredientString;
-                }
+                m.description = m.ingredientString;
             }
 
             m.flavors = sortAndFormatFlavors(m.flavors);


### PR DESCRIPTION
Want to always render ingredients in tiles + and show/hide them based purely on screen size instead of search query.

cc @nilnilnil @russellholt @sdougbrown 
