### PR TITLE
Haxelib: Fix favicon.ico

### DIFF
--- a/share/spice/haxelib/haxelib.js
+++ b/share/spice/haxelib/haxelib.js
@@ -11,7 +11,7 @@
             name: "Software",
             data: response.info,
             meta: {
-                sourceIconUrl   : 'http://haxe.org/img/haxe2/favicon.ico',
+                sourceIconUrl   : 'http://haxe.org/favicon.ico',
                 sourceUrl       : 'http://lib.haxe.org/p/' + encodeURIComponent(response.info.name),
                 sourceName      : 'Haxelib'
             },


### PR DESCRIPTION
Replace the dead favicon.ico link http://haxe.org/img/haxe2/favicon.ico with http://haxe.org/favicon.ico
