### PR TITLE
Single recipe cleanup

### DIFF
--- a/share/spice/recipes/recipes.css
+++ b/share/spice/recipes/recipes.css
@@ -184,16 +184,26 @@
 
 /* single item detail */
 
-.zci__main--detail .detail__media--recipe,
-.zci__main--detail .detail__body--recipe {
+.zci__main--detail .detail__media--recipe {
     height: 10em;
     line-height: 10em;
 }
 
-.is-mobile .zci__main--detail .detail__media--recipe,
-.is-mobile .zci__main--detail .detail__body--recipe {
-    height: 14em;
-    line-height: 14em;
+.zci__main--detail .detail__body--recipe {
+    height: auto;
+    border-top: none;
+    padding-right: 0;
+    padding-left: 0.5em;
+}
+
+.is-mobile .zci__main--detail .detail__media--recipe {
+    height: 8em;
+    width: 8em;
+    line-height: 8em;
+}
+
+.is-mobile .zci__main--detail .detail__body--recipe .detail__body__content {
+    padding-right: 0;
 }
 
 .zci__main--detail .detail__media--recipe {


### PR DESCRIPTION
Changing single recipe result to be dynamic height, instead of forcing to explicit height and chopping off content:

![screen shot 2014-06-04 at 10 22 00 am](https://cloud.githubusercontent.com/assets/126358/3174671/0df8dd24-ebf4-11e3-8a3b-bf0624fb3204.png)
![screen shot 2014-06-04 at 10 22 56 am](https://cloud.githubusercontent.com/assets/126358/3174674/0dfa544c-ebf4-11e3-9308-584e2cc3aa70.png)
![screen shot 2014-06-04 at 10 23 15 am](https://cloud.githubusercontent.com/assets/126358/3174673/0df999e4-ebf4-11e3-964f-35e52f656b01.png)
![screen shot 2014-06-04 at 10 23 24 am](https://cloud.githubusercontent.com/assets/126358/3174672/0df927b6-ebf4-11e3-9350-285b88c16547.png)

cc @sdougbrown @chrismorast @jagtalon 
