### PR TITLE
Add a Spice for querying the current Github Status

### DIFF
--- a/lib/DDG/Spice/GithubStatus.pm
+++ b/lib/DDG/Spice/GithubStatus.pm
@@ -1,0 +1,15 @@
+package DDG::Spice::GithubStatus;
+# ABSTRACT: Returns the current github status
+
+use DDG::Spice;
+
+triggers start => 'github status';
+
+spice to => 'https://status.github.com/api/status.json?callback={{callback}}';
+
+handle remainder => sub {
+  return if $_;
+  return "";
+};
+
+1;

--- a/share/spice/github_status/content.handlebars
+++ b/share/spice/github_status/content.handlebars
@@ -1,0 +1,1 @@
+<p><span style="color: {{color}}">{{{status}}}</span> <em>(last updated on {{{last_updated}}})</em></p>

--- a/share/spice/github_status/github_status.js
+++ b/share/spice/github_status/github_status.js
@@ -1,0 +1,30 @@
+(function(env) {
+    "use strict";
+    env.ddg_spice_github_status = function(api_result) {
+        if (api_result.error) {
+            return Spice.failed('github_status');
+        }
+        switch (api_result.status) {
+            case "good": api_result.color = "green"; break;
+            case "minor": api_result.color = "yellow"; break;
+            case "major": api_result.color = "red"; break;
+        }
+        api_result.status = api_result.status.charAt(0).toUpperCase() + api_result.status.substr(1);
+        Spice.add({
+            id: "github_status",
+            name: "Github Status",
+            data: api_result,
+            meta: {
+                sourceName: "Github",
+                sourceUrl: "https://status.github.com/",
+            },
+            templates: {
+                group: "base",
+                options: {
+                    content: Spice.github_status.content,
+                    moreAt: true,
+                }
+            }
+        });
+    };
+})(this);

--- a/t/GithubStatus.t
+++ b/t/GithubStatus.t
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+ddg_spice_test(
+    [qw( DDG::Spice::GithubStatus ), qw( DDG::Spice::Github )],
+    'github status' => test_spice(
+        '/js/spice/github_status/',
+        call_type => 'include',
+        caller => 'DDG::Spice::GithubStatus'
+    ),
+    'github status foo' => test_spice(
+        '/js/spice/github/status%20foo',
+        call_type => 'include',
+        caller => 'DDG::Spice::Github'
+    ),
+);
+
+done_testing;
+


### PR DESCRIPTION
This uses the Github Status API to report the github status for
exact queries of that term.  Other queries like "github status foo"
go to the Github Spice.
