### PR TITLE
use https link for searchcode

### DIFF
--- a/share/spice/search_code/search_code.js
+++ b/share/spice/search_code/search_code.js
@@ -41,7 +41,7 @@ function ddg_spice_search_code(api_response) {
     Spice.add({
         data             : result,
         header1          : formatName(result),
-        sourceUrl       : 'https://searchco.de/?q=' + query,
+        sourceUrl       : 'https://searchcode.com/?q=' + query,
         sourceName      : 'search[code]',
         templates: {
             item: Spice.search_code.search_code,


### PR DESCRIPTION
it redirects anyway, but that is annoying with requestpolicy, and hey,
who doesn't like tls
