### PR TITLE
Smaller recipe title font-size

### DIFF
--- a/share/spice/recipes/recipes.css
+++ b/share/spice/recipes/recipes.css
@@ -1,7 +1,5 @@
 .tile--recipes .tile__title {
-    font-size: 1.3em;
     font-weight: 600;
-    height: 1.3em;
     padding-bottom: 0;
     margin-bottom: 0;
 }


### PR DESCRIPTION
This takes it from 1.3em to 1.2em (default for basic image tile title)

@sdougbrown @chrismorast 
