### PR TITLE
Hayoo.pm - add 'haskell map' to triggers (Issue #800)

### DIFF
--- a/lib/DDG/Spice/Hayoo.pm
+++ b/lib/DDG/Spice/Hayoo.pm
@@ -11,7 +11,7 @@ topics "programming", "sysadmin";
 category "programming";
 attribution github => ['https://github.com/headprogrammingczar','headprogrammingczar'];
 
-triggers start => "hayoo", "haskell api";
+triggers start => "hayoo", "haskell api", "haskell map";
 
 spice to => 'http://holumbus.fh-wedel.de/hayoo/hayoo.json?query=$1';
 spice wrap_jsonp_callback => 1;


### PR DESCRIPTION
Hello, since it's a really minor fix on an already existent instant answer I thought I didn't need to include the template; let me know if I must include it anyway.

I have tested the change as specified in CONTRIBUTING.md.
