### PR TITLE
Image Model

### DIFF
--- a/share/spice/images/images.js
+++ b/share/spice/images/images.js
@@ -8,6 +8,8 @@ function ddg_spice_images(apiResult) {
 
         data: apiResult.results,
 
+        model: 'Image',
+
         meta: {
             next: apiResult.next,
             searchTerm: apiResult.query


### PR DESCRIPTION
Use Image model for images so it can dedup across multiple calls.

Requires internal PR that created the Image model to be merged first.

cc @nilnilnil 
