### PR TITLE
Change stocks spice trigger

### DIFF
--- a/lib/DDG/Spice/Stocks.pm
+++ b/lib/DDG/Spice/Stocks.pm
@@ -13,7 +13,7 @@ category "finance";
 # trigger is intentionally very specific, should trigger from internal view/deep triggers.
 # It's only here because I couldn't get the /js/stocks/ location to end up in generated nginx conf
 # unless I had at least some kind of trigger defined.
-triggers end => 'stock quote';
+triggers start => 'stock quote';
 
 spice to => 'http://ycharts.com/quotes/$1';
 spice wrap_jsonp_callback => 1;

--- a/t/Stocks.t
+++ b/t/Stocks.t
@@ -7,7 +7,7 @@ use DDG::Test::Spice;
 
 ddg_spice_test(
 	[qw( DDG::Spice::Stocks )],
-	'AAPL stock quote' => test_spice(
+	'stock quote AAPL' => test_spice(
 		'/js/spice/stocks/AAPL',
 		call_type => 'include',
 		caller => 'DDG::Spice::Stocks',


### PR DESCRIPTION
The old one was conflicting with the internal trigger and would result in 'medium' signal when it should be 'high'.

@jagtalon @moollaza I would love to just remove the trigger here altogether since it's all done internally. Is there a way to create a spice w/o a trigger? It seems like if you leave out the triggers it doesn't make it into the generated nginx conf?

cc @russellholt 
