### PR TITLE
New geometry formula shower / calculator Spice

### DIFF
--- a/lib/DDG/Spice/Geometry.pm
+++ b/lib/DDG/Spice/Geometry.pm
@@ -1,4 +1,5 @@
 package DDG::Spice::Geometry;
+# ABSTRACT: Provides a formula shower / calculator for geometry
 
 use DDG::Spice;
 

--- a/lib/DDG/Spice/Geometry.pm
+++ b/lib/DDG/Spice/Geometry.pm
@@ -1,0 +1,19 @@
+package DDG::Spice::Geometry;
+
+use DDG::Spice;
+
+primary_example_queries 'geometry square';
+secondary_example_queries 'formula for circle area', 'geometry cube volume size: 4';
+triggers startend => 'geometry', 'formula', 'calc';
+
+name 'Geometry';
+description 'Little calculator and formula shower for geometric formulas';
+category 'formulas';
+
+spice call_type => 'self';
+
+handle query_lc => sub {
+    return call;
+};
+
+1;

--- a/share/spice/geometry/content.handlebars
+++ b/share/spice/geometry/content.handlebars
@@ -8,6 +8,9 @@
         {{/if}}
     </div>
     {{/each}}
+    {{#if parameter}}
+        <small>Assuming {{parameterName}} = {{parameter}}</small>
+    {{/if}}
 </div>
 <svg id="zci--geometry-svg" viewBox="-5 -5 170 130" style="display: none">
     {{#each svg}}

--- a/share/spice/geometry/content.handlebars
+++ b/share/spice/geometry/content.handlebars
@@ -2,7 +2,7 @@
     {{#each formulas}}
         <div>
         <span>{{name}}:</span>
-        {{symbol}} = {{formula}}
+        {{symbol}} = {{{html}}}
         {{#if result}}
             = {{result}}
         {{/if}}

--- a/share/spice/geometry/content.handlebars
+++ b/share/spice/geometry/content.handlebars
@@ -1,12 +1,15 @@
 <div id="zci--geometry-formulas" class="text--primary">
     {{#each formulas}}
-        <div>
-        <span>{{name}}:</span>
-        {{symbol}} = {{{html}}}
-        {{#if result}}
-            = {{result}}
-        {{/if}}
-    </div>
+        <div class="formula">
+            <div class="dot" style="background-color: {{color}}"></div>
+            <div>
+                <h4>{{nameCaps}}</h4>
+                {{symbol}} = {{{html}}}
+                {{#if result}}
+                 = {{result}}
+                {{/if}}
+            </div>
+        </div>
     {{/each}}
     {{#if parameter}}
         <small>

--- a/share/spice/geometry/content.handlebars
+++ b/share/spice/geometry/content.handlebars
@@ -1,0 +1,19 @@
+<div id="zci--geometry-formulas" class="text--primary">
+    {{#each formulas}}
+        <div>
+        <span>{{name}}:</span>
+        {{symbol}} = {{formula}}
+        {{#if result}}
+            = {{result}}
+        {{/if}}
+    </div>
+    {{/each}}
+</div>
+<svg id="zci--geometry-svg" viewBox="-5 -5 170 130" style="display: none">
+    {{#each svg}}
+        <path
+            d="{{path}}"
+            class="{{class}}"
+        />
+    {{/each}}
+</svg>

--- a/share/spice/geometry/content.handlebars
+++ b/share/spice/geometry/content.handlebars
@@ -9,7 +9,12 @@
     </div>
     {{/each}}
     {{#if parameter}}
-        <small>Assuming {{parameterName}} = {{parameter}}</small>
+        <small>
+            Assuming
+            {{#each parameter}}
+                {{symbol}} = {{value}}
+            {{/each}}
+        </small>
     {{/if}}
 </div>
 <svg id="zci--geometry-svg" viewBox="-5 -5 170 130" style="display: none">

--- a/share/spice/geometry/geometry.css
+++ b/share/spice/geometry/geometry.css
@@ -1,12 +1,41 @@
-#zci--geometry-svg{float: left; fill: transparent}
-#zci--geometry-svg .stroke{stroke: black; stroke-width: 2; stroke-linejoin: round}
-#zci--geometry-svg .stroke.backface{stroke-width: 1.5}
-#zci--geometry-svg .stroke.special{stroke-dasharray: 5,5}
-#zci--geometry-svg .stroke.hover{stroke: #1168CE}
-#zci--geometry-svg .stroke.special.hover{stroke-dasharray: none}
-#zci--geometry-svg .fill.hover{fill: #85B6F1}
+#zci--geometry-svg{
+    float: left;
+    fill: transparent;
+}
+#zci--geometry-svg .stroke{
+    stroke: black;
+    stroke-width: 2;
+    stroke-linejoin: round;
+}
+#zci--geometry-svg .stroke.backface{
+    stroke-width: 1.5;
+}
+#zci--geometry-svg .stroke.special{
+    stroke-dasharray: 5,5;
+}
+#zci--geometry-svg .stroke.hover{
+    stroke: #1168CE;
+}
+#zci--geometry-svg .stroke.special.hover{
+    stroke-dasharray: none;
+}
+#zci--geometry-svg .fill.hover{
+    fill: #85B6F1;
+}
 
-#zci--geometry-formulas{float: left; font-size: 1.5em; margin-right: 10px}
-#zci--geometry-formulas div.hover{color: #1168CE}
-#zci--geometry-formulas span{min-width: 150px; margin-right: 5px; display: inline-block}
-#zci--geometry-formulas small{color: #808080}
+#zci--geometry-formulas{
+    float: left;
+    font-size: 1.5em;
+    margin-right: 10px;
+}
+#zci--geometry-formulas div.hover{
+    color: #1168CE;
+}
+#zci--geometry-formulas span{
+    min-width: 150px;
+    margin-right: 5px;
+    display: inline-block;
+}
+#zci--geometry-formulas small{
+    color: #808080;
+}

--- a/share/spice/geometry/geometry.css
+++ b/share/spice/geometry/geometry.css
@@ -1,6 +1,7 @@
 #zci--geometry-svg{
     float: left;
     fill: transparent;
+    margin-left: 50px;
 }
 #zci--geometry-svg .stroke{
     stroke: black;
@@ -23,6 +24,7 @@
     margin-right: 10px;
 }
 #zci--geometry-formulas .formula{
+    margin-bottom: 5px;
     overflow: hidden;
     clear: left;
 }
@@ -33,19 +35,20 @@
     width: 14px;
     height: 14px;
     border-radius: 7px;
-    opacity: 0.75;
-    margin: 7px 8px;
+    opacity: 0.5;
+    margin: 20px 10px;
 }
 #zci--geometry-formulas .hover .dot{
     opacity: 1;
 }
 #zci--geometry-formulas h4{
-    color: #6E6E6E;
+    color: #999;
     font-size: 12px;
+    padding-bottom: 0;
+    margin-bottom: -3px;
 }
-#zci--geometry-formulas .root{
-    border-top: 1px solid #000;
-    padding-top: 2px;
+#zci--geometry-formulas sup{
+  font-size: 0.6em;
 }
 #zci--geometry-formulas small{
     color: #808080;

--- a/share/spice/geometry/geometry.css
+++ b/share/spice/geometry/geometry.css
@@ -13,14 +13,8 @@
 #zci--geometry-svg .stroke.special{
     stroke-dasharray: 5,5;
 }
-#zci--geometry-svg .stroke.hover{
-    stroke: #1168CE;
-}
 #zci--geometry-svg .stroke.special.hover{
     stroke-dasharray: none;
-}
-#zci--geometry-svg .fill.hover{
-    fill: #85B6F1;
 }
 
 #zci--geometry-formulas{
@@ -28,21 +22,32 @@
     font-size: 1.5em;
     margin-right: 10px;
 }
-#zci--geometry-formulas div.hover{
-    color: #1168CE;
+#zci--geometry-formulas .formula{
+    overflow: hidden;
+    clear: left;
 }
-#zci--geometry-formulas span:first-child{
-    min-width: 150px;
-    margin-right: 5px;
-    display: inline-block;
+#zci--geometry-formulas .formula div{
+    float: left;
+}
+#zci--geometry-formulas .dot{
+    width: 14px;
+    height: 14px;
+    border-radius: 7px;
+    opacity: 0.75;
+    margin: 7px 8px;
+}
+#zci--geometry-formulas .hover .dot{
+    opacity: 1;
+}
+#zci--geometry-formulas h4{
+    color: #6E6E6E;
+    font-size: 12px;
 }
 #zci--geometry-formulas .root{
     border-top: 1px solid #000;
     padding-top: 2px;
 }
