### PR TITLE
AlternativeTo: add heart instead of 'likes'

### DIFF
--- a/share/spice/alternative_to/footer.handlebars
+++ b/share/spice/alternative_to/footer.handlebars
@@ -1,3 +1,3 @@
 <div class="one-line">
-    {{Votes}} likes{{#if Platforms}} &bull; {{AlternativeTo_getPlatform Platforms}}{{/if}}
+    ♥ {{Votes}} {{#if Platforms}} &bull; {{AlternativeTo_getPlatform Platforms}}{{/if}}
 </div>


### PR DESCRIPTION
Fix for issue #698

Tested on Windows 7 x64, with Firefox Beta 31 and Google Chrome.

Let me know if there's anything I have to change!
