### PR TITLE
congress: search by zip

### DIFF
--- a/lib/DDG/Spice/Congress.pm
+++ b/lib/DDG/Spice/Congress.pm
@@ -15,9 +15,10 @@ category "facts";
 attribution web => ['http://kevinschaul.com','Kevin Schaul','http://www.transistor.io', 'Jason Dorweiler'],
             email => ['kevin.schaul@gmail.com','Kevin Schaul','jason@transistor.io', 'Jason Dorweiler'];
 
-spice to => 'https://congress.api.sunlightfoundation.com/legislators?apikey={{ENV{DDG_SPICE_CONGRESS_APIKEY}}}&chamber=$1&state=$2&per_page=all';
+spice to =>'https://congress.api.sunlightfoundation.com/$1?chamber=$2&state=$3&$4=$5&$6=$7&per_page=all&apikey={{ENV{DDG_SPICE_CONGRESS_APIKEY}}}';
 
-spice from => '([^/]+)/?(?:([^/]+)/?(?:([^/]+)|)|)';
+# one group for each of the 7 variables in the Spice to url
+spice from => '([^/]+)/?(?:([^/]+)/?(?:([^/]+)/?(?:([^/]+)/?(?:([^/]+)/?(?:([^/]+)/?(?:([^/]+)/?(?:([^/]+)|)|)|)|)|)|)|)';
 
 spice wrap_jsonp_callback => 1;
 
@@ -129,22 +130,6 @@ handle query_lc => sub {
         'wy' => 'wy'
     );
 
-    # Matches against special variable `$_`, which contains query
-    my ($state1, $chamber, $state2) = /^(.*)(?:\s)*(senate|senators|senator|representatives|representative|reps|house)(?:\s)*(.*)$/g;
-
-    my ($state);
-
-    # Regex returns a space after $1, so we must remove it before hashing
-    $state1 = rtrim($state1);
-
-    if (exists $states{$state1}) {
-        $state = $states{$state1};
-    } elsif (exists $states{$state2}) {
-        $state = $states{$state2};
-    } else {
-        return;
-    }
-
     my (%chambers) = (
         "senators" => "senate",
         "senate" => "senate",
@@ -155,9 +140,77 @@ handle query_lc => sub {
         "house" => "house"
     );
 
+    # Matches against special variable `$_`, which contains query
+    my ($token1, $chamber, $token2) = /^(.*)(?:\s)*(senate|senators|senator|representatives|representative|reps|house)(?:\s)*(.*)$/g;
+    
     $chamber = $chambers{$chamber};
+
+    # We are building the URL for the GET request. The DDG::Spice
+    # package encodes special chars to their equivalent hex number.
+    # This breaks the api with some exceptions, a '/' can
+    # be used as a place holder for 'locate' and a blank space for all
+    # others.
+    # the template for the return statement can look something like this
+    # return location, chamber, state (upper), "zip", $zip, "lat", latitude, "lon", longitude
+
+    # There are 3 return cases:
+
+    # case 1. If we don't have anything in the state variables
+    # : locate by latitude longitude no other terms are needed
+    if($chamber && !$token1 && !$token2){
+        return 'legislators/locate', ' ', ' ', 'latitude', $loc->latitude, 'longitude', $loc->longitude, {is_cached => 0} ;
+    }
+
+    my ($state);
+    my ($zip);
+
+    # Change the name from state to something that makes more sense, 
+    # calling zip = state sounds dumb. 
+    # Regex returns a space after $1, so we must remove it before hashing
+    $token1 = rtrim($token1);
+
+    #trim off "from" for search terms "from state"
+    $token1 =~ s/from\s//;
+    $token2 =~ s/from\s//;
+
+    if (exists $states{$token1}) {
+        $state = $states{$token1};
+    } elsif (exists $states{$token2}) {
+        $state = $states{$token2};
+    }
+    # check to see if we got something that looks like a zip
+
+    else {
+        my $match;
+        if($match = m/(\W|^)\d{5}(\W|^)/){
+            $zip = $token1; 
+        } 
+        if($match = m/(\W|\s)\d{5}(\W|$)/){
+            $zip = $token2;
+        }
+    }
+ 
+    
+    #maybe fall back here to a location search or check 
+    # for phrases like "my sentor"
+
+    # check to see if we only got the search term "house"
+    # this IA probably isn't relevant in this case so return
+    if($chamber eq "house" && !$state && !$zip){
+        return;
+    }
+    
+    # Case 2. If we have a state: provide the chamber and state
     # state needs to be uppercase for Sunlight API
-    return $chamber, uc $state if ($chamber && $state);
+    if($chamber && $state){
+        return 'legislators/', $chamber, uc $state, ' ', ' ', ' ', ' ', ' ' ;
+    }
+
+    # Case 3. If there is a zip code no other terms are needed
+    if($zip){
+        return 'legislators/locate', ' ', ' ', 'zip', $zip, ' ', ' ', ' ';
+    }
+
     return;
 };
 

