### PR TITLE
DNS: Improve readibility of records

### DIFF
--- a/share/spice/dns/content.handlebars
+++ b/share/spice/dns/content.handlebars
@@ -1,6 +1,5 @@
 <table class="zci__table">
     <tr class="zci__table__tr">
-        <th>Name</th>
         <th>TTL</th>
         <th>Class</th>
         <th>Type</th>
@@ -9,7 +8,6 @@
     </tr>
     {{#each records}}
     <tr class="zci__table__tr">
-        <td>{{name}}</td>
         <td>{{ttl}}</td>
         <td>{{class}}</td>
         <td>{{type}}</td>

--- a/share/spice/dns/dns.css
+++ b/share/spice/dns/dns.css
@@ -13,8 +13,15 @@
 .zci--dns .zci__table__tr td {
     padding: 2px 0;
 }
+    .is-mobile .zci--dns .zci__table__tr td {
+        font-size: 75%;
+    }
 
 .zci--dns .zci__table__tr th,
 .zci--dns .zci__table__tr td {
-	padding-right: 2px;
+    padding-right: 15px;
 }
+    .is-mobile .zci--dns .zci__table__tr th,
+    .zci--dns .zci__table__tr td {
+        padding-right: 10px;
+    }

--- a/share/spice/dns/dns.js
+++ b/share/spice/dns/dns.js
@@ -18,7 +18,7 @@
 
         Spice.add({
             id: 'dns',
-            name: 'Answer',
+            name: api_result.query.domain,
             data: api_result.response,
             meta: {
                 sourceUrl: 'http://www.viewdns.info/dnsrecord/?domain=' + api_result.query.domain,


### PR DESCRIPTION
fixes #1112 
Originally, this was cutting off from right on mobile, so by removing name column it fits better, lmk if we have to change the name (domain only should be okay?). SS after changes on mobile:
![ss_dns](https://cloud.githubusercontent.com/assets/1424236/4435414/9a78cb38-4743-11e4-9daf-9107d40f3252.png)
