### PR TITLE
Sound Cloud: remove songs with a low number of likes

### DIFF
--- a/share/spice/sound_cloud/sound_cloud.js
+++ b/share/spice/sound_cloud/sound_cloud.js
@@ -218,7 +218,7 @@ nrj("soundmanager2/script/soundmanager2-nodebug-jsmin.js", 1);
     env.ddg_spice_sound_cloud = function(api_result) {
 
         if(!api_result){
-            return Spice.failed("soundcloud");
+            return Spice.failed("sound_cloud");
         }
 
         Spice.add({


### PR DESCRIPTION
@jagtalon @moollaza @russellholt 
Filters out songs with less than 4 likes. 
Before:
![selection_025](https://cloud.githubusercontent.com/assets/1882892/3008766/2d82c772-decf-11e3-96c6-d9ade03dc84a.png)

After:
![selection_026](https://cloud.githubusercontent.com/assets/1882892/3008767/3416997e-decf-11e3-890d-c1accac278ce.png)