-#zci--geometry-formulas div.hover .root{
-    border-top-color: #1168CE;
-}
 #zci--geometry-formulas small{
     color: #808080;
+    font-size: 0.8em;
 }

--- a/share/spice/geometry/geometry.css
+++ b/share/spice/geometry/geometry.css
@@ -1,36 +1,43 @@
-#zci--geometry-svg{
-    float: left;
+#zci--geometry-svg {
     fill: transparent;
-    margin-left: 50px;
+    margin-left: 40px;
+    max-width: 50%;
 }
-#zci--geometry-svg .stroke{
+
+#zci--geometry-svg .stroke {
     stroke: black;
     stroke-width: 2;
     stroke-linejoin: round;
 }
-#zci--geometry-svg .stroke.backface{
+
+#zci--geometry-svg .stroke.backface {
     stroke-width: 1.5;
 }
-#zci--geometry-svg .stroke.special{
+
+#zci--geometry-svg .stroke.special {
     stroke-dasharray: 5,5;
 }
-#zci--geometry-svg .stroke.special.hover{
+
+#zci--geometry-svg .stroke.special.hover {
     stroke-dasharray: none;
 }
 
-#zci--geometry-formulas{
+
+#zci--geometry-formulas {
     float: left;
     font-size: 1.5em;
     margin-right: 10px;
 }
-#zci--geometry-formulas .formula{
+#zci--geometry-formulas .formula {
     margin-bottom: 5px;
     overflow: hidden;
     clear: left;
 }
-#zci--geometry-formulas .formula div{
+
+#zci--geometry-formulas .formula div {
     float: left;
 }
+
 #zci--geometry-formulas .dot{
     width: 14px;
     height: 14px;
@@ -38,19 +45,23 @@
     opacity: 0.5;
     margin: 20px 10px;
 }
-#zci--geometry-formulas .hover .dot{
+
+#zci--geometry-formulas .hover .dot {
     opacity: 1;
 }
-#zci--geometry-formulas h4{
+
+#zci--geometry-formulas h4 {
     color: #999;
     font-size: 12px;
     padding-bottom: 0;
     margin-bottom: -3px;
 }
-#zci--geometry-formulas sup{
+
+#zci--geometry-formulas sup {
   font-size: 0.6em;
 }
-#zci--geometry-formulas small{
+
+#zci--geometry-formulas small {
     color: #808080;
     font-size: 0.8em;
 }

--- a/share/spice/geometry/geometry.css
+++ b/share/spice/geometry/geometry.css
@@ -1,0 +1,11 @@
+#zci--geometry-svg{float: left; fill: transparent}
+#zci--geometry-svg .stroke{stroke: black; stroke-width: 2; stroke-linejoin: round}
+#zci--geometry-svg .stroke.backface{stroke-width: 1.5}
+#zci--geometry-svg .stroke.special{stroke-dasharray: 5,5}
+#zci--geometry-svg .stroke.hover{stroke: #1168CE}
+#zci--geometry-svg .stroke.special.hover{stroke-dasharray: none}
+#zci--geometry-svg .fill.hover{fill: #85B6F1}
+
+#zci--geometry-formulas{float: left; font-size: 1.5em; margin-right: 10px}
+#zci--geometry-formulas div.hover{color: #1168CE}
+#zci--geometry-formulas span{min-width: 150px; margin-right: 5px; display: inline-block}

--- a/share/spice/geometry/geometry.css
+++ b/share/spice/geometry/geometry.css
@@ -31,10 +31,17 @@
 #zci--geometry-formulas div.hover{
     color: #1168CE;
 }
-#zci--geometry-formulas span{
+#zci--geometry-formulas span:first-child{
     min-width: 150px;
     margin-right: 5px;
     display: inline-block;
+}
+#zci--geometry-formulas .root{
+    border-top: 1px solid #000;
+    padding-top: 2px;
+}
+#zci--geometry-formulas div.hover .root{
+    border-top-color: #1168CE;
 }
 #zci--geometry-formulas small{
     color: #808080;

--- a/share/spice/geometry/geometry.css
+++ b/share/spice/geometry/geometry.css
@@ -9,3 +9,4 @@
 #zci--geometry-formulas{float: left; font-size: 1.5em; margin-right: 10px}
 #zci--geometry-formulas div.hover{color: #1168CE}
 #zci--geometry-formulas span{min-width: 150px; margin-right: 5px; display: inline-block}
