### PR TITLE
Timer: two zeros in minute field, time in page title

### DIFF
--- a/share/spice/timer/timer.js
+++ b/share/spice/timer/timer.js
@@ -6,6 +6,9 @@ License: CC BY-NC 3.0 http://creativecommons.org/licenses/by-nc/3.0/
 
 (function (env) {
     "use strict";
+
+    var started = false;
+
     env.ddg_spice_timer = function(api_result) {
         Spice.add({
             id: "timer",
@@ -23,8 +26,10 @@ License: CC BY-NC 3.0 http://creativecommons.org/licenses/by-nc/3.0/
             //wait for the spice to load before displaying things
             //this makes sure the divs display at the right time so the layout doesn't break
             onShow: function(){
+                if (!started){
+                    $('#timer_input').css('display', 'inline-block');
+                }
                 $('#timer_buttons').css('display', 'inline-block');
-                $('#timer_input').css('display', 'inline-block');
             }
         });
 
@@ -59,7 +64,6 @@ License: CC BY-NC 3.0 http://creativecommons.org/licenses/by-nc/3.0/
         }
 
         var time_left, last_update, update_int,
-            started = false,
             $minute_input = $('#minute_input'),
             $second_input = $('#second_input'),
             $timer = $('#timer'),


### PR DESCRIPTION
Fixes #964 

Also implements a feature that someone requested on [twitter](https://twitter.com/danielponto/status/489111247640858624) to put the time remaining in the page title:

![2014-07-15--1405452255_158x33_scrot](https://cloud.githubusercontent.com/assets/4411471/3590164/eb182d32-0c55-11e4-87e8-fb1af66dbbbe.png)

Also uses `Spice.onShow` for the event handler as per @moollaza's comment on #959.
