### PR TITLE
Only 1 line for mobile recipe titles

### DIFF
--- a/share/spice/recipes/recipes.css
+++ b/share/spice/recipes/recipes.css
@@ -5,10 +5,6 @@
     padding-bottom: 0;
     margin-bottom: 0;
 }
-	.is-mobile .tile--recipes .tile__title {
-		height: 2.7em;
-	}
-
 
 .tile--recipes .tile__media {
     height: 9.5em;


### PR DESCRIPTION
Trying to eliminate some of the extra whitespace/height on mobile recipe tiles.

@sdougbrown @jagtalon 
