### PR TITLE
Only show the subreddit description label if there's a description

### DIFF
--- a/share/spice/reddit_sub_search/detail.handlebars
+++ b/share/spice/reddit_sub_search/detail.handlebars
@@ -1,3 +1,3 @@
 {{#rt "Title"}} <a href="http://www.reddit.com{{url}}">{{title}}</a>{{/rt}}
-{{#if public_description}}{{#rd "Description"}} {{{redditSub_unescape public_description}}} {{/rd}}{{/if}}
+{{#rv "Description" val="public_description"}} {{{redditSub_unescape public_description}}} {{/rv}}
 {{#rd "Subscribers"}} {{redditSub_formatSubscribers subscribers}} {{/rd}}


### PR DESCRIPTION
Hello everyone. Jumping in with something super small. This fixes #1137.
