### PR TITLE
Make attribution text the same size as the more at text

### DIFF
--- a/share/spice/dictionary/definition/content.handlebars
+++ b/share/spice/dictionary/definition/content.handlebars
@@ -17,6 +17,6 @@
 <div class="zci__def__links">
 	{{{moreAt meta.sourceUrl meta.sourceName}}}
 	<span class="zcm__sep"></span>
-	<span class="zci__def__attribution  tx-clr--lt2">{{meta.attributionText}}</span>
+	<span class="zci__def__attribution  tx-clr--lt2  t-s">{{meta.attributionText}}</span>
 </div>
 


### PR DESCRIPTION
Also fixes wrapping issue

![screen shot 2014-10-30 at 10 18 32 pm](https://cloud.githubusercontent.com/assets/126358/4855387/5444363c-60a4-11e4-8c3c-797b2dd2d5b9.png)

cc @sdougbrown @jagtalon @chrismorast 
