### PR TITLE
ISBN: allow for bare ISBN entry.

### DIFF
--- a/lib/DDG/Spice/ISBN.pm
+++ b/lib/DDG/Spice/ISBN.pm
@@ -24,7 +24,7 @@ spice to            =>      'https://duckduckgo.com/m.js?q=$1&cb={{callback}}';
 spice is_cached     =>      1;
 
 # Look for at least 9 digits, spaces and dashes in a row, possibly ending with an X.
-triggers query_raw => qr/[0-9\s-]{10,}[Xx]?/;
+triggers query_raw => qr/[0-9\s-]{9,}[Xx]?/;
 
 my %skip_words = map { uc $_ => 1 } qw( isbn number lookup );    # Appreciate if they tried to give us more context.
 

--- a/t/ISBN.t
+++ b/t/ISBN.t
@@ -84,6 +84,13 @@ ddg_spice_test(
         caller => 'DDG::Spice::ISBN',
         is_cached => 1
     ),
+    # Same thing, all compressed.
+    '080442957X' => test_spice(
+        '/js/spice/isbn/080442957X',
+        call_type => 'include',
+        caller => 'DDG::Spice::ISBN',
+        is_cached => 1
+    ),
     # Mistyped ISBN-10 with X
     '0-8044-2967-X' => undef,
     # Mistyped ISBN-13


### PR DESCRIPTION
We'll trigger if there are at least 10 digits plus spaces and dashes
in a row.

Then clean it up and see if we can find just 10 or 13 digits in a row
which pass check digit verification.  If so, we rock on.

Addresses #1169.
