### PR TITLE
mass_on_time.js: switch from Spice.render to Spice.add

### DIFF
--- a/share/spice/mass_on_time/mass_on_time.js
+++ b/share/spice/mass_on_time/mass_on_time.js
@@ -49,7 +49,7 @@ function ddg_spice_mass_on_time (api_result) {
 
     if (results.length < 1) return;
 
-    Spice.render({
+    Spice.add({
 	id: 'mass',
 	data: results,
 	name: "Parishes",


### PR DESCRIPTION
I'm not quite happy with how this works from duckpan, but I think that's
a local issue.  Regardless, this alias will be going away, so we need to
make this switch.

Fixes #1073.
