### PR TITLE
Forecast: rework triggering.

### DIFF
--- a/lib/DDG/Spice/Forecast.pm
+++ b/lib/DDG/Spice/Forecast.pm
@@ -29,7 +29,7 @@ foreach my $temp (@temperatures) {
 }
 
 my @forecast_words = qw(forecast forcast weather);
-my @triggers = (@forecast_words, @temps_triggers);
+my @triggers = (@forecast_words, @temps_triggers, 'meteo');
 triggers startend => @triggers;
 
 spice from => '([^/]*)/?([^/]*)';

--- a/t/Forecast.t
+++ b/t/Forecast.t
@@ -136,6 +136,12 @@ ddg_spice_test(
     	caller => 'DDG::Spice::Forecast',
         is_cached => 1
     ),
+    'meteo paris' => test_spice(
+    	'/js/spice/forecast/paris',
+    	call_type => 'include',
+    	caller => 'DDG::Spice::Forecast',
+        is_cached => 1
+    ),
     'temperature stockholm' => undef,
     'shipping forecast' => undef,
     'weather forecast bbc' => undef,


### PR DESCRIPTION
Intended effect is to require temperature trigger to be preceded by
"current" or followed by "in/at/for".. or both.

In pursuit of this, also simplified the way forecast skip words
are maintained. At least I think it is simpler.

Also eliminated `meteo` trigger as it seems pretty esoteric and
unhelpful.

Intended to address #1170.