+#zci--geometry-formulas small{color: #808080}

--- a/share/spice/geometry/geometry.js
+++ b/share/spice/geometry/geometry.js
@@ -395,11 +395,15 @@
         if(isNumber(parameter)) //force array
             parameter = [parameter];
 
+        //loop through all formulas of this shape
         for(i = 0, l = data.formulas.length; i < l; ++i){
+            //get the formula symbol and format the name
             data.formulas[i].symbol = formulas[data.formulas[i].name];
             data.formulas[i].name = DDG.capitalize(data.formulas[i].name);
+            //calc the formula if parameter(s) is / are defined
             if(data.parameter !== null)
                 data.formulas[i].result = format(data.formulas[i].calc.apply(0, parameter));
+            //if the formula is in the search string, print only this formula
             if(query.match(data.formulas[i].name, "i")){
                 //cleanup formulas
                 data.formulas = [data.formulas[i]];
@@ -415,6 +419,7 @@
             }
         }
 
+        //if parameter(s) is / are defined print their values
         if(parameter !== null){
             data.parameter = [];
             for(i = 0, l = parameter.length; i < l; ++i){
@@ -445,8 +450,8 @@
                 for(i = 0, l = pairs.length; i < l; ++i)
                     bindHoverPair([formulaNodes[pairs[i][0]], svgNodes[pairs[i][1]]]);
 
+                //wait for stylesheet
                 $(window).load(function(){
-                    console.log("retzguih");
                     svg.height(content.height());
                     svg.show();
                 });

--- a/share/spice/geometry/geometry.js
+++ b/share/spice/geometry/geometry.js
@@ -37,32 +37,60 @@
         return parseFloat(number.toFixed(3));
     }
 
-    function bindHoverPair(pair){
+    function bindHoverPair(formulaNode, svgNode, color){
         function enter(){
-            pair[0].addClass("hover");
-            pair[1].each(function(){
+            formulaNode.addClass("hover");
+            //set the fill/ stroke color for svg nodes
+            svgNode.each(function(){
                 this.classList.add("hover");
             });
+            if(svgNode.is(".fill"))
+                svgNode.css("fill", color);
+            if(svgNode.is(".stroke"))
+                svgNode.css("stroke", color);
         }
         function leave(){
-            pair[0].removeClass("hover");
-            pair[1].each(function(){
+            formulaNode.removeClass("hover");
+            svgNode.each(function(){
                 this.classList.remove("hover");
             });
+            if(svgNode.is(".fill"))
+                svgNode.css("fill", "transparent");
+            if(svgNode.is(".stroke"))
+                svgNode.css("stroke", "#000");
         }
-        pair = [$(pair[0]), $(pair[1])];
+        formulaNode = $(formulaNode);
+        svgNode = $(svgNode);
 
-        pair[0].hover(enter, leave);
-        pair[1].hover(enter, leave);
+        formulaNode.hover(enter, leave);
+        svgNode.hover(enter, leave);
     }
 
     var formulas = {
-        volume: "V",
-        area: "A",
-        surface: "A",
-        perimeter: "u",
-        circumference: "u",
-        diagonal: "e"
+        volume: {
+            symbol: "V",
+            color: "#FF6745"
+        },
+        area: {
+            symbol: "A",
+            color: "#00E204"
+        },
+        surface: {
+            symbol: "A",
+            color: "#00E204"
+        },
+        perimeter: {
+            symbol: "u",
+            color: "#0095FF"
+        },
+        circumference: {
+            symbol: "u",
+            color: "#0095FF"
+        },
+        diagonal: {
+            symbol: "e",
+            color: "#FF8100"
+        }
     };
 
     var shapes = {
@@ -96,11 +124,11 @@
                 path: "M 0,0 l 120,120",
                 class: "stroke special"
             }],
-            pairs: [
-                [0, 0],
-                [1, 1],
-                [2, 2]
-            ],
+            pairs: {
+                area: [0, 0],
+                perimeter: [1, 1],
+                diagonal: [2, 2]
+            },
             getParameter: function(query){
                 return getParameter(query, "a|length|size");
             },
@@ -136,11 +164,11 @@
                 path: "M 0,0 l 160,120",
                 class: "stroke special"
             }],
-            pairs: [
-                [0, 0],
-                [1, 1],
-                [2, 2]
-            ],
+            pairs: {
+                area: [0, 0],
+                perimeter: [1, 1],
+                diagonal: [2, 2]
+            },
             getParameter: function(query){
                 var p = getParameter(query, "length|size", 1);
                 if(p !== null)
@@ -177,10 +205,10 @@
                 path: "M 70,0 l 70,120 m -140,0 l 70,-120 m 70,120 h -140",
                 class: "stroke"
             }],
-            pairs: [
-                [0, 0],
-                [1, 1]
-            ],
+            pairs: {
+                area: [0, 0],
+                perimeter: [1, 1]
+            },
             getParameter: function(query){
                 return getParameter(query, "a|length|size");
             },
@@ -207,10 +235,10 @@
                 path: "M 0,60 a 25 25 0 0 0 120,0 a 25 25 0 0 0 -120,0",
                 class: "stroke"
             }],
-            pairs: [
-                [0, 0],
-                [1, 1]
-            ],
+            pairs: {
+                area: [0, 0],
+                circumference: [1, 1]
+            },
             getParameter: function(query){
                 var r = getParameter(query, "radius|r");
                 if(r !== null) return r;
@@ -256,11 +284,11 @@
                 path: "M 0,40 h 80 v 80 h -80 v -80 l 40,-40 h 80 v 80 l -40,40 v -80 l 40,-40",
                 class: "stroke"
             }],
-            pairs: [
-                [1, 0],
-                [2, 2],
-                [0, 3]
-            ],
+            pairs: {
+                surface: [1, 0],
+                diagonal: [2, 2],
+                volume: [0, 3]
+            },
             getParameter: function(query){
                 return getParameter(query, "a|length|size");
             },
@@ -302,11 +330,11 @@
                 path: "M 0,40 h 120 v 80 h -120 v -80 l 40,-40 h 120 v 80 l -40,40 v -80 l 40,-40",
                 class: "stroke"
             }],
