### PR TITLE
BTTF: CodeSearch

### DIFF
--- a/share/spice/code_search/code_search.js
+++ b/share/spice/code_search/code_search.js
@@ -1,49 +1,33 @@
-function ddg_spice_code_search(response) {
+(function(env){
     "use strict";
 
-    var query = response.query;
-    var data  = response.results;
+    env.ddg_spice_code_search = function (api_result) {
 
-	if (!data || data.length === 0) {
-        return Spice.failed('code_search');
-    }
-    var result = data[0];
-
-    var lines = [];
-    for(var i in result.lines) {
-        lines.push([i, result.lines[i]]);
-    }
-
-    lines.sort(function(a, b) {
-        if(a[0] < b[0]) {
-            return -1;
+        if (!api_result.results.length === 0) {
+            return Spice.failed('code_search');
         }
-        if(a[0] > b[0]) {
-            return 1;
-        }
-        return 0;
-    });
 
-    var code = "";
-    for(var i = 0; i < lines.length; i += 1) {
-        code += lines[i][0] + ": " + lines[i][1] + "\n";
-    }
+        var query = encodeURIComponent(api_result.query);
 
-    Spice.add({
-        id: 'code_search',
-        name: "Code Search",
-        data             : { 'lines' : code },
-        meta: {
-            sourceUrl       : 'http://searchco.de/?q='
-                                + encodeURIComponent(query)
-                                + '&cs=true',
-            sourceName      : 'search[code]',
-        },
-        templates: {
-            group: 'info',
-            options: {
-                content: Spice.code_search.content
+        Spice.add({
+            id: 'code_search',
+            name: "Code Search",
+            data: api_result.results[0],
+            meta: {
+                sourceUrl: 'http://searchco.de/?q=' + query + '&cs=true',
+                sourceName: 'search[code]'
+            },
+            templates: {
+                group: 'base',
+                options: {
+                    content: Spice.code_search.content,
+                    moreAt: true
+                }
             }
-        }
+        });
+    }
+
+    Spice.registerHelper("stripNewline", function(text){
+        return text.replace(/\r/g, "");
     });
-}
+}(this));

--- a/share/spice/code_search/content.handlebars
+++ b/share/spice/code_search/content.handlebars
@@ -1,1 +1,1 @@
-<pre>{{lines}}</pre>
+<pre>{{#keys lines}}{{key}}:{{stripNewline value}}<br>{{/keys}}</pre>


### PR DESCRIPTION
//cc @russellholt 
Switched it to use the 'base' group and also simplified the JS a bunch thanks to the `{{#keys}}` helper
