### PR TITLE
fix rubygems

### DIFF
--- a/share/spice/ruby_gems/ruby_gems.js
+++ b/share/spice/ruby_gems/ruby_gems.js
@@ -13,7 +13,7 @@
 
         // Display the instant answer.
         Spice.add({
-            id: "rubygems",
+            id: "ruby_gems",
             name: "Software",
             data: api_result,
             meta: {


### PR DESCRIPTION
Fixes #972 

Tested with DuckPAN and the tab now opens by default.

//cc @jagtalon @jdorweiler @bsstoner 