-            pairs: [
-                [1, 0],
-                [2, 2],
-                [0, 3]
-            ],
+            pairs: {
+                surface: [1, 0],
+                diagonal: [2, 2],
+                volume: [0, 3]
+            },
             getParameter: function(query){
                 var p = getParameter(query, "length|size", 2);
                 if(p !== null) return p;
@@ -349,10 +377,10 @@
                 path: "M 0,60 a 30 10 0 1 0 120,0 a 25 25 0 0 0 -120,0 a 25 25 0 0 0 120,0",
                 class: "stroke"
             }],
-            pairs: [
-                [0, 2],
-                [1, 0]
-            ],
+            pairs: {
+                volume: [0, 2],
+                surface: [1, 0]
+            },
             getParameter: function(query){
                 var r = getParameter(query, "radius|r");
                 if(r !== null) return r;
@@ -397,12 +425,14 @@
 
         //loop through all formulas of this shape
         for(i = 0, l = data.formulas.length; i < l; ++i){
-            //get the formula symbol and format the name
-            data.formulas[i].symbol = formulas[data.formulas[i].name];
-            data.formulas[i].name = DDG.capitalize(data.formulas[i].name);
+            //get the formula symbol, color and format the name
+            data.formulas[i].symbol = formulas[data.formulas[i].name].symbol;
+            data.formulas[i].color = formulas[data.formulas[i].name].color;
+            data.formulas[i].nameCaps = data.formulas[i].name.toUpperCase();
             //calc the formula if parameter(s) is / are defined
             if(data.parameter !== null)
                 data.formulas[i].result = format(data.formulas[i].calc.apply(0, parameter));
+
             //if the formula is in the search string, print only this formula
             if(query.match(data.formulas[i].name, "i")){
                 //cleanup formulas
@@ -449,8 +479,8 @@
                     svgNodes = svg.children(),
                     content = svg.parent();
 
-                for(i = 0, l = pairs.length; i < l; ++i)
-                    bindHoverPair([formulaNodes[pairs[i][0]], svgNodes[pairs[i][1]]]);
+                for(var i in pairs)
+                    bindHoverPair(formulaNodes[pairs[i][0]], svgNodes[pairs[i][1]], formulas[i].color);
 
                 //wait for stylesheet
                 $(window).load(function(){

--- a/share/spice/geometry/geometry.js
+++ b/share/spice/geometry/geometry.js
@@ -1,6 +1,25 @@
 (function(env){
     "use strict";
 
+    function getParameter(query, trigger){
+        var regex, result;
+        regex = new RegExp("(?:" + trigger + ")\\s*[=:]?\\s*(\\d+(?:[.,]\\d+)?)");
+        //(?:trigger)\s?[=:]?\s? => matches the name of the formula, following by optional whitespace, = or :, whitespace
+        //(\d+(?:[.,]\d+)?) => matches the number, as integer or float
+
+        result = query.match(regex);
+        if(result === null) return null; //no match
+        result = result[1].replace(",", "."); //stores the result as string and replace commas with points
+        result = parseFloat(result);
+
+        return result;
+    }
+
+    function format(number){
+        //maximal three decimal places
+        return parseFloat(number.toFixed(3));
+    }
+
     function bindHoverPair(pair){
         function enter(){
             pair[0].addClass("hover");
@@ -61,7 +80,11 @@
                 [0, 0],
                 [1, 1],
                 [2, 2]
-            ]
+            ],
+            getParameter: function(query){
+                return getParameter(query, 'a|length|size');
+            },
+            parameterName: "a"
         }
     };
 
@@ -85,19 +108,26 @@
             return;
         }
 
-        data.formulas = shapes[shape].formulas;
-        data.svg = shapes[shape].svg;
-        pairs = shapes[shape].pairs;
+        shape = shapes[shape];
+
+        data.formulas = shape.formulas;
+        data.svg = shape.svg;
+        pairs = shape.pairs;
+        data.parameter = shape.getParameter(query);
+        data.parameterName = shape.parameterName;
 
         for(i = 0, l = data.formulas.length; i < l; ++i){
             data.formulas[i].symbol = formulas[data.formulas[i].name];
             data.formulas[i].name = DDG.capitalize(data.formulas[i].name);
+            if(data.parameter !== null)
+                data.formulas[i].result = format(data.formulas[i].calc(data.parameter));
         }
 
         // Display the plugin.
         Spice.add({
             data: data,
             id: "geometry",
+            name: "Geometry",
             templates: {
                 group: "base",
                 options: {

--- a/share/spice/geometry/geometry.js
+++ b/share/spice/geometry/geometry.js
@@ -1,35 +1,98 @@
 (function(env){
     "use strict";
 
-    env.ddg_spice_geometry = function(){
-        var data = {
+    function bindHoverPair(pair){
+        function enter(){
+            pair[0].addClass("hover");
+            pair[1].each(function(){
+                this.classList.add("hover");
+            });
+        }
+        function leave(){
+            pair[0].removeClass("hover");
+            pair[1].each(function(){
+                this.classList.remove("hover");
+            });
+        }
+        pair = [$(pair[0]), $(pair[1])];
+
+        pair[0].hover(enter, leave);
+        pair[1].hover(enter, leave);
+    }
+
+    var formulas = {
+        area: "A",
+        perimeter: "u",
+        diagonal: "e"
+    };
+
+    var shapes = {
+        square: {
             formulas: [{
-                name: "Area",
-                symbol: "A",
-                formula: "a\u00B2"
+                name: "area",
+                html: "a<sup>2</sup>",
+                calc: function(a){
+                    return a * a;
+                }
             }, {
-                name: "Perimeter",
-                symbol: "u",
-                formula: "4a"
+                name: "perimeter",
+                html: "4a",
+                calc: function(a){
+                    return 4 * a;
+                }
             }, {
-                name: "Diagonal",
-                symbol: "e",
-                formula: "a\u221A2"
+                name: "diagonal",
+                html: "a&radic;2",
+                calc: function(a){
+                    return a * Math.SQRT2;
+                }
             }],
             svg: [{
                 path: "M 0,0 h 120 v 120 h -120 z",
-                class: "fill",
-                symbol: "A"
+                class: "fill"
             }, {
                 path: "M 0,0 h 120 m 0,120 h -120 m 120,0 v -120 m -120,0 v 120",
-                class: "stroke",
-                symbol: "u"
+                class: "stroke"
             }, {
                 path: "M 0,0 l 120,120",
-                class: "stroke special",
-                symbol: "e"
-            }]
-        };
+                class: "stroke special"
+            }],
+            pairs: [
+                [0, 0],
+                [1, 1],
+                [2, 2]
+            ]
+        }
+    };
+
+    env.ddg_spice_geometry = function(){
+        var query = DDG.get_query(),
+            shape,
+            data = {},
+            pairs,
+            i, l,
+            got = false;
+
+        for(shape in shapes){
+            if(query.match(shape)){
+                got = true;
+                break;
+            }
+        }
+
+        if(!got){   //failed, no shape was matched
+            Spice.failed("geometry");
+            return;
+        }
+
+        data.formulas = shapes[shape].formulas;
+        data.svg = shapes[shape].svg;
+        pairs = shapes[shape].pairs;
+
+        for(i = 0, l = data.formulas.length; i < l; ++i){
+            data.formulas[i].symbol = formulas[data.formulas[i].name];
+            data.formulas[i].name = DDG.capitalize(data.formulas[i].name);
+        }
 
         // Display the plugin.
         Spice.add({
@@ -43,7 +106,12 @@
             }
         });
         var content = Spice.getDOM("geometry"),
-            svg = $("#zci--geometry-svg", content);
+            formulaNodes = $("#zci--geometry-formulas", content).children(),
+            svg = $("#zci--geometry-svg", content),
+            svgNodes = svg.children();
+
+        for(i = 0, l = pairs.length; i < l; ++i)
+            bindHoverPair([formulaNodes[pairs[i][0]], svgNodes[pairs[i][1]]]);
 
         $(window).load(function(){
             svg.height(content.height());
@@ -51,5 +119,3 @@
         });
     };
 }(this));
-
-ddg_spice_geometry();

--- a/share/spice/geometry/geometry.js
+++ b/share/spice/geometry/geometry.js
@@ -57,8 +57,11 @@
     }
 
     var formulas = {
+        volume: "V",
         area: "A",
+        surface: "A",
         perimeter: "u",
+        circumference: "u",
         diagonal: "e"
     };
 
@@ -99,7 +102,7 @@
                 [2, 2]
             ],
             getParameter: function(query){
-                return [getParameter(query, "a|length|size")];
+                return getParameter(query, "a|length|size");
             },
             parameterNames: ["a"]
         },
@@ -139,8 +142,7 @@
                 [2, 2]
             ],
             getParameter: function(query){
-                var p;
-                p = getParameter(query, "length|size", 1);
+                var p = getParameter(query, "length|size", 1);
                 if(p !== null)
                     return p;
 
@@ -153,6 +155,212 @@
                 return null;
             },
             parameterNames: ["a", "b"]
+        },
+        "equilateral triangle": {
+            formulas: [{
+                name: "area",
+                html: "(a<sup>2</sup>*&radic;3)/4",
+                calc: function(a){
+                    return a / 4 * Math.sqrt(3);
+                }
+            }, {
+                name: "perimeter",
+                html: "3a",
+                calc: function(a){
+                    return a * 3;
+                }
+            }],
+            svg: [{
+                path: "M 70,0 l 70,120 h -140 z",
+                class: "fill"
+            }, {
+                path: "M 70,0 l 70,120 m -140,0 l 70,-120 m 70,120 h -140",
+                class: "stroke"
+            }],
+            pairs: [
+                [0, 0],
+                [1, 1]
+            ],
+            getParameter: function(query){
+                return getParameter(query, "a|length|size");
+            },
+            parameterNames: ["a"]
+        },
+        circle: {
+            formulas: [{
+                name: "area",
+                html: "&pi;r<sup>2</sup>",
+                calc: function(r){
+                    return Math.PI * r * r;
+                }
+            }, {
+                name: "circumference",
+                html: "2&pi;r",
+                calc: function(r){
+                    return 2 * Math.PI * r;
+                }
+            }],
+            svg: [{
+                path: "M 0,60 a 25 25 0 0 0 120,0 a 25 25 0 0 0 -120,0",
+                class: "fill"
+            }, {
+                path: "M 0,60 a 25 25 0 0 0 120,0 a 25 25 0 0 0 -120,0",
+                class: "stroke"
+            }],
+            pairs: [
+                [0, 0],
+                [1, 1]
+            ],
+            getParameter: function(query){
+                var r = getParameter(query, "radius|r");
+                if(r !== null) return r;
+                r = getParameter(query, "diameter|d");
+                if(r !== null) return r / 2;
+                return null;
+            },
+            parameterNames: ["r"]
+        },
+        cube: {
+            formulas: [{
+                name: "volume",
+                html: "a<sup>3</sup>",
+                calc: function(a){
+                    return a * a * a;
+                }
+            }, {
+                name: "surface",
+                html: "6a<sup>2</sup>",
+                calc: function(a){
+                        return 6 * a * a;
+                }
+            }, {
+                name: "diagonal",
+                html: "a&radic;3",
+                calc: function(a){
+                    return a * Math.sqrt(3);
+                }
+            }],
+            svg: [{
+                path: "M 0,120 v -80 l 40,-40 h 80 v 80 l -40 40 z",
+                class: "fill"
+            }, {
+                path: "M 0,120 l 40,-40 v -80 v 80 h 80",
+                class: "stroke backface"
+            }, {
+                path: "M 0,40 l 120,40",
+                class: "stroke special"
+            }, {
+                path: "M 0,120 v -80 l 40,-40 h 80 v 80 l -40 40 z",
+                class: "fill"
+            }, {
+                path: "M 0,40 h 80 v 80 h -80 v -80 l 40,-40 h 80 v 80 l -40,40 v -80 l 40,-40",
+                class: "stroke"
+            }],
+            pairs: [
+                [1, 0],
+                [2, 2],
+                [0, 3]
+            ],
+            getParameter: function(query){
+                return getParameter(query, "a|length|size");
+            },
+            parameterNames: ["a"]
+        },
+        cuboid: {
+            formulas: [{
+                name: "volume",
+                html: "abc",
+                calc: function(a, b, c){
+                    return a * b * c;
+                }
+            }, {
+                name: "surface",
+                html: "2(ab + ac + bc)",
+                calc: function(a, b, c){
+                    return 2 * (a * b + a * c + b * c);
+                }
+            }, {
+                name: "diagonal",
+                html: "&radic;(a<sup>2</sup> + b<sup>2</sup> + c<sup>2</sup>)",
+                calc: function(a, b, c){
+                    return Math.sqrt(a * a + b * b + c * c);
+                }
+            }],
+            svg: [{
+                path: "M 0,120 v -80 l 40,-40 h 120 v 80 l -40 40 z",
+                class: "fill"
+            }, {
+                path: "M 0,120 l 40,-40 v -80 v 80 h 120",
+                class: "stroke backface"
+            }, {
+                path: "M 0,40 l 160,40",
+                class: "stroke special"
+            }, {
+                path: "M 0,120 v -80 l 40,-40 h 120 v 80 l -40 40 z",
+                class: "fill"
+            }, {
+                path: "M 0,40 h 120 v 80 h -120 v -80 l 40,-40 h 120 v 80 l -40,40 v -80 l 40,-40",
+                class: "stroke"
+            }],
+            pairs: [
+                [1, 0],
+                [2, 2],
+                [0, 3]
+            ],
+            getParameter: function(query){
+                var p = getParameter(query, "length|size", 2);
+                if(p !== null) return p;
+
+                p = [
+                    getParameter(query, "a"),
+                    getParameter(query, "b"),
+                    getParameter(query, "c")
+                ];
+                if(p[0] !== null && p[1] !== null && p[2] !== null)
+                    return p;
+                return null;
+            },
+            parameterNames: ["a", "b", "c"]
+        },
+        sphere : {
+            formulas: [{
+                name: "volume",
+                html: "4/3&pi;r<sup>3</sup>",
+                calc: function(r){
+                    return 4 / 3 * Math.PI * r * r * r;
+                }
+            }, {
+                name: "surface",
+                html: "4&pi;r<sup>2</sup>",
+                calc: function(r){
+                    return 4 * Math.PI * r * r;
+                }
+            }],
+            svg: [{
+                path: "M 0,60 a 25 25 0 0 0 120,0 a 25 25 0 0 0 -120,0",
+                class: "fill"
+            }, {
+                path: "M 0,60 a 30 10 0 0 1 120,0",
+                class: "stroke backface"
+            }, {
+                path: "M 0,60 a 25 25 0 0 0 120,0 a 25 25 0 0 0 -120,0",
+                class: "fill"
+            }, {
+                path: "M 0,60 a 30 10 0 1 0 120,0 a 25 25 0 0 0 -120,0 a 25 25 0 0 0 120,0",
+                class: "stroke"
+            }],
+            pairs: [
+                [0, 2],
+                [1, 0]
+            ],
+            getParameter: function(query){
+                var r = getParameter(query, "radius|r");
+                if(r !== null) return r;
+                r = getParameter(query, "diameter|d");
+                if(r !== null) return r / 2;
+                return null;
+            },
+            parameterNames: ["r"]
         }
     };
 
