### PR TITLE
BTTF: Recipes, sorting-fix

### DIFF
--- a/share/spice/recipes/recipes.js
+++ b/share/spice/recipes/recipes.js
@@ -135,9 +135,11 @@ function ddg_spice_recipes(res) {
 
         normalize: normalize,
 
-        sort_fields: {rating: function(a,b){
-            return (a.rating > b.rating) ? -1 : 1;
-        }},
+        sort_fields: {
+            rating: function(a,b){
+                return (a.rating > b.rating) ? -1 : 1;
+            }
+        },
         sort_default: 'rating',
 
         /*


### PR DESCRIPTION
//cc @russellholt 

Fixed the sorting, changed `sort` to `sort_fields` and `default_sort` to `sort_default` -- this alone won't make the sorting work, a related PR has been made to the core code so sorting works without a relevancy block
