### PR TITLE
Stopwatch: one line quick fixes

### DIFF
--- a/lib/DDG/Spice/Stopwatch.pm
+++ b/lib/DDG/Spice/Stopwatch.pm
@@ -11,7 +11,7 @@ code_url 'https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/
 attribution twitter => 'mattr555',
             github => ['https://github.com/mattr555/', 'Matt Ramina'];
 
-triggers end => ['stopwatch', 'stop watch'];
+triggers startend => ['stopwatch', 'stop watch'];
 
 #in real code this should just be spice call_type => 'self'
 #for now, it lets me test on DuckPAN

--- a/share/spice/stopwatch/stopwatch.css
+++ b/share/spice/stopwatch/stopwatch.css
@@ -11,7 +11,6 @@
 	border: 1px solid black;
 	font-size: 13px;
 	font-weight: bold;
-	background-color: #fff;
 	margin-left: 5px;
 	margin-right: 5px;
 	outline: none; /*remove the blue outline in chrome/opera*/

--- a/share/spice/stopwatch/stopwatch.js
+++ b/share/spice/stopwatch/stopwatch.js
@@ -105,6 +105,7 @@ function ddg_spice_stopwatch(api_result) { //api_result should be removed in pro
 
     $('.stopwatch__btn.stop').removeClass('stop').addClass('start').html('START');
     $(this).prop('disabled', true);
+    $lap_btn.prop('disabled', true);
     $split_list.addClass('hidden');
   });
 

--- a/t/Stopwatch.t
+++ b/t/Stopwatch.t
@@ -23,6 +23,12 @@ ddg_spice_test(
             call_type => 'self', #should be 'self' in real code
             caller => 'DDG::Spice::Stopwatch'
         ),
+    'stopwatch online' =>
+        test_spice(
+            '',
+            call_type => 'self', #should be 'self' in real code
+            caller => 'DDG::Spice::Stopwatch'
+        ),
 );
 
 done_testing;


### PR DESCRIPTION
As per @chrismorast's comment on #847, I removed the white fill on the lap/reset buttons.
![screenshot from 2014-07-02 13 29 57](https://cloud.githubusercontent.com/assets/4411471/3459601/853f6350-020e-11e4-8142-956f1441c7a2.png)

I also used `startend` to trigger "stopwatch online", and I fixed a problem where the lap button doesn't reset when you press the reset button while the stopwatch is running.