@@ -184,6 +392,8 @@
         data.svg = shape.svg;
         pairs = shape.pairs;
         parameter = shape.getParameter(query);
+        if(isNumber(parameter)) //force array
+            parameter = [parameter];
 
         for(i = 0, l = data.formulas.length; i < l; ++i){
             data.formulas[i].symbol = formulas[data.formulas[i].name];

--- a/share/spice/geometry/geometry.js
+++ b/share/spice/geometry/geometry.js
@@ -81,7 +81,7 @@
                 }
             }, {
                 name: "diagonal",
-                html: "a&radic;2",
+                html: "a&radic;<span class='root'>2</span>",
                 calc: function(a){
                     return a * Math.SQRT2;
                 }
@@ -121,7 +121,7 @@
                 }
             }, {
                 name: "diagonal",
-                html: "&radic;a<sup>2</sup>+b<sup>2</sup>",
+                html: "&radic;<span class='root'>a<sup>2</sup>+b<sup>2</sup></span>",
                 calc: function(a, b){
                     return Math.sqrt(a * a + b * b);
                 }
@@ -159,7 +159,7 @@
         "equilateral triangle": {
             formulas: [{
                 name: "area",
-                html: "(a<sup>2</sup>*&radic;3)/4",
+                html: "(a<sup>2</sup>*&radic;<span class='root'>3</span>)/4",
                 calc: function(a){
                     return a / 4 * Math.sqrt(3);
                 }
@@ -235,7 +235,7 @@
                 }
             }, {
                 name: "diagonal",
-                html: "a&radic;3",
+                html: "a&radic;<span class='root'>3</span>",
                 calc: function(a){
                     return a * Math.sqrt(3);
                 }
@@ -281,7 +281,7 @@
                 }
             }, {
                 name: "diagonal",
-                html: "&radic;(a<sup>2</sup> + b<sup>2</sup> + c<sup>2</sup>)",
+                html: "&radic;<span class='root'>a<sup>2</sup> + b<sup>2</sup> + c<sup>2</sup></span>",
                 calc: function(a, b, c){
                     return Math.sqrt(a * a + b * b + c * c);
                 }

--- a/share/spice/geometry/geometry.js
+++ b/share/spice/geometry/geometry.js
@@ -1,0 +1,55 @@
+(function(env){
+    "use strict";
+
+    env.ddg_spice_geometry = function(){
+        var data = {
+            formulas: [{
+                name: "Area",
+                symbol: "A",
+                formula: "a\u00B2"
+            }, {
+                name: "Perimeter",
+                symbol: "u",
+                formula: "4a"
+            }, {
+                name: "Diagonal",
+                symbol: "e",
+                formula: "a\u221A2"
+            }],
+            svg: [{
+                path: "M 0,0 h 120 v 120 h -120 z",
+                class: "fill",
+                symbol: "A"
+            }, {
+                path: "M 0,0 h 120 m 0,120 h -120 m 120,0 v -120 m -120,0 v 120",
+                class: "stroke",
+                symbol: "u"
+            }, {
+                path: "M 0,0 l 120,120",
+                class: "stroke special",
+                symbol: "e"
+            }]
+        };
+
+        // Display the plugin.
+        Spice.add({
+            data: data,
+            id: "geometry",
+            templates: {
+                group: "base",
+                options: {
+                    content: Spice.geometry.content
+                }
+            }
+        });
+        var content = Spice.getDOM("geometry"),
+            svg = $("#zci--geometry-svg", content);
+
+        $(window).load(function(){
+            svg.height(content.height());
+            svg.show();
+        });
+    };
+}(this));
+
+ddg_spice_geometry();

--- a/share/spice/geometry/geometry.js
+++ b/share/spice/geometry/geometry.js
@@ -69,27 +69,27 @@
     var formulas = {
         volume: {
             symbol: "V",
-            color: "#FF6745"
+            color: "#DE5833"
         },
         area: {
             symbol: "A",
-            color: "#00E204"
+            color: "#F1A031"
         },
         surface: {
             symbol: "A",
-            color: "#00E204"
+            color: "#F1A031"
         },
         perimeter: {
             symbol: "u",
-            color: "#0095FF"
+            color: "#5B9E4D"
         },
         circumference: {
             symbol: "u",
-            color: "#0095FF"
+            color: "#5B9E4D"
         },
         diagonal: {
             symbol: "e",
-            color: "#FF8100"
+            color: "#4495D4"
         }
     };
 
@@ -109,7 +109,7 @@
                 }
             }, {
                 name: "diagonal",
-                html: "a&radic;<span class='root'>2</span>",
+                html: "a&radic;2",
                 calc: function(a){
                     return a * Math.SQRT2;
                 }
@@ -149,7 +149,7 @@
                 }
             }, {
                 name: "diagonal",
-                html: "&radic;<span class='root'>a<sup>2</sup>+b<sup>2</sup></span>",
+                html: "&radic;(a<sup>2</sup>+b<sup>2</sup>)",
                 calc: function(a, b){
                     return Math.sqrt(a * a + b * b);
                 }
@@ -187,7 +187,7 @@
         "equilateral triangle": {
             formulas: [{
                 name: "area",
-                html: "(a<sup>2</sup>*&radic;<span class='root'>3</span>)/4",
+                html: "(a<sup>2</sup>*&radic;3)/4",
                 calc: function(a){
                     return a / 4 * Math.sqrt(3);
                 }
@@ -263,7 +263,7 @@
                 }
             }, {
                 name: "diagonal",
-                html: "a&radic;<span class='root'>3</span>",
+                html: "a&radic;3",
                 calc: function(a){
                     return a * Math.sqrt(3);
                 }
@@ -309,7 +309,7 @@
                 }
             }, {
                 name: "diagonal",
-                html: "&radic;<span class='root'>a<sup>2</sup> + b<sup>2</sup> + c<sup>2</sup></span>",
+                html: "&radic;(a<sup>2</sup> + b<sup>2</sup> + c<sup>2</sup>)",
                 calc: function(a, b, c){
                     return Math.sqrt(a * a + b * b + c * c);
                 }
@@ -484,7 +484,8 @@
 
                 //wait for stylesheet
                 $(window).load(function(){
-                    svg.height(content.height());
+                    //set the height of the svg to the same like the content, but 150 as maximal value
+                    svg.height(Math.min(content.height(), 150));
                     svg.show();
                 });
             }

--- a/share/spice/geometry/geometry.js
+++ b/share/spice/geometry/geometry.js
@@ -435,19 +435,22 @@
                 options: {
                     content: Spice.geometry.content
                 }
+            },
+            onShow: function(){
+                var formulaNodes = $("#zci--geometry-formulas").children(),
+                    svg = $("#zci--geometry-svg"),
+                    svgNodes = svg.children(),
+                    content = svg.parent();
+
+                for(i = 0, l = pairs.length; i < l; ++i)
+                    bindHoverPair([formulaNodes[pairs[i][0]], svgNodes[pairs[i][1]]]);
+
+                $(window).load(function(){
+                    console.log("retzguih");
+                    svg.height(content.height());
+                    svg.show();
+                });
             }
