### PR TITLE
Lastfm: updated regex [WIP]

### DIFF
--- a/lib/DDG/Spice/Lastfm/Artist.pm
+++ b/lib/DDG/Spice/Lastfm/Artist.pm
@@ -38,11 +38,11 @@ handle query_lc => sub {
         return $1, 'similar';
     }
     #Queries like "weezer band"
-    if(m{(\S+(?:\s+\S+)*)\s+(?:$synonyms)}) {
+    if(m{(\S+(?:\s+\S+)*)\s+(?:$synonyms)$}) {
         return $1, 'all';
     }
     #Queries like "artist kanye west"
-    if(m{(?:$synonyms)\s+(\S+(?:\s+\S+)*)}) {
+    if(m{^(?:$synonyms)\s+(\S+(?:\s+\S+)*)}) {
         return $1, 'all';
     }
     return;


### PR DESCRIPTION
fixes #1150 @jagtalon this should solve the irrelevant popping up of results. Except artist nothing else is ported to the new spice api, is that intended? We have no test for lastfm as well, so ill write that, once you provide feedback on this matter ( will need the key as well ).
