### PR TITLE
More graceful handling of no/empty results from movies spice

### DIFF
--- a/share/spice/movie/movie.js
+++ b/share/spice/movie/movie.js
@@ -23,7 +23,7 @@
     }
     
     env.ddg_spice_movie = function(api_result) {
-        if(!api_result) {
+        if(!api_result || !api_result.movies || !api_result.movies.length) {
             return Spice.failed('movie');
         }
         
@@ -79,7 +79,10 @@
         
         // Make sure we hide the title and ratings.
         // It looks nice to show only the poster of the movie.
-        Spice.getDOM('movie').find('.tile__body').hide();
+        var $dom = Spice.getDOM('movie')
+        if ($dom && $dom.length) {
+            $dom.find('.tile__body').hide();
+        }
     };
     
     // Convert minutes to hr. min. format.


### PR DESCRIPTION
The deep triggers are exposing this. I guess any time it triggered before it would always return results? Or those cases where it didn't were rare enough that we didn't come across them.

@jagtalon @russellholt 
