### PR TITLE
SEPTA: Add aliases for some train stations.

### DIFF
--- a/lib/DDG/Spice/SEPTA.pm
+++ b/lib/DDG/Spice/SEPTA.pm
@@ -1,4 +1,5 @@
 package DDG::Spice::SEPTA;
+# ABSTRACT: Show train schedules for the SEPTA Regional Rail network
 
 use DDG::Spice;
 
@@ -25,10 +26,69 @@ spice from => '(.*)/(.*)';
 spice proxy_cache_valid => "418 1d";
 
 handle query_lc => sub {
+    my (%stops) = ( #This is just a few aliases. Not all stops are listed here.
+        "30th St" => "30th Street Station",
+        "30th St." => "30th Street Station",
+        "30th Street" => "30th Street Station",
+        "49th St." => "49th St",
+        "49th Street" => "49th St",
+        "Allen Ln" => "Allen Lane",
+        "Allen Ln." => "Allen Lane",
+        "Chelten Ave" => "Chelten Avenue",
+        "Chelten Ave." => "Chelten Avenue",
+        "Chester" => "Chester TC",
+        "Chester Transit Center" => "Chester TC",
+        "Eastwick" => "Eastwick Station",
+        "Elm St." => "Elm St",
+        "Elm Street" => "Elm St",
+        "Elwyn" => "Elwyn Station",
+        "Fern Rock" => "Fern Rock TC",
+        "Fern Rock Transit Center" => "Fern Rock TC",
+        "Ft. Washington" => "Ft Washington",
+        "Fort Washington" => "Ft Washington",
+        "Highland Ave." => "Highland Ave",
+        "Highland Avenue" => "Highland Ave",
+        "Holmesburg" => "Holmesburg Jct",
+        "Holmesburg Junction" => "Holmesburg Jct",
+        "Jenkintown" => "Jenkintown-Wyncote",
+        "Main St." => "Main St",
+        "Main Street" => "Main St",
+        "Market East Station" => "Market East",
+        "Mt. Airy" => "Mt Airy",
+        "Mount Airy" => "Mt Airy",
+        "Norristown" => "Norristown TC",
+        "Norristown Transit Center" => "Norristown TC",
+        "North Broad St." => "North Broad St",
+        "North Broad Street" => "North Broad St",
+        "North Broad" => "North Broad St",
+        "St Davids" => "St. Davids",
+        "Saint Davids" => "St. Davids",
+        "St Martins" => "St. Martins",
+        "Saint Martins" => "St. Martins",
+        "Suburban" => "Suburban Station",
+        "Temple" => "Temple U",
+        "Temple Univ" => "Temple U",
+        "Temple Univ." => "Temple U",
+        "Temple University" => "Temple U",
+        "Drexel" => "University City",
+        "Penn" => "University City",
+        "Wayne Junction" => "Wayne Jct",
+        "Wynnefield Ave." => "Wynnefield Avenue"
+    );
+
     s/\s+septa|septa\s+//;
     /(?:next trains?|train times|train schedule)?(?: from| to)? (.+) (to|from) (.+)/;
+
     my $curr = join " ", map { ucfirst } split /\s+/, $1;
     my $dest = join " ", map { ucfirst } split /\s+/, $3;
+
+    if (exists $stops{$curr}) {
+        $curr = $stops{$curr};
+    }
+    if (exists $stops{$dest}) {
+        $dest = $stops{$dest};
+    }
+
     return ($2 eq 'to' ? ($curr, $dest) : ($dest, $curr));
 };
 

--- a/t/SEPTA.t
+++ b/t/SEPTA.t
@@ -7,12 +7,12 @@ use DDG::Test::Spice;
 
 my %queries = (
     'villanova' => 'paoli',
-    'university city' => '49th street',
+    'university city' => '49th st'
 );
 
 ddg_spice_test(
     [qw( DDG::Spice::SEPTA )],
-    map {(
+    (map {(
         "next train from $_ to $queries{$_}" => test_spice(
             '/js/spice/septa/'
             . (join '%20', map { ucfirst } split /\s+/, $_)
@@ -29,7 +29,12 @@ ddg_spice_test(
             call_type => 'include',
             caller => 'DDG::Spice::SEPTA'
         ),
-    )} keys %queries
+    )} keys %queries),
+    'next train from west trenton to market east station' => test_spice(
+        '/js/spice/septa/West%20Trenton/Market%20East',     #"station" should be removed
+        call_type => 'include',
+        caller => 'DDG::Spice::SEPTA'
+    ),
 );
 
 done_testing;


### PR DESCRIPTION
SEPTA's API uses some non-intuitive and inconsistent names for stations. I ran into this frustration over the weekend.

This PR adds some aliases for common stations to make triggering the IA more natural.

Other changes included:
- Added abstract to SEPTA.pm
- Changed one of the previous tests to use `49th st` instead of `49th street`, which was not a valid station name.
