### PR TITLE
Use Product model for Amazon to eliminate dups

### DIFF
--- a/share/spice/amazon/amazon.js
+++ b/share/spice/amazon/amazon.js
@@ -15,6 +15,7 @@
             name: 'Products',
             data: items,
             allowMultipleCalls: true,
+            model: 'Product',
             meta: {
                 itemType: 'Products',
                 sourceName: 'Amazon',


### PR DESCRIPTION
This requires internal core PR to be merged first.

@sdougbrown @yegg 
