### PR TITLE
Quixey: add skip regex to improve relevancy.

### DIFF
--- a/lib/DDG/Spice/Quixey.pm
+++ b/lib/DDG/Spice/Quixey.pm
@@ -41,6 +41,8 @@ my %platform_ids = (
 
 my @triggers = keys %platform_ids;
 my @extraTriggers = qw(quixey app apps);
+my $skip_re = qr/(?:release date)/i; # Things which indicate different intent.
+
 push(@triggers, @extraTriggers);
 
 triggers any => @triggers;
@@ -56,6 +58,8 @@ handle query_parts => sub {
 	my $full_query = join(" ", @_);
 	my $restriction;
 	my $max_price = 999999;
+
+	return if ($full_query =~ $skip_re);
 
 	# set price to $0 if "free" is in the query
 	$max_price = 0 if ($full_query =~ s/\bfree\b//ig);

--- a/t/Quixey.t
+++ b/t/Quixey.t
@@ -158,7 +158,8 @@ my @q = (
   "ipone cracked screen",
   "windows 8 license",
   "windows 8 skype keeps closing",
-  "apple ios 5 musicplayer tutorial"
+  "apple ios 5 musicplayer tutorial",
+  "trainyard app release date",
 );
 
 ddg_spice_test(


### PR DESCRIPTION
At present, it only contains the single phrase but built for adding more
if we need.

Fixes #866.
