### PR TITLE
drinks.css - don't show ingredients on mobile view (Issue #782)

### DIFF
--- a/share/spice/drinks/drinks.css
+++ b/share/spice/drinks/drinks.css
@@ -14,3 +14,12 @@
 	padding-left: 0px;
 	padding-top: 0px;
 }
+
+@media only screen 
+and (min-device-width : 320px) 
+and (max-device-width : 800px) {
+	.zci--drinks h5:not(:first-child), .zci--drinks ul {
+        display: none;
+    }
+}
+


### PR DESCRIPTION
Added mediaqueries to prevent ingredients from showing on mobile view.

Tested on Windows 7 x64, with Firefox Beta 31 (using the responsive design view) and Google Chrome (just reducing the size of the browser window).

Let me know if I need to change anything!
