### PR TITLE
Stopwatch: fixed alignment, better dark theme colors

### DIFF
--- a/share/spice/stopwatch/stopwatch.css
+++ b/share/spice/stopwatch/stopwatch.css
@@ -139,7 +139,7 @@
 }
 
 .zci--stopwatch .lap-time.lap-total {
-    padding-right: 2.25em;
+    padding-right: 2.75em;
 }
 
 /*stack the big time divs if the screen is too narrow*/
@@ -156,5 +156,9 @@
 
     .zci--stopwatch .zci__body {
         padding-right: 1em;
+    }
+
+    .zci--stopwatch .lap-time {
+        padding-right: 1em !important;
     }
 }

--- a/share/spice/stopwatch/stopwatch.handlebars
+++ b/share/spice/stopwatch/stopwatch.handlebars
@@ -16,11 +16,5 @@
       <button class="stopwatch__btn" id="lap_btn" disabled>LAP</button>
     </div>
   </div>
-  <table id="split_list" class="hidden">
-    <thead><tr>
-      <th></th>
-      <th>Lap</th>
-      <th>Total</th>
-    </tr></thead>
-  </table>
+  <table id="split_list" class="hidden"></table>
 </div>

--- a/share/spice/stopwatch/stopwatch.js
+++ b/share/spice/stopwatch/stopwatch.js
@@ -59,7 +59,7 @@ function ddg_spice_stopwatch(api_result) { //api_result should be removed in pro
     var current_time = updateStopwatch();
     var current_lap = current_time - last_lap;
     $split_list.prepend('<tr><td class="lap-num">' + lap_num + '</td><td class="lap-time lap-total">' +
-      formatTime(current_lap) + '</td><td class="lap-time">' + $total_time.html() + '</td></tr>');
+      $total_time.html() + '</td><td class="lap-time">' + formatTime(current_lap) + '</td></tr>');
     $split_list.removeClass('hidden');
     last_lap = current_time;
     lap_num++;


### PR DESCRIPTION
This fixes both #705 and #848.
![screenshot from 2014-07-05 20 55 33](https://cloud.githubusercontent.com/assets/4411471/3487830/cd994f84-04a8-11e4-8691-4b312b948355.png)
![screenshot from 2014-07-05 20 55 49](https://cloud.githubusercontent.com/assets/4411471/3487831/d19d8622-04a8-11e4-87a3-6a736d3caaaa.png)
<img src="https://cloud.githubusercontent.com/assets/4411471/3487835/11e6090c-04a9-11e4-963a-bf3c348d5f33.PNG" width="250"/>

I'm interested in the status of #492, @moollaza it's still an issue, right?
