### PR TITLE
MassOnTime: use DDG.getDateFromString() for date.

### DIFF
--- a/share/spice/mass_on_time/mass_on_time.js
+++ b/share/spice/mass_on_time/mass_on_time.js
@@ -111,9 +111,9 @@ Handlebars.registerHelper("MassOnTime_format_parish_address", function (address,
     }
 });
 
-Handlebars.registerHelper( "MassOnTime_format_12h_start", function (starttime) {
-    if (starttime) {
-        var start = new Date(starttime);
+Handlebars.registerHelper( "MassOnTime_format_12h_start", function (utc_starttime) {
+    if (utc_starttime) {
+        var start = DDG.getDateFromString(utc_starttime);
         var meridian = 'am';
         var hours = start.getHours();
         if (hours >= 12) {


### PR DESCRIPTION
By the time this hits core, core will contain the fixes which make it able to parse these UTC timestamps.  This will then fix #1098.