-        });
-        var content = Spice.getDOM("geometry"),
-            formulaNodes = $("#zci--geometry-formulas", content).children(),
-            svg = $("#zci--geometry-svg", content),
-            svgNodes = svg.children();
-
-        for(i = 0, l = pairs.length; i < l; ++i)
-            bindHoverPair([formulaNodes[pairs[i][0]], svgNodes[pairs[i][1]]]);
-
-        $(window).load(function(){
-            svg.height(content.height());
-            svg.show();
         });
     };
 }(this));

--- a/share/spice/geometry/geometry.js
+++ b/share/spice/geometry/geometry.js
@@ -1,18 +1,35 @@
 (function(env){
     "use strict";
 
-    function getParameter(query, trigger){
+    function getParameter(query, trigger, count){
         var regex, result;
-        regex = new RegExp("(?:" + trigger + ")\\s*[=:]?\\s*(\\d+(?:[.,]\\d+)?)");
-        //(?:trigger)\s?[=:]?\s? => matches the name of the formula, following by optional whitespace, = or :, whitespace
-        //(\d+(?:[.,]\d+)?) => matches the number, as integer or float
+        if(!count){
+            regex = new RegExp("(?:" + trigger + ")\\s*[=:]?\\s*(\\d+(?:[.,]\\d+)?)");
+            //(?:trigger)\s?[=:]?\s? => matches the name of the formula, following by optional whitespace, = or :, whitespace
+            //(\d+(?:[.,]\d+)?) => matches the number, as integer or float
 
-        result = query.match(regex);
-        if(result === null) return null; //no match
-        result = result[1].replace(",", "."); //stores the result as string and replace commas with points
-        result = parseFloat(result);
+            result = query.match(regex);
+            if(result === null) return null; //no match
+            result = result[1].replace(",", "."); //stores the result as string and replace commas with points
+            result = parseFloat(result);
 
-        return result;
+            return result;
+        } else {
+            regex = new RegExp("(?:" + trigger + ")\\s*[=:]?\\s*((?:\\d+(?:[.,]\\d+)?)(?:[,;]?\\s+\\d+(?:[.,]\\d+)?){" + count + "})");
+            //(?:trigger)\s?[=:]?\s? => matches the name of the formula, following by optional whitespace, = or :, whitespace
+            //(\d+(?:[.,]\d+)?) => matches the first number, as integer or float
+            //(?:[,;]?\s+\d+(?:[.,]\d+)?){count} => matches all other numbers, as integer or float
+
+            result = query.match(regex);
+            if(result === null) return null; //no match
+            result = result[1].split(/\s+/); //split up the numbers
+            for(var i = 0, l = result.length; i < l; ++i){
+                result[i].replace(",", ".");
+                result[i] = parseFloat(result[i]);
+            }
+
+            return result;
+        }
     }
 
     function format(number){
@@ -82,9 +99,60 @@
                 [2, 2]
             ],
             getParameter: function(query){
-                return getParameter(query, 'a|length|size');
+                return [getParameter(query, "a|length|size")];
             },
-            parameterName: "a"
+            parameterNames: ["a"]
+        },
+        rect: {
+            formulas: [{
+                name: "area",
+                html: "ab",
+                calc: function(a, b){
+                    return a * b;
+                }
+            }, {
+                name: "perimeter",
+                html: "2(a+b)",
+                calc: function(a, b){
+                    return 2 * (a + b);
+                }
+            }, {
+                name: "diagonal",
+                html: "&radic;a<sup>2</sup>+b<sup>2</sup>",
+                calc: function(a, b){
+                    return Math.sqrt(a * a + b * b);
+                }
+            }],
+            svg: [{
+                path: "M 0,0 h 160 v 120 h -160 z",
+                class: "fill"
+            }, {
+                path: "M 0,0 h 160 m 0,120 h -160 m 160,0 v -120 m -160,0 v 120",
+                class: "stroke"
+            }, {
+                path: "M 0,0 l 160,120",
+                class: "stroke special"
+            }],
+            pairs: [
+                [0, 0],
+                [1, 1],
+                [2, 2]
+            ],
+            getParameter: function(query){
+                var p;
+                p = getParameter(query, "length|size", 1);
+                if(p !== null)
+                    return p;
+
+                p = [
+                    getParameter(query, "a"),
+                    getParameter(query, "b")
+                ];
+                if(p[0] !== null && p[1] !== null)
+                    return p;
+                return null;
+            },
+            parameterNames: ["a", "b"]
         }
     };
 
@@ -93,6 +161,7 @@
             shape,
             data = {},
             pairs,
+            parameter,
             i, l,
             j, k,
             got = false;
@@ -114,14 +183,13 @@
         data.formulas = shape.formulas;
         data.svg = shape.svg;
         pairs = shape.pairs;
-        data.parameter = shape.getParameter(query);
-        data.parameterName = shape.parameterName;
+        parameter = shape.getParameter(query);
 
         for(i = 0, l = data.formulas.length; i < l; ++i){
             data.formulas[i].symbol = formulas[data.formulas[i].name];
             data.formulas[i].name = DDG.capitalize(data.formulas[i].name);
             if(data.parameter !== null)
-                data.formulas[i].result = format(data.formulas[i].calc(data.parameter));
+                data.formulas[i].result = format(data.formulas[i].calc.apply(0, parameter));
             if(query.match(data.formulas[i].name, "i")){
                 //cleanup formulas
                 data.formulas = [data.formulas[i]];
@@ -134,6 +202,16 @@
                     }
                 }
                 break;
+            }
+        }
+
+        if(parameter !== null){
+            data.parameter = [];
+            for(i = 0, l = parameter.length; i < l; ++i){
+                data.parameter[i] = {
+                    symbol: shape.parameterNames[i],
+                    value: parameter[i]
+                };
             }
         }
 

