### PR TITLE
congress: priceAndBrand set to false

### DIFF
--- a/share/spice/congress/congress.js
+++ b/share/spice/congress/congress.js
@@ -66,7 +66,8 @@
                 options: {
                     buy: Spice.congress.buy,
                     rating: false,
-                    variant: 'narrow'
+                    variant: 'narrow',
+                    priceAndBrand: false
                 }
             }
         });


### PR DESCRIPTION
@jagtalon @russellholt @moollaza 
This gets rid of "by undefined"
![selection_017](https://cloud.githubusercontent.com/assets/1882892/2976088/8c3d7cde-db9c-11e3-9f63-e543c869dcde.png)
