### PR TITLE
Envato: Fix Audio Duration Split

### DIFF
--- a/share/spice/envato/envato.js
+++ b/share/spice/envato/envato.js
@@ -45,7 +45,7 @@
 
         if (marketplace && marketplace[0] == 'audiojungle'){
             spice.normalize = function(item){
-                var info = item.item_info, duration = 0, x = info.length.split(':')
+                var info = item.item_info, duration = 0, x = info.length_audio.split(':')
 
                 switch (x.length){
                     case 1:


### PR DESCRIPTION
Fixes #1292

Looks like the API changed `length` to `length_audio` or it was `length_audio` all along :smile: 

//cc @jagtalon @mobily
