### PR TITLE
Forecast: switch the wind units as well

### DIFF
--- a/share/spice/forecast/forecast.js
+++ b/share/spice/forecast/forecast.js
@@ -287,11 +287,12 @@ function ddg_spice_forecast(r) {
   }
 
   var convertSpeed = function(from, to, val){
+    // http://en.wikipedia.org/wiki/Miles_per_hour#Conversions
     var conversionFactors = {
-      'mph-m/s': 0.45,
-      'm/s-mph': 2.24,
+      'mph-m/s': 0.4471,
+      'm/s-mph': 2.237,
       'mph-km/h': 1.609,
-      'km/h-mph': 0.62,
+      'km/h-mph': 0.6214
     };
 
     return val * conversionFactors[from + '-' + to];


### PR DESCRIPTION
Fixes #1250, cc @jagtalon 

![screenshot - 11122014 - 07 17 57 pm](https://cloud.githubusercontent.com/assets/4411471/5021223/a111f390-6aa0-11e4-9c60-1f0f788ee1a0.png)

There is one roadblock I ran into: If the API returns fahrenheit results (`unit == 'us'`), then we can't be sure which unit speed unit to switch to. We have a choice between `km/h` and `m/s`, and I assumed the latter. Maybe this could be a setting?
