### PR TITLE
IPLookup: will now match IPv4 or IPv6 by itself as well as query formats

### DIFF
--- a/t/IPLookup.t
+++ b/t/IPLookup.t
@@ -66,6 +66,14 @@ ddg_spice_test(
         call_type => 'include',
         caller => 'DDG::Spice::IPLookup',
     ),
+    '5.6.7.8' => test_spice(
+        '/js/spice/iplookup/5.6.7.8',
+        call_type => 'include',
+        caller => 'DDG::Spice::IPLookup'
+    ),
+    '1.2.3.4/24' => undef,
+    '1.2.3.4 255.255.0.0' => undef,
+    '1.2.3.4/255.255.0.0' => undef,
 );
 
 done_testing;


### PR DESCRIPTION
Should address https://github.com/duckduckgo/zeroclickinfo-spice/issues/1108 & supersede the existing answer
