### PR TITLE
Light Detail Variant (Coupon Mountain)

### DIFF
--- a/share/spice/coupon_mountain/coupon_mountain.js
+++ b/share/spice/coupon_mountain/coupon_mountain.js
@@ -33,7 +33,8 @@
                     buy: Spice.coupon_mountain.buy,
                     brand: false,
                     rating: false,
-		    price: true
+                    price: true,
+                    detailVariant: 'light'
                 }
             },
             sort_fields: {


### PR DESCRIPTION
The default detail pane is now dark - this allow spices to use the lighter detail pane (as featured in Amazon/Products).

Coupon Mountain just looks better like this. :)
