### PR TITLE
Properly escape HTML in ShortDescription of AlternativeTo IA.

### DIFF
--- a/share/spice/alternative_to/alternative_to.js
+++ b/share/spice/alternative_to/alternative_to.js
@@ -10,7 +10,10 @@
         Spice.add({
             id: 'alternative_to',
             name: 'Software',
-            data: api_result.Items,
+            data: $.map(api_result.Items, function(o, idx) {
+              o.ShortDescription = DDG.strip_html(o.ShortDescription);
+              return o;
+            }),
             signal: 'high',
             meta: {
                 searchTerm: api_result.Name,


### PR DESCRIPTION
This fixes [issue 1120](https://github.com/duckduckgo/zeroclickinfo-spice/issues/1120): HTML characters appear in some of the alternatives' respective descriptions.
