### PR TITLE
Whois spice - Don't trigger on naked domains

### DIFF
--- a/lib/DDG/Spice/Whois.pm
+++ b/lib/DDG/Spice/Whois.pm
@@ -34,7 +34,7 @@ my $url_qr = qr/(?:http:\/\/)?    # require http
 # additional keywords that trigger this spice
 my $whois_keywords_qr = qr/whois|who\sis|lookup|(?:is\s|)domain|(?:is\s|)available|register|owner(?:\sof|)|who\sowns|(?:how\sto\s|)buy/i;
 
-# trigger this spice when either the query starts or end.
+# trigger this spice when either the query starts or ends
 # with any of the whois keywords.
 #
 # note that there are additional guards in the handle() function that

--- a/lib/DDG/Spice/Whois.pm
+++ b/lib/DDG/Spice/Whois.pm
@@ -34,7 +34,7 @@ my $url_qr = qr/(?:http:\/\/)?    # require http
 # additional keywords that trigger this spice
 my $whois_keywords_qr = qr/whois|who\sis|lookup|(?:is\s|)domain|(?:is\s|)available|register|owner(?:\sof|)|who\sowns|(?:how\sto\s|)buy/i;
 
-# trigger this spice when either the query starts or ends
+# trigger this spice when the query starts or ends
 # with any of the whois keywords.
 #
 # note that there are additional guards in the handle() function that

--- a/share/spice/whois/whois.js
+++ b/share/spice/whois/whois.js
@@ -49,9 +49,21 @@
     // Returns whether we should show whois data if this
     // domain is not available.
     var is_whois_query = function(query) {
+	/*
+	   2014.09.29 - Now always returns true, since we no longer trigger
+	                on naked domains
+
+	                Previously, when we were triggering on naked domains,
+	                this function returned false for naked domain queries
+	                and true otherwise. We didn't want to show whois info
+	                for naked domains because they were usually navigational.
+
         // show whois results except when the query contains only the domain
         // and no other keywords, which we test by looking for a space in the query.
         return /\s/.test($.trim(query));
+	*/
+
+	return true;
     };
 
     // parse the api response into a standard format
@@ -108,8 +120,9 @@
                 && api_result.expiresDate.replace(/^(.*)?\s(.*)?$/, '$1'),
         };
 
