### PR TITLE
Strawman fix for #1254: add timezone to stocks

### DIFF
--- a/share/spice/stocks/content.handlebars
+++ b/share/spice/stocks/content.handlebars
@@ -5,7 +5,8 @@
 </h1>
 <div class="stocks__sub  zci__header__sub">
     <span class="stocks__symbol">{{symbol}}</span>
-    <span>as of {{quote_date}} EST</span>
+    <span>as of {{quote_date}}</span>
+    <span title="Eastern Time Zone"> ET</span>
 </div>
 <div class="stocks__quotes  stocks__quote-{{quoteChangeDir}}">
     <span class="stocks__quote text--primary">{{quote}}</span>


### PR DESCRIPTION
This PR hard-codes "EST" to the content template to address #1254. Based on the news feeds at YCharts, as well as the times for the 1-day stock charts, EST should be the correct time zone to display. However, as shown below in the JSON response from YCharts, it looks like YCharts does not directly specify the time zone for its data. Here's an example of a logged callback function:

<code>ddg_spice_stocks( [{"name": "Apple", "url": "/companies/AAPL", "quote": "115.47", "symbol": "AAPL", "friendly_name": "Apple", "change_percent": "+1.30%", "change": "+1.48", "quote_date": "Nov 18 08:00PM"}]); 
</code>

From digging around the website, it seems that YCharts is only returning information from American Exchanges (for example, ARM returns Arm Holdings, ARMH, on NASDAQ even though ARM is actually listed on the London Stock Exchange; and ticker symbols that exist on American and international exchanges but refer to different companies return information for the American company). So, if we are okay hard-coding the time zone into the template, then this PR should suffice. (I was unable to find documentation about YCharts' API to dig a little deeper into whether or not we could use another endpoint that would embed the timezone.)

I noticed something odd when trying to test this (hence, no screenshot): when running a browser query, I received an API key error, but then the attempt to use DDG's endpoint led to a syntax error in my browser due to something in <code>http://10.0.1.23:5000/js/spice/zipcode/AAPL/ZZ</code>, and I was unable to pull up the stock quote using my local DuckPAN server. Should I have been able to make this work locally, out of curiosity? 

Here's the server log for my local query attempt:

<pre><code>DDG::ZeroClickInfo::Spice  {
    Parents       Moo::Object
    public methods (8) : call, call_data, call_path, call_type, has_call, has_call_data, has_call_type, new
    private methods (0)
    internals: {
        call        "/js/spice/zipcode/AAPL/ZZ",
        caller      "DDG::Spice::Zipcode",
        call_type   "include",
        is_cached   1,
        is_unsafe   0
    }
}
10.0.1.13 - - [19/Nov/2014:02:30:53 -0500] "GET /?q=aapl HTTP/1.1" 200 5077 "http://10.0.1.23:5000/?q=aap" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:33.0) Gecko/20100101 Firefox/33.0"
10.0.1.13 - - [19/Nov/2014:02:30:53 -0500] "GET /?duckduckhack_css=1 HTTP/1.1" 200 270042 "http://10.0.1.23:5000/?q=aapl" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:33.0) Gecko/20100101 Firefox/33.0"
10.0.1.13 - - [19/Nov/2014:02:30:53 -0500] "GET /?duckduckhack_ignore=1 HTTP/1.1" 204 0 "http://10.0.1.23:5000/?q=aapl" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:33.0) Gecko/20100101 Firefox/33.0"
10.0.1.13 - - [19/Nov/2014:02:30:53 -0500] "GET /?duckduckhack_locales=1 HTTP/1.1" 200 85914 "http://10.0.1.23:5000/?q=aapl" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:33.0) Gecko/20100101 Firefox/33.0"
10.0.1.13 - - [19/Nov/2014:02:30:53 -0500] "GET /?duckduckhack_js=1 HTTP/1.1" 200 451729 "http://10.0.1.23:5000/?q=aapl" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:33.0) Gecko/20100101 Firefox/33.0"
10.0.1.13 - - [19/Nov/2014:02:30:53 -0500] "GET /?duckduckhack_templates=1 HTTP/1.1" 200 126786 "http://10.0.1.23:5000/?q=aapl" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:33.0) Gecko/20100101 Firefox/33.0"
10.0.1.13 - - [19/Nov/2014:02:30:53 -0500] "GET /share/spice/zipcode/zipcode.js HTTP/1.1" 200 1985 "http://10.0.1.23:5000/?q=aapl" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:33.0) Gecko/20100101 Firefox/33.0"
10.0.1.13 - - [19/Nov/2014:02:30:53 -0500] "GET /?duckduckhack_ignore=1& HTTP/1.1" 204 0 "http://10.0.1.23:5000/?q=aapl" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:33.0) Gecko/20100101 Firefox/33.0"
10.0.1.13 - - [19/Nov/2014:02:30:54 -0500] "GET /?duckduckhack_js=1 HTTP/1.1" 200 451729 "http://10.0.1.23:5000/?q=aapl" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:33.0) Gecko/20100101 Firefox/33.0"
10.0.1.13 - - [19/Nov/2014:02:30:54 -0500] "GET /js/mapbox/mapbox-1.6.2.css HTTP/1.1" 200 15311 "http://10.0.1.23:5000/?q=aapl" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:33.0) Gecko/20100101 Firefox/33.0"
10.0.1.13 - - [19/Nov/2014:02:30:54 -0500] "GET /country.json HTTP/1.1" 200 17 "http://10.0.1.23:5000/?q=aapl" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:33.0) Gecko/20100101 Firefox/33.0"
10.0.1.13 - - [19/Nov/2014:02:30:54 -0500] "GET /js/mapbox/mapbox-1.6.2.js HTTP/1.1" 200 194530 "http://10.0.1.23:5000/?q=aapl" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:33.0) Gecko/20100101 Firefox/33.0"

API key not found. Using DuckDuckGo's endpoint:
"https://ddh1.duckduckgo.com/js/spice/zipcode/AAPL/ZZ"
10.0.1.13 - - [19/Nov/2014:02:30:55 -0500] "GET /js/spice/zipcode/AAPL/ZZ HTTP/1.1" 200 5433 "http://10.0.1.23:5000/?q=aapl" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:33.0) Gecko/20100101 Firefox/33.0"
10.0.1.13 - - [19/Nov/2014:02:30:55 -0500] "GET /assets/flags/16/wt.png?v=3 HTTP/1.1" 200 1479 "http://10.0.1.23:5000/?q=aapl" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:33.0) Gecko/20100101 Firefox/33.0"
10.0.1.13 - - [19/Nov/2014:02:30:55 -0500] "GET /country.json HTTP/1.1" 200 17 "http://10.0.1.23:5000/?q=aapl" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:33.0) Gecko/20100101 Firefox/33.0"
</code></pre>
