### PR TITLE
templates: freshen for current use.

### DIFF
--- a/t/Zanran.t
+++ b/t/Zanran.t
@@ -8,7 +8,6 @@ use DDG::Test::Spice;
 use_ok('DDG::Spice::Zanran');
 
 spice call_type => 'include';
-spice answer_type => 'zanran';
 spice caller => 'DDG::Spice::Zanran';
 
 

--- a/template/lib/DDG/Spice/Example.pm
+++ b/template/lib/DDG/Spice/Example.pm
@@ -5,8 +5,7 @@ package DDG::Spice::<: $ia_name :>;
 
 use DDG::Spice;
 
-zci answer_type => "<: $lia_name :>";
-zci is_cached   => 1;
+spice is_cached => 1;
 
 # Metadata.  See https://duck.co/duckduckhack/metadata for help in filling out this section.
 name "<: $ia_name :>";

--- a/template/t/Example.t
+++ b/template/t/Example.t
@@ -5,8 +5,7 @@ use warnings;
 use Test::More;
 use DDG::Test::Spice;
 
-zci answer_type => "<: $lia_name :>";
-zci is_cached   => 1;
+spice is_cached => 1;
 
 ddg_spice_test(
     [qw( DDG::Spice::<: $ia_name :>)],


### PR DESCRIPTION
- Add explicit answer_type and caching settings.
- Point to metadata documentation to help complete section.
- Rearrange metadata to match documentation.
- Update attribution with better example strings.
- Place guard clause before work clause in example code.