--- a/share/spice/geometry/geometry.js
+++ b/share/spice/geometry/geometry.js
@@ -442,6 +442,8 @@
                 }
             },
             onShow: function(){
+                if(!Modernizr.svg) return;
+
                 var formulaNodes = $("#zci--geometry-formulas").children(),
                     svg = $("#zci--geometry-svg"),
                     svgNodes = svg.children(),
@@ -459,3 +461,5 @@
         });
     };
 }(this));
+
+ddg_spice_geometry();

--- a/share/spice/geometry/geometry.js
+++ b/share/spice/geometry/geometry.js
@@ -94,6 +94,7 @@
             data = {},
             pairs,
             i, l,
+            j, k,
             got = false;
 
         for(shape in shapes){
@@ -121,6 +122,19 @@
             data.formulas[i].name = DDG.capitalize(data.formulas[i].name);
             if(data.parameter !== null)
                 data.formulas[i].result = format(data.formulas[i].calc(data.parameter));
+            if(query.match(data.formulas[i].name, "i")){
+                //cleanup formulas
+                data.formulas = [data.formulas[i]];
+                //cleanup pairs
+                for(j = 0, k = pairs.length; j < k; ++j){
+                    //find the right pair
+                    if(pairs[j][0] === i){
+                        pairs = [[0, pairs[j][1]]];
+                        break;
+                    }
+                }
+                break;
+            }
         }
 
         // Display the plugin.

