### PR TITLE
Forecast: show city name instead of 'Right Now:' on mobile

### DIFF
--- a/share/spice/forecast/forecast.js
+++ b/share/spice/forecast/forecast.js
@@ -241,6 +241,7 @@ function ddg_spice_forecast(r) {
   weatherData.alerts = build_alerts(r);
   weatherData.daily = build_daily(r);
   weatherData.activeUnit = unit_labels[units].temperature;
+  weatherData.city = r.flags['ddg-location'];
   
   // structure the data differently for mobile and desktop views
   if (is_mobile) {

--- a/share/spice/forecast/forecast_detail_mobile.handlebars
+++ b/share/spice/forecast/forecast_detail_mobile.handlebars
@@ -1,7 +1,7 @@
 <div class="tile--s  fe_current-wrap--mob">
 	<div class="fe_currently {{#if alerts}}alert{{/if}}">
 		<span class="fe_meta">&deg;{{activeUnit}}<span class="fe_sep">|</span>{{{moreAt meta.sourceUrl meta.sourceName className="fe_more-at" noIcon="1"}}}</span>
-		<h5 class="fe_label"><a href="{{{meta.sourceUrl}}}">Right Now:</a></h5>
+		<h5 class="fe_label"><a href="{{{meta.sourceUrl}}}">{{city}}</a></h5>
 		<div class="fe_current-wrap">
 		{{#with current}}
 			<div class="fe_top">


### PR DESCRIPTION
cc @russellholt @sdougbrown 
