### PR TITLE
Shorten: tighten up triggering.

### DIFF
--- a/lib/DDG/Spice/Shorten.pm
+++ b/lib/DDG/Spice/Shorten.pm
@@ -19,8 +19,10 @@ spice from => '([^/]+)/(.*)';
 spice to => 'http://is.gd/create.php?format=json&url=$1%3A%2F%2F$2&callback={{callback}}';
 triggers any => 'shorten', 'shorten url', 'short url', 'url shorten';
 
+my %connector_words = map { $_ => 1 } qw(for of);
+
 handle remainder => sub {
-    my @query_words = split /\s+/;
+    my @query_words =  grep { !$connector_words{$_} } split /\s+/;
     my $q           = shift @query_words;
     return if (@query_words);    # We should only work for a single 'word' in the query.
     $q =~ m|(?<schema>https?)?(?:://)?(?<loc>.+)|;

--- a/t/Shorten.t
+++ b/t/Shorten.t
@@ -35,7 +35,17 @@ ddg_spice_test(
         caller => 'DDG::Spice::Shorten',
     ),
     'https://www.duckduckgo.com/about.html shorten' => test_spice(
+        '/js/spice/shorten/https/www.duckduckgo.com%2Fabout.html',
+        call_type => 'include',
+        caller    => 'DDG::Spice::Shorten'
+    ),
+    'shorten url of http://www.duckduckgo.com/about.html' => test_spice(
         '/js/spice/shorten/http/www.duckduckgo.com%2Fabout.html',
+        call_type => 'include',
+        caller    => 'DDG::Spice::Shorten'
+    ),
+    'short url for https://www.duckduckgo.com/about.html' => test_spice(
+        '/js/spice/shorten/https/www.duckduckgo.com%2Fabout.html',
         call_type => 'include',
         caller    => 'DDG::Spice::Shorten'
     ),


### PR DESCRIPTION
- Only shorten a single remaining "word"
- Require that word to contain a dot (for quad or domain, at least)
- Expand testing to cover more cases

Fixes #1106.