--- a/share/spice/congress/congress.js
+++ b/share/spice/congress/congress.js
@@ -7,24 +7,36 @@
             return Spice.failed("congress");
         }
 
-        var state = api_result.results[0].state_name,
-            chamber = api_result.results[0].chamber;
+        var query = getChamber(DDG.get_query().toLowerCase());
 
-        var itemType;    
-        // sort by district for House members
-        // TODO: Use sorting block
+        // location search returns a list of both senate and house members
+        // figure out which the user searched for and push those member
+        // to the result array.
+        var results = [];
+        for(var e in api_result.results){
+            if(api_result.results[e].chamber == query){
+                results.push(api_result.results[e]);
+            }
+        }
+
+        var state = api_result.results[0].state_name,
+        chamber = api_result.results[0].chamber;
+
+        var itemType;  
+
         if(chamber == 'house') {
-            api_result.results = sortDistrict(api_result.results);
+            results = sortDistrict(results);
             itemType =  'U.S. ' + DDG.capitalize(chamber) + ' Representatives from ' + state;
         }
         else{
             itemType =  'U.S. ' + 'Senators from ' + state;
         }
 
+
         Spice.add({
             id: 'congress',
             name: 'Congress',
-            data: api_result.results,
+            data: results,
             meta: {
                 sourceName: 'govtrack.us',
                 sourceUrl: "https://www.govtrack.us/congress/members/"+state,
@@ -67,8 +79,8 @@
                     buy: Spice.congress.buy,
                     rating: false,
                     variant: 'narrow',
-		    price: false,
-		    brand: false
+            price: false,
+            brand: false
                 }
             }
         });
@@ -82,6 +94,17 @@
             return ((x < y) ? -1 : ((x > y) ? 1 : 0));
         });
     }
+
+        // return the chamber from the search query
+    function getChamber(string){
+        //matches senate, senator
+        if(string.indexOf("senat") != -1)
+            return 'senate';
+        // matches rep, represenative(s), and house
+        if(string.indexOf("rep") !== -1 || string.indexOf("house") != -1)
+            return 'house';
+    }
+
 }(this));
 
 

--- a/t/Congress.t
+++ b/t/Congress.t
@@ -8,20 +8,28 @@ use DDG::Test::Spice;
 ddg_spice_test(
     [qw( DDG::Spice::Congress )],
     'ny representatives' => test_spice(
-        '/js/spice/congress/house/NY',
+        '/js/spice/congress/legislators%2F/house/NY/%20/%20/%20/%20/%20',
         call_type => 'include',
         caller => 'DDG::Spice::Congress'
     ),
     'new york senators' => test_spice(
-        '/js/spice/congress/senate/NY',
+        '/js/spice/congress/legislators%2F/senate/NY/%20/%20/%20/%20/%20',
         caller => 'DDG::Spice::Congress',
     ),
     'florida representatives' => test_spice(
-        '/js/spice/congress/house/FL',
+        '/js/spice/congress/legislators%2F/house/FL/%20/%20/%20/%20/%20',
         caller => 'DDG::Spice::Congress',
     ),
     'house california' => test_spice(
-        '/js/spice/congress/house/CA',
+        '/js/spice/congress/legislators%2F/house/CA/%20/%20/%20/%20/%20',
+        caller => 'DDG::Spice::Congress',
+    ),
+    'representative from 55812' => test_spice(
+        '/js/spice/congress/legislators%2Flocate/%20/%20/zip/55812/%20/%20/%20',
+        caller => 'DDG::Spice::Congress',
+    ),
+    'senator from pa' => test_spice(
+        '/js/spice/congress/legislators%2F/senate/PA/%20/%20/%20/%20/%20',
         caller => 'DDG::Spice::Congress',
     ),
 );


### PR DESCRIPTION
Adds searching by zip code and also handles "from" in the search term.  Searches using a zip code are narrowed down to only people representing that area. 
examples:
    reps from 17089
    representatives from pa

![selection_038](https://cloud.githubusercontent.com/assets/1882892/3110420/3ed79ce0-e6a5-11e3-992b-5942f1c9e49a.png)
![selection_039](https://cloud.githubusercontent.com/assets/1882892/3110424/41532908-e6a5-11e3-9622-ad141785b5f5.png)
@jagtalon @moollaza @russellholt
