### PR TITLE
 IPLookup: "blacklist" isn't listed even though they're returned by the API #1116 

### DIFF
--- a/share/spice/iplookup/content.handlebars
+++ b/share/spice/iplookup/content.handlebars
@@ -2,8 +2,9 @@
     {{#each famlist from="0" to="1"}}
     <h1 class='text--primary iplookup_domain_name zci__header--detail'><a href='http://{{this}}'>{{this}}</a></h1>
     {{/each}}
-    <div class='text--primary iplookup_owner'>Owner: {{shortwho}}</div>
-    <div class='text--secondary iplookup_location'>{{shortloc}}</div>
+    <div class='text--primary iplookup_owner'>Owner: {{shortwho}}
+    <span class='text--secondary iplookup_location'>({{shortloc}})</span>
+    </div>
     {{#if blacklists}}
         <div class='text--secondary iplookup_blacklist'>Blacklists: 
             {{#concat blacklists sep="," conj="and"}}

--- a/share/spice/iplookup/content.handlebars
+++ b/share/spice/iplookup/content.handlebars
@@ -7,9 +7,7 @@
     </div>
     {{#if blacklists}}
         <div class='text--secondary iplookup_blacklist'>Blacklists: 
-            {{#concat blacklists sep="," conj="and"}}
-                {{this}}
-            {{/concat}}
+            {{#concat blacklists sep="," conj="and"}}{{this}}{{/concat}}
         </div>
     {{/if}}
 </div>

--- a/share/spice/iplookup/content.handlebars
+++ b/share/spice/iplookup/content.handlebars
@@ -6,7 +6,9 @@
     <div class='text--secondary iplookup_location'>{{shortloc}}</div>
     {{#if blacklists}}
         <div class='text--secondary iplookup_blacklist'>Blacklists: 
-            {{#each blacklists}} List: {{this}}; this is filler text to force ellipses to display.{{/each}}
+            {{#concat blacklists sep="," conj="and"}}
+                {{this}}
+            {{/concat}}
         </div>
     {{/if}}
 </div>

--- a/share/spice/iplookup/content.handlebars
+++ b/share/spice/iplookup/content.handlebars
@@ -5,12 +5,8 @@
     <div class='text--primary iplookup_owner'>Owner: {{shortwho}}</div>
     <div class='text--secondary iplookup_location'>{{shortloc}}</div>
     {{#if blacklists}}
-        <div class='text--secondary iplookup_blacklist'>Blacklists:
-            <ul class='blacklists text--secondary'>
-                {{#each blacklists}}
-                    <li>{{this}}</li>
-                {{/each}}
-            </ul>
+        <div class='text--secondary iplookup_blacklist'>Blacklists: 
+            {{#each blacklists}} List: {{this}}; this is filler text to force ellipses to display.{{/each}}
         </div>
     {{/if}}
 </div>


### PR DESCRIPTION
This pull request addresses #1116: **IPLookup: "blacklist" isn't listed even though they're returned by the API** by printing blacklists on the same line as the header and shrinking the vertical space required by the IA.

![screen shot 2014-10-03 at 1 48 12 am](https://cloud.githubusercontent.com/assets/5326740/4502229/a5c2f5be-4ac1-11e4-9bf4-26c82d411456.png)

However, I think that there might be a larger front-end issue regarding this template? I think that the original reason for this bug is that the function that automatically crops text does not always show ellipses after it does the truncation, suggesting to the user that there is no more content even when there is. This is still reproducible if we shrink the size of the browser:

![screen shot 2014-10-03 at 1 48 02 am](https://cloud.githubusercontent.com/assets/5326740/4502259/739c6a1a-4ac2-11e4-87e7-1d3589588ca0.png)
