### PR TITLE
Added PATH transit answer

### DIFF
--- a/lib/DDG/Spice/Transit/PATH.pm
+++ b/lib/DDG/Spice/Transit/PATH.pm
@@ -1,0 +1,50 @@
+package DDG::Spice::Transit::PATH;
+
+use DDG::Spice;
+
+primary_example_queries "next train from JSQ to WTC";
+secondary_example_queries "train times to hoboken from 33rd street";
+description "Lookup the next PATH train going your way";
+name "PATH";
+source "PATH";
+code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/PATH.pm";
+topics "everyday";
+category "time_sensitive";
+attribution twitter => 'mattr555',
+            github => ['https://github.com/mattr555/', 'Matt Ramina'];
+
+spice to => 'http://njt-api.appspot.com/path/times/$1';
+spice wrap_jsonp_callback => 1;
+spice proxy_cache_valid => "418 1d";
+
+#load a list of stops so we don't trigger this if we don't get njt stops
+#(the triggers are similar to other transit IAs)
+my @stops = share('stops.txt')->slurp;
+
+#check if the stop name is in the list of stops
+#(using the same matching algorithm as the backend)
+sub is_stop {
+    foreach my $stop (@stops){
+        return 1 if index(lc $stop, lc $_[0]) > -1;
+    }
+    return;
+};
+
+triggers any => "next train", "train times", "train schedule", "path", "trans hudson";
+
+handle remainder => sub {
+    return unless /(?:from |to )?(.+) (to|from) (.+)/;
+    my $orig = $1;
+    my $dest = $3;
+    if (is_stop($orig) and is_stop($dest)){
+        #lowercase the stop names found in the query and change the spaces to dashes
+        my $orig = join "-", map { lc } split /\s+/, $orig;
+        my $dest = join "-", map { lc } split /\s+/, $dest;
+        #if the word between the two stop names is "to", then we're going from the first stop to the second
+        #if it's "from", then we're going from the second stop to the first
+        return $2 eq 'to' ? ($orig, $dest) : ($dest, $orig);
+    }
+    return;
+};
+
+1;

--- a/share/spice/transit/path/stops.txt
+++ b/share/spice/transit/path/stops.txt
@@ -1,0 +1,17 @@
+Grove Street
+9th Street
+Exchange Place
+Christopher Street
+14th Street
+Journal Square
+World Trade Center
+Newport
+Harrison
+Hoboken
+Newark Penn Station
+33rd Street
+23rd Street
+pavonia
+wtc
+jsq
+nwk

