### PR TITLE
Convert NPM Spice to "text" template (addresses #1224)

### DIFF
--- a/share/spice/npm/content.handlebars
+++ b/share/spice/npm/content.handlebars
@@ -1,5 +1,1 @@
-<h5>
-    {{name}} ({{version}})
-</h5>
-<div>{{description}}</div>
 <pre>$ npm install {{name}}</pre>

--- a/share/spice/npm/npm.js
+++ b/share/spice/npm/npm.js
@@ -14,8 +14,16 @@
                 sourceName: "npmjs.org",
                 sourceUrl: 'http://npmjs.org/package/' + api_result.name
             },
+            
+            normalize: function(item) {
+                return {
+                    title: item.name + " " + item.version,
+                    subtitle: item.description
+                }  
+            },
+
             templates: {
-                group: 'base',
+                group: 'text',
                 options: {
                     content: Spice.npm.content,
                     moreAt: true


### PR DESCRIPTION
Made the changes suggested by @jagtalon to fix #1224 (and learned what the normalize function does in the process :). Here's a screenshot of the updated IA:

![screen shot 2014-11-09 at 12 34 22 am](https://cloud.githubusercontent.com/assets/5326740/4966583/dd985b04-67d2-11e4-91a0-71f0a8db232b.png)
