### PR TITLE
Add 'next' url to Amazon

### DIFF
--- a/share/spice/amazon/amazon.js
+++ b/share/spice/amazon/amazon.js
@@ -14,11 +14,13 @@
             id: 'products',
             name: 'Products',
             data: items,
+            allowMultipleCalls: true,
             meta: {
                 itemType: 'Products',
                 sourceName: 'Amazon',
                 sourceUrl: api_result.more_at,
-                sourceIcon: true
+                sourceIcon: true,
+                next: api_result.next
             },
             templates: {
                 group: 'products',


### PR DESCRIPTION
Allows for loading more than 7 Amazon items. :)

Internal PR required for the proper styling of the load more tile, so that it fits the sizing of the products tiles.

to @bsstoner 
