### PR TITLE
Update Airlines source and icon to reflect current provider

### DIFF
--- a/lib/DDG/Spice/Airlines.pm
+++ b/lib/DDG/Spice/Airlines.pm
@@ -6,7 +6,7 @@ primary_example_queries "AA 102";
 secondary_example_queries "Delta 3684";
 description "Flight information";
 name "Flight Info";
-icon_url "/i/www.flightstats.com.ico";
+icon_url "/i/flightstats.com.ico";
 source "FlightStats";
 code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/Airlines.pm";
 topics "economy_and_finance", "travel", "everyday";


### PR DESCRIPTION
//cc @jagtalon @russellholt @nilnilnil 

We haven't been using FlightAware as the provider for quite a while, the discrepency was recently pointed out to me by @tommytommytommy
