### PR TITLE
news: looser relevancy for entities.

### DIFF
--- a/share/spice/news/news.js
+++ b/share/spice/news/news.js
@@ -32,7 +32,7 @@ function ddg_spice_news(apiResult) {
     };
 
     var entityWords = [];
-    if (typeof Spice.news.entities !== 'undefined' && Spice.news.entities.length > 0) {
+    if (Spice.news && Spice.news.entities && Spice.news.entities.length) {
         for (var j = 0, entity; entity = Spice.news.entities[j]; j++) {
             var tmpEntityWords = entity.split(" ");
             for (var k = 0, entityWord; entityWord = tmpEntityWords[k]; k++) {


### PR DESCRIPTION
cc @bsstoner @russellholt @nilnilnil @jagtalon 

allow looser news relevancy when we have a good signal that the query contains a newsworthy entity.
`DDG.news_entities` will be set internally.

this is pretty far out of my domain, so if there's a better way to override (not in the technical sense, but in the sense contained herein) `DDG.isRelevant` (or if my JS sucks) please let me know. moreover, not sure who to assign.
