### PR TITLE
Dictionary - fix overlapping text

### DIFF
--- a/share/spice/dictionary/definition/dictionary_definition.css
+++ b/share/spice/dictionary/definition/dictionary_definition.css
@@ -21,8 +21,7 @@
 
 .zci__def__part-of-speech {
     font-style: italic;
-    width: 1em;
     float: left;
-    margin-right: 1.85em;
+    margin-right: 1em;
 }
 


### PR DESCRIPTION
Fix for issue #1111 //cc @jagtalon 

Desktop view:
![screen shot 2014-09-04 at 22 31 18](https://cloud.githubusercontent.com/assets/3652195/4395403/ac395188-442a-11e4-86f0-9fbe0efcb5bc.png)
![screen shot 2014-09-04 at 22 33 13](https://cloud.githubusercontent.com/assets/3652195/4395406/af3da794-442a-11e4-8fec-6d544c761213.png)

Mobile 320x480:
![screen shot 2014-09-04 at 22 33 28](https://cloud.githubusercontent.com/assets/3652195/4395412/b96f0db6-442a-11e4-9332-4e677fb0c587.png)
![screen shot 2014-09-04 at 22 33 42](https://cloud.githubusercontent.com/assets/3652195/4395413/bbb2ad1c-442a-11e4-8425-03582a97827f.png)
