### PR TITLE
Octopart: fix buttons for mobile view

### DIFF
--- a/share/spice/octopart/octopart.css
+++ b/share/spice/octopart/octopart.css
@@ -3,8 +3,6 @@
     background-color: #e5e5e5;
 }
 
-.is-mobile .detail--octopart .detail__body__content{
-    position: absolute;
-    margin-right: 1.6em;
-    bottom: 4em;
+.is-mobile .detail--octopart .detail__body.detail__body--pr {
+    padding-top: 1em;
 }

--- a/share/spice/octopart/octopart.js
+++ b/share/spice/octopart/octopart.js
@@ -36,12 +36,14 @@ function ddg_spice_octopart (api_result) {
     //     return;
     // }
 
+    var isMobile = $('.is-mobile').length;
+
     Spice.add({
         id: 'octopart',
         name: 'Parts',
         data: api_result.results,
         signal: 'high',
-
+ 
         meta: {
             itemType: 'Parts',
             sourceName: 'Octopart',
@@ -49,17 +51,20 @@ function ddg_spice_octopart (api_result) {
         },
         normalize: function(item) {
             var img = DDG.getProperty(item, "item.images.0.url_90px");
+            var desc_length = 60;
+            var description = (isMobile ? 
+                Handlebars.helpers.ellipsis(DDG.strip_html(item.item.short_description), desc_length) :
+                DDG.strip_html(item.item.short_description));
 
             return {
                 brand: item.item.manufacturer.displayname,
                 price: item.item.avg_price[1] + ' ' + item.item.avg_price[0].toFixed(2),
                 img: img,
                 img_m: img,
-				// url_review: item.item.detail_url,
 				url: item.item.detail_url,
                 title: DDG.strip_html(item.item.mpn).toUpperCase(),
                 heading: DDG.strip_html(item.item.mpn).toUpperCase(),
-                description: DDG.strip_html(item.item.short_description),
+                description: description,
                 datasheet: item.item.datasheets[0].url
             };
         },


### PR DESCRIPTION
The datasheet/buy buttons are showing up under the nav buttons. 
Before:
![selection_069](https://cloud.githubusercontent.com/assets/1882892/3271970/d53144f6-f312-11e3-9370-d1015068c05f.png)

After:
![selection_068](https://cloud.githubusercontent.com/assets/1882892/3271975/deece11c-f312-11e3-8696-d2174361c162.png)

cc  @jagtalon @chrismorast 
