### PR TITLE
time.js: correct July typo.

### DIFF
--- a/share/spice/time/time.js
+++ b/share/spice/time/time.js
@@ -25,7 +25,7 @@
         }
 
         var dateObj = DDG.getDateFromString(chosen.time.iso),
-            months = ['January', 'February', 'March', 'April', 'May', 'June', 'Jully', 'August', 'September', 'October', 'November', 'December'],
+            months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
             days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
         //Convert 24 hour time to 12 hour time


### PR DESCRIPTION
Replace 'Jully' with 'July'.
