### PR TITLE
IPLookup concatenation spacing

### DIFF
--- a/share/spice/iplookup/content.handlebars
+++ b/share/spice/iplookup/content.handlebars
@@ -7,7 +7,7 @@
     </div>
     {{#if blacklists}}
         <div class='text--secondary iplookup_blacklist'>Blacklists: 
-            {{#concat blacklists sep="," conj="and"}}{{this}}{{/concat}}
+            {{#concat blacklists sep=", " conj=" and "}}{{this}}{{/concat}}
         </div>
     {{/if}}
 </div>


### PR DESCRIPTION
@jagtalon Re: #1116 and #1139, I misunderstood how the concatenation function works and didn't properly include spaces after the comma and before and after the final conjunction. When I committed the code to make multiple lists appear correctly, I inadvertently broke the spacing when an IP has just two blacklists. This new pull request should format blacklists correctly, regardless of how many there are. Screenshots attached for 1, 2, and 4 blacklists. Apologies for the extra pull request!

![screen shot 2014-10-06 at 11 18 39 pm](https://cloud.githubusercontent.com/assets/5326740/4536928/ce4a25a4-4dd0-11e4-9fc7-c9f57cbae16c.png)
![screen shot 2014-10-06 at 11 03 09 pm](https://cloud.githubusercontent.com/assets/5326740/4536932/d73fb1a6-4dd0-11e4-9795-94cf72c93db6.png)
![screen shot 2014-10-06 at 11 03 29 pm](https://cloud.githubusercontent.com/assets/5326740/4536933/d93522d4-4dd0-11e4-8e37-dcade4823099.png)