--- a/share/spice/transit/path/train_item.handlebars
+++ b/share/spice/transit/path/train_item.handlebars
@@ -1,0 +1,5 @@
+<div class="path__time">{{departure_time}}</div>
+<div class="path__details">
+    {{#if cancelled}}N/A{{else}}Arrives {{arrival_time}}{{/if}}<br/>
+    {{line}}<br/>
+</div>

--- a/share/spice/transit/path/transit_path.css
+++ b/share/spice/transit/path/transit_path.css
@@ -3,8 +3,10 @@
     width: 13em;
 }
 
-.is-mobile .zci--path .tile--path {
-    width: 12.25em;
+@media screen and (max-device-width: 640px) and (orientation: portrait){
+	.is-mobile .zci--path .tile--path {
+	    width: 48%;
+	}
 }
 
 .tile--path .path__time {

--- a/share/spice/transit/path/transit_path.css
+++ b/share/spice/transit/path/transit_path.css
@@ -16,5 +16,5 @@
 .tile--path .path__details {
     color: #999;
     margin-top: 5px;
-    margin-bottom: 10px;
+    margin-bottom: 5px;
 }

--- a/share/spice/transit/path/transit_path.css
+++ b/share/spice/transit/path/transit_path.css
@@ -1,0 +1,20 @@
+.zci--path .tile--path {
+    text-align: center;
+    width: 13em;
+}
+
+.is-mobile .zci--path .tile--path {
+    width: 12.25em;
+}
+
+.tile--path .path__time {
+    font-size: 2.3em;
+    color: #333;
+    font-weight: 300;
+}
+
+.tile--path .path__details {
+    color: #999;
+    margin-top: 5px;
+    margin-bottom: 10px;
+}

--- a/share/spice/transit/path/transit_path.js
+++ b/share/spice/transit/path/transit_path.js
@@ -1,0 +1,64 @@
+(function (env){
+    "use strict";
+    env.ddg_spice_transit_path = function(api_result){
+        if (!api_result || api_result.failed){
+            return Spice.failed('path');
+        }
+
+        Spice.add({
+            id: 'path',
+            name: 'PATH',
+            data: api_result.routes,
+            meta: {
+                heading: api_result.origin + " to " + api_result.destination,
+                sourceUrl: "http://www.panynj.gov/path/",
+                sourceName: "PATH"
+            },
+            templates: {
+                group: 'base',
+                detail: false,
+                item_detail: false,
+                options: {
+                    content: Spice.transit_path.train_item
+                }
+            },
+            normalize: function(item){
+                var route_replacements = {
+                    "Journal Square - 33rd Street (via Hoboken)": "JSQ-HOB-33",
+                    "Journal Square - 33rd Street": "JSQ-33",
+                    "Hoboken - 33rd Street": "HOB-33",
+                    "Hoboken - World Trade Center": "HOB-WTC",
+                    "Newark - World Trade Center": "NWK-WTC"
+                }
+                return {
+                    departure_time: format_time(item.departure_time),
+                    arrival_time: format_time(item.arrival_time),
+                    line: route_replacements[item.line]
+                }
+            }
+        });
+    }
+
+    function padZeros(n, len) {
+        var s = n.toString();
+        while (s.length < len) {
+            s = '0' + s;
+        }
+        return s;
+    }   
+
+    function format_time(t) {
+        var hour = parseInt(t.split(':')[0]),
+            minute = parseInt(t.split(':')[1]),
+            ampm = (hour >= 24) ? 'AM' : (hour >= 12) ? 'PM' : 'AM';
+        if (hour > 24) {
+            hour -= 24;
+        } else if (hour > 12) {
+            hour -= 12;
+        }
+        if (hour === 0){
+            hour = 12;
+        }
+        return hour + ':' + padZeros(minute, 2) + ' ' + ampm;
+    }
+}(this));

--- a/t/PATH.t
+++ b/t/PATH.t
@@ -1,0 +1,52 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+my %queries = (
+    'nwk' => 'jsq',
+    'harrison' => 'wtc',
+    'jsq' => 'hoboken',
+    'grove st' => '33rd'
+);
+
+my %tests = map {(
+    "next train from $_ to $queries{$_}" => test_spice(
+        '/js/spice/transit/path/'
+        . (join '-', map { lc } split /\s+/, $_)
+        . '/'
+        . (join '-', map { lc } split /\s+/, $queries{$_}),
+        call_type => 'include',
+        caller => 'DDG::Spice::Transit::PATH'
+    ),
+    "next train to $_ from $queries{$_}" => test_spice(
+        '/js/spice/transit/path/'
+        . (join '-', map { lc } split /\s+/, $queries{$_})
+        . '/'
+        . (join '-', map { lc } split /\s+/, $_),
+        call_type => 'include',
+        caller => 'DDG::Spice::Transit::PATH'
+    ),
+    "path $_ to $queries{$_}" => test_spice(
+        '/js/spice/transit/path/'
+        . (join '-', map { lc } split /\s+/, $_)
+        . '/'
+        . (join '-', map { lc } split /\s+/, $queries{$_}),
+        call_type => 'include',
+        caller => 'DDG::Spice::Transit::PATH'
+    )
+)} keys %queries;
+
+ddg_spice_test(
+    [qw( DDG::Spice::Transit::PATH )],
+    (
+        %tests,
+        'next train from a station that doesnt exist to another' => undef,
+        'path jsq to blah station' => undef,
+        'path rail map' => undef
+    )
+);
+
+done_testing;


### PR DESCRIPTION
**What does your Instant Answer do?**
Give a timetable for the PATH (Port Authority Trans-Hudson)

**What problem does your Instant Answer solve (Why is it better than organic links)?**
It gives an answer for the next train.

**What is the data source for your Instant Answer? (Provide a link if possible)**
[My own api](https://github.com/mattr555/njt-api) that uses the [GTFS data](http://www.panynj.gov/path/developers.html).

**Why did you choose this data source?**
The GTFS data is official

**Are there any other alternative (better) data sources?**
Nope

**What are some example queries that trigger this Instant Answer?**
`path nwk to jsq`, `next train to newark from wtc`.

**Which communities will this Instant Answer be especially useful for? (gamers, book lovers, etc)**
Commuters who use the PATH

**Is this Instant Answer connected to a DuckDuckHack [Instant Answer idea](https://duck.co/ideas)?**
Nope

**Which existing Instant Answers will this one supersede/overlap with?**
None

**Are you having any problems? Do you need our help with anything?**
There is no real time data available for the PATH, so maybe the design could be different (though I think it looks ok now).

**What are the terms of use for the API? Will DuckDuckGo need specific authorization (e.g. an API key)? Are there any costs associated with API usage?**
DDG may use my api with my blessing.

**What does the Instant Answer look like? (Provide a screenshot for new or updated Instant Answers)**
![desktop](http://i.imgur.com/WhnRmHj.png)
![moblie](http://i.imgur.com/NTrWxau.png)

This also establishes the Transit namespace, which will also be added when #1056 is merged.
## Checklist

Please place an 'X' where appropriate.

```
[x] Added metadata and attribution information
[x] Wrote test file and added to t/ directory
[x] Verified that instant answer adheres to design guidelines (https://duck.co/duckduckhack/design_styleguide)
[x] Verified that instant answer adheres to code styleguide (https://duck.co/duckduckhack/code_styleguide)
[/] Tested cross-browser compatibility

    Please let us know which browsers/devices you've tested on:
    - Windows 8
        [] Google Chrome
        [] Firefox
        [] Opera
        [] IE 10

    - Windows 7
        [] Google Chrome
        [] Firefox
        [] Opera
        [] IE 8
        [] IE 9
        [] IE 10

    - Windows XP
        [] IE 7
        [] IE 8

    - Mac OSX
        [] Google Chrome
        [] Firefox
        [] Opera
        [] Safari

    - iOS (iPhone)
        [x] Safari Mobile
        [] Google Chrome
        [] Opera

    - iOS (iPad)
        [x] Safari Mobile
        [] Google Chrome
        [] Opera

    - Android
        [] Firefox
        [] Native Browser
        [] Google Chrome
        [] Opera

    - Crunchbang (Linux)
        [x] Google Chrome
```
