### PR TITLE
definition: ensure we show only the exact word

### DIFF
--- a/share/spice/dictionary/definition/dictionary_definition.js
+++ b/share/spice/dictionary/definition/dictionary_definition.js
@@ -45,9 +45,13 @@ var ddg_spice_dictionary = {
     $el: null,
 
     render: function(definitions) {
-        var word = definitions[0].word;
+        var word = definitions[0].word,
+            q = DDG.get_query(),
+            r = new RegExp(word, 'i');
 
-        var q = DDG.get_query();
+        if (!q.match(r)) {
+            return Spice.failed('dictionary_definition');
+        }
 
         Spice.add({
             id: 'definition',


### PR DESCRIPTION
wordnik does autocorrection. this ensures we are only doing showing the exact word. eg, 'dax' does not show 'fax', and 'toms' does not show 'tons'.

@jagtalon 