--- a/t/Geometry.t
+++ b/t/Geometry.t
@@ -1,0 +1,28 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+ddg_spice_test(
+    [qw( DDG::Spice::Geometry )],
+    'geometry square' => test_spice(
+        '/js/spice/geometry/',
+        call_type => 'self',
+        caller => 'DDG::Spice::Geometry'
+    ),
+    'area rectangle formula' => test_spice(
+        '/js/spice/geometry/',
+        call_type => 'self',
+        caller => 'DDG::Spice::Geometry'
+    ),
+    'calc volume of a cube with size = 5' => test_spice(
+        '/js/spice/geometry/',
+        call_type => 'self',
+        caller => 'DDG::Spice::Geometry'
+    )
+);
+
+done_testing;
+


### PR DESCRIPTION
This is a converted Goodie, the old PR was duckduckgo/zeroclickinfo-goodies#464

**What does your instant answer do?**
This spice shows geometric formulas (e.g. circle area) with a mockup or calculates them if sizes are specified.

**What are some example queries that trigger this instant answer?**
- formula circle perimeter
- calc circle area with radius = 3
- geometry cube volume length 50.6
- calc equilateral triangle perimeter
- formula ball volume
- geometry rectangle area a = 5,2, b = 10
- geometry cuboid volume a: 5; b: 3; c: 4

**Is this instant answer connected to a DuckDuckHack [instant answer idea](https://duck.co/ideas)?**
Yes, https://duck.co/ideas/idea/1053/geometry-calculator.

**Which existing instant answers will this one supercede/overlap with?**
Not known yet

**Are you having any problems? Do you need our help with anything?**
Only improvement questions:
 - The data is static in [geometry.js, line 68 to 365](https://github.com/pixunil/zeroclickinfo-spice/blob/geometry/share/spice/geometry/geometry.js#L68-365), maybe perl could fetch the shape wanted in a separate js file

- it would be great to get the hover color defined by the user in settings

**Checklist:**

- [x] Added metadata and attribution information
- [x] Wrote test file and added to t/ directory
- [x] Verified that instant answer adheres to design guidelines(https://github.com/duckduckgo/duckduckgo-documentation/blob/master/duckduckhack/styleguides/design_styleguide.md)
- [x] Tested cross-browser compatability *with support tables*

 Browser | supported versions | unsupported feature for older versions
 ----|-----|----
 IE | 10+ | classList
 Firefox | 8+ | classList
 Chrome | 8+ | classList
 Safari | 5.1+ | classList
 Opera | 11.5+ | classList
- [x] Tested live only on Linux (Mint) 64-bit, Firefox 33