### PR TITLE
added the ability to store skip words in an array

### DIFF
--- a/lib/DDG/Spice/Twitter.pm
+++ b/lib/DDG/Spice/Twitter.pm
@@ -10,19 +10,26 @@ code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/
 topics "everyday", "social";
 category "time_sensitive";
 attribution github => ["https://github.com/duckduckgo/", "DuckDuckGo"],
-            twitter => ["https://twitter.com/duckduckgo", "duckduckgo"],
-            github => ["https://github.com/ecounysis/", "Eric Christensen"];
+    twitter => ["https://twitter.com/duckduckgo", "duckduckgo"],
+    github => ["https://github.com/ecounysis/", "Eric Christensen"],
+    twitter => ["https://twitter.com/ecounysis", "Eric Christensen"];
 
 spice to => 'https://duckduckgo.com/tw.js?user=$1&callback={{callback}}&current=1';
 triggers query => qr/^(?:twitter\s)?@([a-z0-9_]+)$|^twitter\s([a-z0-9_]+)$/i;
 
+# Possibly add skip words to a file for slurping?
+my $skip = join "|", ("apis?",
+		      "developers?",
+		      "users?",
+		      "search(es)?");
+
 handle matches => sub { 
-    if($1) {
+    if ($1) {
 	return $1;
     } elsif ($2) {
-	return $2 unless ($2 =~ m/^apis?$/i || $2 =~ m/^developers?$/i) ;
+	return $2 unless ($2 =~ m/^($skip)$/i)
     }
     return;
-};
+}; 
 
 1;


### PR DESCRIPTION
This is an enhancement to the Twitter spice and is related to discussion on pull request 923 for issue 900
https://github.com/duckduckgo/zeroclickinfo-spice/pull/923
