### PR TITLE
Recipes: do not trigger on a single ingredient alone.

### DIFF
--- a/lib/DDG/Spice/Recipes.pm
+++ b/lib/DDG/Spice/Recipes.pm
@@ -29,7 +29,7 @@ handle query_lc => sub {
         exists $ingredients{$word} ? $ingredient_count++ : $non_ingredient_count++;
     };
 
-    return $_ if $ingredient_count > 0 && $non_ingredient_count < $ingredient_count;
+    return $_ if $ingredient_count > 1 && $non_ingredient_count < $ingredient_count;
     return;
 };
 

--- a/t/Recipes.t
+++ b/t/Recipes.t
@@ -11,7 +11,18 @@ ddg_spice_test(
 		'/js/spice/recipes/tofu%20ginger',
 		call_type => 'include',
 		caller => 'DDG::Spice::Recipes',
-	)
+	),
+	'tofu ginger' => test_spice(
+		'/js/spice/recipes/tofu%20ginger',
+		call_type => 'include',
+		caller => 'DDG::Spice::Recipes',
+	),
+	'ginger recipes' => test_spice(
+		'/js/spice/recipes/ginger',
+		call_type => 'include',
+		caller => 'DDG::Spice::Recipes',
+	),
+	'ginger' => undef, # No results for a single ingredient alone
 );
 
 done_testing;


### PR DESCRIPTION
With keyword 'recipe' we can always trigger, but require at least two
ingredients otherwise.

Fixes #1064.