-        // return nothing if all key whois data is missing
-        if( !normalized['Registered to']
+        // return nothing if domain has an owner but is missing all key whois data
+        if( !normalized['available']
+	    && !normalized['Registered to']
             && !normalized['Email']
             && !normalized['Last updated']
             && !normalized['Expires']) {
@@ -154,7 +167,7 @@
             name: "Whois",
             meta: {
                 sourceName: "Whois API",
-                sourceUrl: 'http://www.whoisxmlapi.com/whois-api-doc.php#whoisserver/WhoisService?rid=2&domainName='
+		sourceUrl: 'https://www.whoisxmlapi.com/#whoisserver/WhoisService?domainName='
                     + api_result.domainName
                     + '&outputFormat=json&target=raw'
             },

--- a/share/spice/whois/whois.js
+++ b/share/spice/whois/whois.js
@@ -122,7 +122,7 @@
 
         // return nothing if domain has an owner but is missing all key whois data
         if( !normalized['available']
-	    && !normalized['Registered to']
+            && !normalized['Registered to']
             && !normalized['Email']
             && !normalized['Last updated']
             && !normalized['Expires']) {
@@ -167,7 +167,7 @@
             name: "Whois",
             meta: {
                 sourceName: "Whois API",
-		sourceUrl: 'https://www.whoisxmlapi.com/#whoisserver/WhoisService?domainName='
+                sourceUrl: 'https://www.whoisxmlapi.com/#whoisserver/WhoisService?domainName='
                     + api_result.domainName
                     + '&outputFormat=json&target=raw'
             },

--- a/share/spice/whois/whois.js
+++ b/share/spice/whois/whois.js
@@ -51,9 +51,9 @@
     var is_whois_query = function(query) {
 
         // show whois results unless the query is a naked domain
-	// (i.e. contains only the domain and no other keywords).
-	//
-	// we test for naked domains by looking for a space in the query.
+        // (i.e. contains only the domain and no other keywords).
+        //
+        // we test for naked domains by looking for a space in the query.
         return /\s/.test($.trim(query));
 
     };

--- a/share/spice/whois/whois.js
+++ b/share/spice/whois/whois.js
@@ -49,21 +49,13 @@
     // Returns whether we should show whois data if this
     // domain is not available.
     var is_whois_query = function(query) {
-	/*
-	   2014.09.29 - Now always returns true, since we no longer trigger
-	                on naked domains
 
-	                Previously, when we were triggering on naked domains,
-	                this function returned false for naked domain queries
-	                and true otherwise. We didn't want to show whois info
-	                for naked domains because they were usually navigational.
-
-        // show whois results except when the query contains only the domain
-        // and no other keywords, which we test by looking for a space in the query.
+        // show whois results unless the query is a naked domain
+	// (i.e. contains only the domain and no other keywords).
+	//
+	// we test for naked domains by looking for a space in the query.
         return /\s/.test($.trim(query));
-	*/
 
-	return true;
     };
 
     // parse the api response into a standard format

--- a/t/Whois.t
+++ b/t/Whois.t
@@ -11,49 +11,72 @@ ddg_spice_test(
     # This is the name of the Spice that will be loaded to test.
     [ 'DDG::Spice::Whois' ],
 
-     # A naked domain should trigger.
-    'duckduckgo.com' => expected_output_for('duckduckgo.com'),
+    # 2014.09.29 - Removed naked domain triggering.
+    #
+    # A naked domain should trigger.
+    #'duckduckgo.com' => expected_output_for('duckduckgo.com'),
 
+    # A naked domain should NOT trigger.
+    'duckduckgo.com' => undef,
+
+    # 2014.09.29 - Removed naked domain triggering.
+    #
     # A naked domain with 'www' should trigger.
-    'http://www.duckduckgo.com' => expected_output_for('duckduckgo.com'),
+    #'http://www.duckduckgo.com' => expected_output_for('duckduckgo.com'),
 
-     # Domains should be lowercased
-    'dUcKdUcKgO.cOm' => expected_output_for('duckduckgo.com'),
+    # 2014.09.29 - Removed naked domain triggering.
+    #
+    # Domains should be lowercased
+    #'dUcKdUcKgO.cOm' => expected_output_for('duckduckgo.com'),
 
+    # 2014.09.29 - Removed naked domain triggering.
+    #
     # A naked domain with a subdomain that's not 'www' should not trigger.
-    'blah.duckduckgo.com' => undef,
+    #'blah.duckduckgo.com' => undef,
 
     # Whois keywords with a subdomain that's not 'www' should trigger.
     'whois blah.duckduckgo.com' => expected_output_for('duckduckgo.com'),
 
+    # 2014.09.29 - Removed naked domain triggering.
+    #
     # A naked domain with an unknown tld should not trigger.
-    'blah.duckduckgo.wtflmao' => undef,
+    #'blah.duckduckgo.wtflmao' => undef,
 
     # Whois keywords with an unknown tld should not trigger.
     'whois blah.duckduckgo.wtflmao' => undef,
 
+    # 2014.09.29 - Removed naked domain triggering.
+    #
     # A naked domain with a port should not trigger.
-    'duckduckgo.com:8000' => undef,
+    #'duckduckgo.com:8000' => undef,
 
     # Whois keywords with a port should trigger.
     'whois duckduckgo.com:8000' => expected_output_for('duckduckgo.com'),
 
+    # 2014.09.29 - Removed naked domain triggering.
+    #
     # A naked domain with a resource path should not trigger.
-    'duckduckgo.com/about' => undef,
+    #'duckduckgo.com/about' => undef,
 
     # Whois keywords with a resource path should trigger.
     'whois duckduckgo.com/about' => expected_output_for('duckduckgo.com'),
 
-     # A domain preceeded by 'http://' should trigger.
-    'http://duckduckgo.com' => expected_output_for('duckduckgo.com'),
+    # 2014.09.29 - Removed naked domain triggering.
+    #
+    # A domain preceeded by 'http://' should trigger.
+    #'http://duckduckgo.com' => expected_output_for('duckduckgo.com'),
 
-     # A domain preceeded by 'http://' and 'www' should trigger.
-    'http://www.duckduckgo.com' => expected_output_for('duckduckgo.com'),
+    # 2014.09.29 - Removed naked domain triggering.
+    #
+    # A domain preceeded by 'http://' and 'www' should trigger.
+    #'http://www.duckduckgo.com' => expected_output_for('duckduckgo.com'),
 
-     # A domain preceeded by 'http://' and a subdomain that's not 'www' should not trigger.
-    'http://blah.duckduckgo.com' => undef,
+    # 2014.09.29 - Removed naked domain triggering.
+    #
+    # A domain preceeded by 'http://' and a subdomain that's not 'www' should not trigger.
+    #'http://blah.duckduckgo.com' => undef,
 
-     # A random keyword before the domain should not trigger
+    # A random keyword before the domain should not trigger
     'blah duckduckgo.com' => undef,
 
      # A random keyword after the domain should not trigger


### PR DESCRIPTION
The main goal of this PR is to reduce API calls by removing naked domains (i.e. the query 'duckduckgo.com') from the triggers.

Also includes a few other small fixes and tweaks:
- Adds 'who is' to the triggers
- Changes the 'More at' URL
- Updates the check for insufficient whois data
