### PR TITLE
MBTA module

### DIFF
--- a/lib/DDG/Spice/Transit/MBTA.pm
+++ b/lib/DDG/Spice/Transit/MBTA.pm
@@ -20,7 +20,7 @@ attribution twitter => 'mattr555',
 spice to => 'http://realtime.mbta.com/developer/api/v2/predictionsbystop?api_key=wX9NwuHnZU2ToO7GmGR9uw&stop=$1&format=jsonp&jsonpcallback={{callback}}';   #FIXME that's the demo API key
 spice proxy_cache_valid => '418 1d';
 
-triggers any => 'mbta', 'next train', 'train from', 'train times', 'train schedule';
+triggers any => 'mbta', 'next train', 'train leaving', 'trains leaving', 'train from', 'train times', 'train schedule';
 
 my %stops = yaml_to_stops(scalar share('stops.yml')->slurp);
 
@@ -62,7 +62,7 @@ sub normalize_stop {
 }
 
 handle remainder => sub {
-    return unless /(?:from )?(.+)/;
+    return unless /(?:.*from )?(.+)/;
 
     my $curr = normalize_stop($1);
     return $curr if $curr;

--- a/lib/DDG/Spice/Transit/MBTA.pm
+++ b/lib/DDG/Spice/Transit/MBTA.pm
@@ -1,0 +1,72 @@
+package DDG::Spice::Transit::MBTA;
+# ABSTRACT: Show MBTA Commuter Rail departures for a given station
+
+use strict;
+use DDG::Spice;
+use YAML::XS qw(Load);
+
+primary_example_queries 'MBTA trains leaving from Plymouth';
+secondary_example_queries 'Next MBTA train from Forge Park';
+description 'Show MBTA Commuter Rail departures for a given station';
+name 'MBTA';
+source 'MBTA';
+code_url 'https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/Transit/MBTA.pm';
+topics 'everyday';
+category 'time_sensitive';
+attribution twitter => 'mattr555',
+            github => ['https://github.com/mattr555/', 'Matt Ramina'],
+            github => ['elebow', 'Eddie Lebow'];
+
+spice to => 'http://realtime.mbta.com/developer/api/v2/predictionsbystop?api_key=wX9NwuHnZU2ToO7GmGR9uw&stop=$1&format=jsonp&jsonpcallback={{callback}}';   #FIXME that's the demo API key
+spice proxy_cache_valid => '418 1d';
+
+triggers any => 'mbta', 'next train', 'train from', 'train times', 'train schedule';
+
+my %stops = yaml_to_stops(scalar share('stops.yml')->slurp);
+
+#add the canonical names to the arrays in the stop hash
+sub yaml_to_stops {
+    my $yaml = shift;
+    my %data;
+
+    my %yml = %{Load($yaml)};
+
+    while (my ($key, $value) = each %yml) {
+        push(@$value, $key); #add the canonical station name to the list of aliases
+
+        foreach (@$value) {    #add a mapping for every alias to the canonical name
+            $data{$_} = $key;
+        }
+    }
+
+    return %data;
+}
+
+#find a stop from a partial name (e.g. converts "Plymo" -> "Plymouth")
+sub normalize_stop {
+    my @matches = ();  #list of stop matches
+    my $in = lc $_[0];
+    $in =~ s/\bstation//;
+
+    foreach my $alias (keys %stops) {
+        #look through each alias of each stop
+        return $stops{$alias} if ($in) eq (lc $alias);
+        #if the stop name contains the input, add it to matches
+        if (index(lc $alias, $in) > -1) {
+            push(@matches, $stops{$alias});
+            last;
+        }
+    }
+    return $matches[0] if scalar(@matches) == 1;  #if we have one match, return it
+    return;  #if we have no matches or too many, then we don't know the stop :(
+}
+
+handle remainder => sub {
+    return unless /(?:from )?(.+)/;
+
+    my $curr = normalize_stop($1);
+
+    return $curr;
+};
+
+1;

--- a/lib/DDG/Spice/Transit/MBTA.pm
+++ b/lib/DDG/Spice/Transit/MBTA.pm
@@ -17,7 +17,7 @@ attribution twitter => 'mattr555',
             github => ['https://github.com/mattr555/', 'Matt Ramina'],
             github => ['elebow', 'Eddie Lebow'];
 
-spice to => 'http://realtime.mbta.com/developer/api/v2/predictionsbystop?api_key=wX9NwuHnZU2ToO7GmGR9uw&stop=$1&format=jsonp&jsonpcallback={{callback}}';   #FIXME that's the demo API key
+spice to => 'http://realtime.mbta.com/developer/api/v2/predictionsbystop?api_key={{ENV{DDG_SPICE_MBTA_APIKEY}}}&stop=$1&format=jsonp&jsonpcallback={{callback}}';
 spice proxy_cache_valid => '418 1d';
 
 triggers any => 'mbta', 'next train', 'train leaving', 'trains leaving', 'train from', 'train times', 'train schedule';

--- a/lib/DDG/Spice/Transit/MBTA.pm
+++ b/lib/DDG/Spice/Transit/MBTA.pm
@@ -62,7 +62,8 @@ sub normalize_stop {
 }
 
 handle remainder => sub {
-    return unless /(?:.*from )?(.+)/;
+    s/\b(?:inbound|outbound)\b//g;    #this is handled in the JavaScript, so just strip it here
+    return unless /(?:.*from\s+)?(.+)/;
 
     my $curr = normalize_stop($1);
     return $curr if $curr;

--- a/lib/DDG/Spice/Transit/MBTA.pm
+++ b/lib/DDG/Spice/Transit/MBTA.pm
@@ -65,8 +65,9 @@ handle remainder => sub {
     return unless /(?:from )?(.+)/;
 
     my $curr = normalize_stop($1);
+    return $curr if $curr;
 
-    return $curr;
+    return;
 };
 
 1;

--- a/share/spice/transit/mbta/item.handlebars
+++ b/share/spice/transit/mbta/item.handlebars
@@ -1,5 +1,5 @@
-<div class="mbta__mode">{{mode_name}}</div>
+<div class="mbta__details">{{route_name}}</div>
 <div class="mbta__time">{{departs}}</div>
 <div class="mbta__details">
-    {{route_name}} to {{trip_headsign}} ({{direction_name}})
+    {{direction_name}} to {{trip_headsign}}
 </div>

--- a/share/spice/transit/mbta/item.handlebars
+++ b/share/spice/transit/mbta/item.handlebars
@@ -1,5 +1,6 @@
-<div class="mbta__details">{{route_name}}</div>
 <div class="mbta__time">{{departs}}</div>
 <div class="mbta__details">
-    {{direction_name}} to {{trip_headsign}}
+    {{direction_name}} to {{trip_headsign}}<br>
+    {{route_name}}<br>
+    Train {{train_num}}
 </div>

--- a/share/spice/transit/mbta/item.handlebars
+++ b/share/spice/transit/mbta/item.handlebars
@@ -1,0 +1,5 @@
+<div class="mbta__mode">{{mode_name}}</div>
+<div class="mbta__time">{{departs}}</div>
+<div class="mbta__details">
+    {{route_name}} to {{trip_headsign}} ({{direction_name}})
+</div>

--- a/share/spice/transit/mbta/stops.yml
+++ b/share/spice/transit/mbta/stops.yml
@@ -1,0 +1,292 @@
+Wickford Junction:
+  - Wickford Jct
+  - Wickford Jct.
+Talbot Avenue:
+  - Talbot Ave
+  - Talbot Ave.
+Four Corners / Geneva:
+  - Four Corners
+  - Geneva
+  - Four Corners/Geneva
+  - Four Corners /Geneva
+  - Four Corners/ Geneva
+Newmarket:
+Abington:
+Anderson/ Woburn:
+  - Anderson
+  - Woburn
+  - Anderson/Woburn
+  - Anderson /Woburn
+  - Anderson / Woburn
+Andover:
+Ashland:
+Attleboro:
+Auburndale:
+Ayer:
+Back Bay:
+Ballardvale:
+Bellevue:
+Belmont:
+Beverly:
+Beverly Farms:
+Bradford:
+Braintree:
+Brandeis/ Roberts:
+  - Brandeis
+  - Roberts
+  - Brandeis/Roberts
+  - Brandeis /Roberts
+  - Brandeis / Roberts
+Bridgewater:
+Brockton:
+Campello:
+Canton Center:
+  - Canton Ctr
+  - Canton Ctr.
+Canton Junction:
+  - Canton Jct
+  - Canton Jct.
+Chelsea:
+Cohasset:
+Concord:
+Dedham Corp Center:
+  - Dedham Corp Ctr
+  - Dedham Corp Ctr.
+  - Dedham Corp. Ctr
+  - Dedham Corp. Ctr.
+  - Dedham Corp. Center
+  - Dedham Corporate Ctr
+  - Dedham Corporate Ctr.
+  - Dedham Corporate Center
+East Weymouth:
+  - E Weymouth
+  - E. Weymouth
+Endicott:
+Fairmount:
+Fitchburg:
+Forest Hills:
+Forge Park / 495:
+  - Forge Park
+  - Forge Park/495
+  - Forge Park /495
+  - Forge Park/ 495
+Framingham:
+Franklin:
+Gloucester:
+Grafton:
+Greenbush:
+Greenwood:
+Halifax:
+Hamilton/ Wenham:
+  - Hamilton
+  - Wenham
+  - Hamilton/Wenham
+  - Hamilton /Wenham
+  - Hamilton / Wenham
+Hanson:
+Hastings:
+Haverhill:
+Hersey:
+Highland:
+Holbrook/ Randolph:
+  - Holbrook
+  - Randolph
+  - Holbrook/Randolph
+  - Holbrook /Randolph
+  - Holbrook / Randolph
+Hyde Park:
+Ipswich:
+Islington:
+JFK/UMASS:
+  - JFK
+  - UMASS
+  - JFK /UMASS
+  - JFK/ UMASS
+Kendal Green:
+Kingston:
+Lawrence:
+Lincoln:
+Littleton / Rte 495:
+  - Littleton
+  - Littleton/Rte 495
+  - Littleton /Rte 495
+  - Littleton/ Rte 495
+Lowell:
+Lynn:
+Malden Center:
+  - Malden Ctr
+  - Malden Ctr.
+Manchester:
+Mansfield:
+Melrose Cedar Park:
+Melrose Highlands:
+Middleborough/ Lakeville:
+  - Middleborough
+  - Lakeville
+  - Middleborough/Lakeville
+  - Middleborough /Lakeville
+  - Middleborough / Lakeville
+Mishawum:
+Montello:
+Montserrat:
+Morton Street:
+  - Morton St
+  - Morton St.
+Nantasket Junction:
+  - Nantasket Jct
+  - Nantasket Jct.
+Natick Center:
+  - Natick Ctr
+  - Natick Ctr.
+Needham Center:
+  - Needham Ctr
+  - Needham Ctr.
+Needham Heights:
+Needham Junction:
+  - Needham Jct
+  - Needham Jct.
+Newburyport:
+Newtonville:
+Norfolk:
+North Beverly:
+  - N Beverly
+  - N. Beverly
+North Billerica:
+  - N Billerica
+  - N. Billerica
+North Leominster:
+  - N Leominster
+  - N. Leominster
+North Scituate:
+  - N Scituate
+  - N. Scituate
+North Station:
+  - N Station
+  - N. Station
+North Wilmington:
+  - N Wilmington
+  - N. Wilmington
+Norwood Central:
+Norwood Depot:
+Plimptonville:
+Plymouth:
+Porter Square:
+  - Porter Sq
+  - Porter Sq.
+Prides Crossing:
+Providence:
+Quincy Center:
+  - Quincy Ctr
+  - Quincy Ctr.
+Reading:
+Readville:
+River Works / GE Employees Only:
+  - River Works
+  - GE
+  - River Works/GE
+  - River Works /GE
+  - River Works/ GE
+Rockport:
+Roslindale Village:
+Route 128:
+  - Rt 128
+  - Rt. 28
+  - Rte 28
+Rowley:
+Ruggles:
+Salem:
+Sharon:
+Shirley:
+Silver Hill:
+South Acton:
+  - S Acton
+  - S. Acton
+South Attleboro:
+  - S Attleboro
+  - S. Attleboro
+South Station:
+South Weymouth:
+  - S Weymouth
+  - S. Weymouth
+Southborough:
+Stoughton:
+Swampscott:
+Uphams Corner:
+  - Upham's Corner
+Wakefield:
+Walpole:
+Waltham:
+Waverley:
+Wedgemere:
+Wellesley Farms:
+Wellesley Hills:
+Wellesley Square:
+  - Wellesley Sq
+  - Wellesley Sq.
+West Concord:
+  - W Concord
+  - W. Concord
+West Gloucester:
+  - W Gloucester
+  - W. Gloucester
+West Hingham:
+  - W Hingham
+  - W. Hingham
+West Medford:
+  - W Medford
+  - W. Medford
+West Natick:
+  - W Natick
+  - W. Natick
+West Newton:
+  - W Newton
+  - W. Newton
+West Roxbury:
+  - W Roxbury
+  - W. Roxbury
+Westborough:
+Weymouth Landing/ East Braintree:
+  - Weymouth Landing
+  - E Braintree
+  - E. Braintree
+  - East Braintree
+  - Weymouth Landing/E Braintree
+  - Weymouth Landing/E. Braintree
+  - Weymouth Landing/East Braintree
+  - Weymouth Landing /E Braintree
+  - Weymouth Landing /E. Braintree
+  - Weymouth Landing /East Braintree
+  - Weymouth Landing / E Braintree
+  - Weymouth Landing / E. Braintree
+  - Weymouth Landing / East Braintree
+Whitman:
+Wilmington:
+Winchester Center:
+  - Winchester Ctr
+  - Winchester Ctr.
+Windsor Gardens:
+Worcester / Union Station:
+  - Worcester
+  - Union
+  - Union Sta
+  - Union Sta.
+  - Union Station
+  - Worcester/Union
+  - Worcester/Union Sta
+  - Worcester/Union Sta.
+  - Worcester/Union Station
+  - Worcester /Union
+  - Worcester /Union Sta
+  - Worcester /Union Sta.
+  - Worcester /Union Station
+  - Worcester/ Union
+  - Worcester/ Union Sta
+  - Worcester/ Union Sta.
+  - Worcester/ Union Station
+Wyoming Hill:
+Yawkey:
+TF Green Airport:
+  - T.F. Green
+  - T. F. Green
+  - T.F. Green Airport
+  - T. F. Green Airport

--- a/share/spice/transit/mbta/stops.yml
+++ b/share/spice/transit/mbta/stops.yml
@@ -10,6 +10,7 @@ Four Corners / Geneva:
   - Four Corners/Geneva
   - Four Corners /Geneva
   - Four Corners/ Geneva
+  - Four Corners-Geneva
 Newmarket:
 Abington:
 Anderson/ Woburn:
@@ -18,6 +19,7 @@ Anderson/ Woburn:
   - Anderson/Woburn
   - Anderson /Woburn
   - Anderson / Woburn
+  - Anderson-Woburn
 Andover:
 Ashland:
 Attleboro:
@@ -37,6 +39,7 @@ Brandeis/ Roberts:
   - Brandeis/Roberts
   - Brandeis /Roberts
   - Brandeis / Roberts
+  - Brandeis-Roberts
 Bridgewater:
 Brockton:
 Campello:
@@ -70,6 +73,7 @@ Forge Park / 495:
   - Forge Park/495
   - Forge Park /495
   - Forge Park/ 495
+  - Forge Park-495
 Framingham:
 Franklin:
 Gloucester:
@@ -83,6 +87,7 @@ Hamilton/ Wenham:
   - Hamilton/Wenham
   - Hamilton /Wenham
   - Hamilton / Wenham
+  - Hamilton-Wenham
 Hanson:
 Hastings:
 Haverhill:
@@ -94,6 +99,7 @@ Holbrook/ Randolph:
   - Holbrook/Randolph
   - Holbrook /Randolph
   - Holbrook / Randolph
+  - Holbrook-Randolph
 Hyde Park:
 Ipswich:
 Islington:
@@ -102,15 +108,21 @@ JFK/UMASS:
   - UMASS
   - JFK /UMASS
   - JFK/ UMASS
+  - JFK-UMASS
 Kendal Green:
 Kingston:
 Lawrence:
 Lincoln:
 Littleton / Rte 495:
   - Littleton
+  - Littleton/495
+  - Littleton /495
+  - Littleton/ 495
+  - Littleton-495
   - Littleton/Rte 495
   - Littleton /Rte 495
   - Littleton/ Rte 495
+  - Littleton-Rte 495
 Lowell:
 Lynn:
 Malden Center:
@@ -126,6 +138,7 @@ Middleborough/ Lakeville:
   - Middleborough/Lakeville
   - Middleborough /Lakeville
   - Middleborough / Lakeville
+  - Middleborough-Lakeville
 Mishawum:
 Montello:
 Montserrat:
@@ -186,12 +199,14 @@ River Works / GE Employees Only:
   - River Works/GE
   - River Works /GE
   - River Works/ GE
+  - River Works-GE
 Rockport:
 Roslindale Village:
 Route 128:
+  - 128
   - Rt 128
-  - Rt. 28
-  - Rte 28
+  - Rt. 128
+  - Rte 128
 Rowley:
 Ruggles:
 Salem:
@@ -259,6 +274,9 @@ Weymouth Landing/ East Braintree:
   - Weymouth Landing / E Braintree
   - Weymouth Landing / E. Braintree
   - Weymouth Landing / East Braintree
+  - Weymouth Landing-East Braintree
+  - Weymouth Landing-E. Braintree
+  - Weymouth Landing-E Braintree
 Whitman:
 Wilmington:
 Winchester Center:
@@ -283,6 +301,10 @@ Worcester / Union Station:
   - Worcester/ Union Sta
   - Worcester/ Union Sta.
   - Worcester/ Union Station
+  - Worcester-Union Station
+  - Worcester-Union Sta
+  - Worcester-Union Sta.
+  - Worcester-Union
 Wyoming Hill:
 Yawkey:
 TF Green Airport:

--- a/share/spice/transit/mbta/transit_mbta.css
+++ b/share/spice/transit/mbta/transit_mbta.css
@@ -1,0 +1,20 @@
+.zci--mbta .tile--mbta {
+    text-align: center;
+    width: 13em;
+}
+
+.is-mobile .zci--mbta .tile--mbta {
+    width: 12.25em;
+}
+
+.tile--mbta .mbta__time {
+    font-size: 2.3em;
+    color: #333;
+    font-weight: 300;
+}
+
+.tile--mbta .mbta__details {
+    color: #999;
+    margin-top: 5px;
+    margin-bottom: 10px;
+}

--- a/share/spice/transit/mbta/transit_mbta.css
+++ b/share/spice/transit/mbta/transit_mbta.css
@@ -1,3 +1,7 @@
+.zci--mbta .tile {
+    min-width: 15em;
+}
+
 .zci--mbta .tile--mbta {
     text-align: center;
     width: 13em;

--- a/share/spice/transit/mbta/transit_mbta.js
+++ b/share/spice/transit/mbta/transit_mbta.js
@@ -17,6 +17,9 @@
         var trips = []
         for (var i = 0; i < api_result.mode.length; i++) {
             var mode = api_result.mode[i];
+            if (mode.mode_name !== "Commuter Rail") {   //skip anything other than rail
+                continue
+            }
             for (var ii = 0; ii < mode.route.length; ii++) {
                 var route = mode.route[ii];
                 for (var iii = 0; iii < route.direction.length; iii++) {

--- a/share/spice/transit/mbta/transit_mbta.js
+++ b/share/spice/transit/mbta/transit_mbta.js
@@ -5,6 +5,14 @@
             return Spice.failed('mbta');
         }
 
+        var query = DDG.get_query();    //is the user interested in inbound, outbound, or both?
+        var inbound = (query.indexOf("inbound") > -1);
+        var outbound = (query.indexOf("outbound") > -1);
+        if (!inbound && !outbound) {    //if neither is specified, show both
+            outbound = true;
+            inbound = true;
+        }
+
         //The trips that serve a stop are organized by mode (subway, bus, etc). We'll put them in a single array.
         var trips = []
         for (var i = 0; i < api_result.mode.length; i++) {
@@ -13,6 +21,9 @@
                 var route = mode.route[ii];
                 for (var iii = 0; iii < route.direction.length; iii++) {
                     var direction = route.direction[iii];
+                    if ((direction.direction_name === "Inbound" && !inbound) || (direction.direction_name === "Outbound" && !outbound)) {
+                        continue;
+                    }
                     for (var iv = 0; iv < direction.trip.length; iv++) {
                         var trip = direction.trip[iv];
                         trip.mode_name = mode.mode_name; //add these so we don't lose them when we denormalize

--- a/share/spice/transit/mbta/transit_mbta.js
+++ b/share/spice/transit/mbta/transit_mbta.js
@@ -20,7 +20,18 @@
                         trip.direction_name = direction.direction_name;
 
                         var dep =  new Date(trip.sch_dep_dt*1000);
-                        trip.departs = padZeros(dep.getHours(), 2) + ":" + padZeros(dep.getMinutes(), 2);
+                        var hours = dep.getHours();
+                        var ampm;
+                        if (hours > 12) {
+                            hours -= 12;
+                            ampm = "pm";
+                        } else {
+                            if (hours === 0) {
+                                hours = 12;
+                            }
+                            ampm = "am";
+                        }
+                        trip.departs = hours + ":" + padZeros(dep.getMinutes(), 2) + " " + ampm;
 
                         trips.push(trip);
                     }

--- a/share/spice/transit/mbta/transit_mbta.js
+++ b/share/spice/transit/mbta/transit_mbta.js
@@ -32,6 +32,7 @@
                         trip.mode_name = mode.mode_name; //add these so we don't lose them when we denormalize
                         trip.route_name = route.route_name;
                         trip.direction_name = direction.direction_name;
+                        trip.train_num = trip.trip_name.split(" ")[0];
 
                         var dep =  new Date(trip.sch_dep_dt*1000);
                         var hours = dep.getHours();

--- a/share/spice/transit/mbta/transit_mbta.js
+++ b/share/spice/transit/mbta/transit_mbta.js
@@ -1,0 +1,66 @@
+(function (env){
+    "use strict";
+    env.ddg_spice_transit_mbta = function(api_result) {
+        if (!api_result || api_result.failed){
+            return Spice.failed('mbta');
+        }
+
+        //The trips that serve a stop are organized by mode (subway, bus, etc). We'll put them in a single array.
+        var trips = []
+        for (var i = 0; i < api_result.mode.length; i++) {
+            var mode = api_result.mode[i];
+            for (var ii = 0; ii < mode.route.length; ii++) {
+                var route = mode.route[ii];
+                for (var iii = 0; iii < route.direction.length; iii++) {
+                    var direction = route.direction[iii];
+                    for (var iv = 0; iv < direction.trip.length; iv++) {
+                        var trip = direction.trip[iv];
+                        trip.mode_name = mode.mode_name; //add these so we don't lose them when we denormalize
+                        trip.route_name = route.route_name;
+                        trip.direction_name = direction.direction_name;
+
+                        var dep =  new Date(trip.sch_dep_dt*1000);
+                        trip.departs = padZeros(dep.getHours(), 2) + ":" + padZeros(dep.getMinutes(), 2);
+
+                        trips.push(trip);
+                    }
+                }
+            }
+        }
+
+        Spice.add({
+            id: 'mbta',
+            name: 'MBTA',
+            data: trips,
+            meta: {
+                heading: "Trains from " + api_result.stop_name,
+                sourceUrl: "http://mbta.com/schedules_and_maps/rail/", //FIXME Is there a way to link to a specific station's schedule?
+                sourceName: "MBTA"
+            },
+            sort_fields: {
+                departure: function(a, b) {
+                    return a.sch_dep_dt < b.sch_dep_dt ? -1 : (a.sch_dep_dt > b.sch_dep_dt ? 1 : 0);
+                }
+            },
+            sort_default: "departure",
+            templates: {
+                group: 'base',
+                detail: false,
+                item_detail: false,
+                options: {
+                    content: Spice.transit_mbta.item
+                }
+            }
+        });
+
+        function padZeros(n, len) {
+            var s = n.toString();
+            while (s.length < len) {
+                s = '0' + s;
+            }
+            return s;
+        }
+
+    };
+
+}(this));

--- a/t/MBTA.t
+++ b/t/MBTA.t
@@ -17,6 +17,16 @@ ddg_spice_test(
         call_type => 'include',
         caller => 'DDG::Spice::Transit::MBTA'
     ),
+    "MBTA trains leaving from Plymouth" => test_spice(   #primary_example_query
+        '/js/spice/transit/mbta/Plymouth',
+        call_type => 'include',
+        caller => 'DDG::Spice::Transit::MBTA'
+    ),
+    "Next MBTA train from Forge Park" => test_spice(   #secondary_example_query
+        '/js/spice/transit/mbta/Forge%20Park%20%2F%20495',
+        call_type => 'include',
+        caller => 'DDG::Spice::Transit::MBTA'
+    ),
     "next train from King Street Station" => undef    #station doesn't exist
 );
 

--- a/t/MBTA.t
+++ b/t/MBTA.t
@@ -17,6 +17,11 @@ ddg_spice_test(
         call_type => 'include',
         caller => 'DDG::Spice::Transit::MBTA'
     ),
+    "outbound MBTA train from Worcester" => test_spice(     #strip outbound
+        '/js/spice/transit/mbta/Worcester%20%2F%20Union%20Station',
+        call_type => 'include',
+        caller => 'DDG::Spice::Transit::MBTA'
+    ),
     "MBTA trains leaving from Plymouth" => test_spice(   #primary_example_query
         '/js/spice/transit/mbta/Plymouth',
         call_type => 'include',

--- a/t/MBTA.t
+++ b/t/MBTA.t
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+ddg_spice_test(
+    [qw( DDG::Spice::Transit::MBTA )],
+    "next train from Ashland" => test_spice(
+        '/js/spice/transit/mbta/Ashland',
+        call_type => 'include',
+        caller => 'DDG::Spice::Transit::MBTA'
+    ),
+    "train schedule from Brandeis" => test_spice(
+        '/js/spice/transit/mbta/Brandeis%2F%20Roberts',     #expand an alias
+        call_type => 'include',
+        caller => 'DDG::Spice::Transit::MBTA'
+    ),
+    "next train from King Street Station" => undef    #station doesn't exist
+);
+
+done_testing;


### PR DESCRIPTION
# Spice Pull Request

**What does your instant answer do?**
Shows MBTA Commuter Rail departure times, similar to the existing SEPTA and NJ Transit answers. The biggest difference in functionality is the lack of "now boarding" status or lateness indicators, since the MBTA API doesn't provide that information (as far as I could tell).

Furthermore, the MBTA API doesn't have an endpoint to show trains from X to Y. It can only show trains departing from X, regardless of destination. We could implement an X-to-Y feature ourselves, but that's some fancy logic probably best left to a later PR. Fortunately, it's not that large of an issue, because the MBTA network (like SEPTA) is a star topology, where the important "destinations" are really just *inbound* and *outbound*.

For the moment, this only includes Commuter Rail stations, but the API endpoint I'm using also supports other transport modes operated by the MBTA, including subway and bus. That's an area for possible future expansion.

This PR also establishes the `Transit` namespace for transit-related Spices.


**What problem does your instant answer solve (Why is it better than organic links)?**
It shows upcoming departures at a glance.


**What is the data source for your instant answer? (Provide a link if possible)**
http://realtime.mbta.com/portal


**Why did you choose this data source?**
It's the official source and is very comprehensive.


**Are there any other alternative (better) data sources?**
Highly unlikely.


**What are some example queries that trigger this instant answer?**
`Next train from Braintree`, `MBTA from Providence`

In the future, I would like to support `MBTA train from Worcester to South Station`


**Which communities will this instant answer be especially useful for? (gamers, book lovers, etc)**
People in the Massachusetts Bay area.


**Is this instant answer connected to a DuckDuckHack [instant answer idea](https://duck.co/ideas)?**
No.


**Which existing instant answers will this one supersede/overlap with?**
None known.


**Are you having any problems? Do you need our help with anything?**
I would appreciate some visual design advice. I've attached screenshots of two alternatives, but I'm sure someone else can do even better.

Also, the code in this PR contains a demo API key. A real key will need to be used for production—I left the demo in there so people can run this module easily for review purposes.

![2014-08-31-21 19 39_1440x900](https://cloud.githubusercontent.com/assets/7873686/4104089/9e2bdd16-3180-11e4-9b3b-fb98a3bfe2b9.png)
![2014-08-31-21 21 42_1440x900](https://cloud.githubusercontent.com/assets/7873686/4104092/a4269f30-3180-11e4-8673-208687d0dc56.png)



## Checklist
Please place an 'X' where appropriate.

```
[X] Added metadata and attribution information
[X] Wrote test file and added to t/ directory
[X] Verified that instant answer adheres to design guidelines (https://duck.co/duckduckhack/design_styleguide)
[X] Verified that instant answer adheres to code styleguide (https://duck.co/duckduckhack/code_styleguide)
[X] Tested cross-browser compatibility

    Please let us know which browsers/devices you've tested on:
    - GNU/Linux
        [X] Opera 12.x
        [X] Firefox

```