### PR TITLE
Forecast: better colors for dark theme

### DIFF
--- a/share/spice/forecast/forecast.css
+++ b/share/spice/forecast/forecast.css
@@ -248,3 +248,11 @@
 #fe_temp_switch .bold {
 	font-weight: bold;
 }
+
+.dark-header #fe_temp_switch {
+	color: #dadada;
+}
+
+.dark-header #fe_temp_switch .gray {
+	color: #696969;
+}


### PR DESCRIPTION
Before:
![screenshot from 2014-07-06 21 38 40](https://cloud.githubusercontent.com/assets/4411471/3490683/83b6960e-0577-11e4-86e4-8a74961ac772.png)
After:
![screenshot from 2014-07-06 21 39 37](https://cloud.githubusercontent.com/assets/4411471/3490685/93102b92-0577-11e4-8c54-0946d18bb8d8.png)
(the problem is that they're both selected on Fahrenheit)
