### PR TITLE
Lastfm (ArtistTracks): Port to new spice api 

### DIFF
--- a/share/spice/lastfm/artist_tracks/lastfm_artist_tracks.css
+++ b/share/spice/lastfm/artist_tracks/lastfm_artist_tracks.css
@@ -1,0 +1,5 @@
+.zci--lastfm_artist_tracks .tile__title {
+    height: 1.25em;
+    margin-bottom: 0 !important;
+    white-space: nowrap;
+}

--- a/share/spice/lastfm/artist_tracks/lastfm_artist_tracks.handlebars
+++ b/share/spice/lastfm/artist_tracks/lastfm_artist_tracks.handlebars
@@ -1,1 +1,0 @@
-<a href="{{url}}">{{name}}</a>

--- a/share/spice/lastfm/artist_tracks/lastfm_artist_tracks.js
+++ b/share/spice/lastfm/artist_tracks/lastfm_artist_tracks.js
@@ -1,50 +1,54 @@
-ddg_spice_lastfm_artist_tracks = function (api_result) {
-    // Don't do anything if we find an error.
+(function (env) {
+    "use strict";
+
+    env.ddg_spice_lastfm_artist_tracks = function (api_result) {
     
-    if(api_result.error || !api_result.toptracks || !api_result.toptracks.track || api_result.toptracks.track.length === 0) {
-        Spice.failed('lastfm_artist_tracks');
-    }
-
-    var artist = api_result.toptracks.track[0].artist.name;
-    Spice.add({
-        id: 'lastfm_artist_tracks',
-        name: 'Tracks by ' + artist,
-        data: api_result.toptracks.track,
-        meta: {
-            itemType: 'Tracks',
-            sourceName: 'Last.fm',
-            sourceUrl: 'http://www.last.fm/search?q=' + artist + '&type=track',
-            sourceIconUrl: 'http://cdn.last.fm/flatness/favicon.2.ico'
-        },
-        normalize: function(item) {
-            var seconds = item.duration % 60;
-            if (seconds < 10) {
-                seconds = "0" + seconds;
-            }
- 
-            if (!item.image) {
-                return;
-            }
-
-            return {
-                img: item.image[2]["#text"],
-                heading: item.name,
-                url: item.url,
-                reviewCount: "▶ " + DDG.commifyNumber(item.playcount),
-                price: Math.floor(item.duration / 60) + ":" + seconds,
-            };
-        },
-        templates: {
-            group: 'products',
-            detail: false,
-            item_detail: false,
-            options: {
-                moreAt: true,
-                reviewCount: true
-            }
-        },
-        onShow: function () {
-                Spice.getDOM('lastfm_artist_tracks').find('.stars').hide();
+        // Don't do anything if we find an error.
+        if(api_result.error || !api_result.toptracks || !api_result.toptracks.track || api_result.toptracks.track.length === 0) {
+            Spice.failed('lastfm_artist_tracks');
         }
-    });
-};
+
+        var artist = api_result.toptracks.track[0].artist.name;
+        Spice.add({
+            id: 'lastfm_artist_tracks',
+            name: 'Tracks by ' + artist,
+            data: api_result.toptracks.track,
+            meta: {
+                itemType: 'Tracks',
+                sourceName: 'Last.fm',
+                sourceUrl: 'http://www.last.fm/search?q=' + artist + '&type=track',
+                sourceIconUrl: 'http://cdn.last.fm/flatness/favicon.2.ico'
+            },
+            normalize: function(item) {
+                var seconds = item.duration % 60;
+                if (seconds < 10) {
+                    seconds = "0" + seconds;
+                }
+ 
+                if (!item.image) {
+                    return;
+                }
+
+                return {
+                    img: item.image[2]["#text"],
+                    heading: item.name,
+                    url: item.url,
+                    reviewCount: "▶ " + DDG.commifyNumber(item.playcount),
+                    price: Math.floor(item.duration / 60) + ":" + seconds,
+                };
+            },
+            templates: {
+                group: 'products',
+                detail: false,
+                item_detail: false,
+                options: {
+                    moreAt: true,
+                    reviewCount: true
+                }
+            },
+            onShow: function () {
+                Spice.getDOM('lastfm_artist_tracks').find('.stars').hide();
+            }
+        });
+    };
+}(this));

--- a/share/spice/lastfm/artist_tracks/lastfm_artist_tracks.js
+++ b/share/spice/lastfm/artist_tracks/lastfm_artist_tracks.js
@@ -1,28 +1,50 @@
-function ddg_spice_lastfm_artist_tracks (api_result) {
-
+ddg_spice_lastfm_artist_tracks = function (api_result) {
     // Don't do anything if we find an error.
+    
     if(api_result.error || !api_result.toptracks || !api_result.toptracks.track || api_result.toptracks.track.length === 0) {
-        return;
+        Spice.failed('lastfm_artist_tracks');
     }
 
     var artist = api_result.toptracks.track[0].artist.name;
     Spice.add({
-        data              : api_result,
-        header1           : "Tracks from " + artist,
-        sourceName       : "Last.fm",
-        sourceUrl        : "http://www.last.fm/search?q=" + artist + "&type=track",
-
-	id        : "lastfm_artist_tracks",
-        template_frame    : "list",
-        templates  : {
-            items: api_result.toptracks.track,
-            item: Spice.lastfm_artist_tracks.lastfm_artist_tracks,
-            show: 3,
-            max: 10,
-            type: "ul"
+        id: 'lastfm_artist_tracks',
+        name: 'Tracks by ' + artist,
+        data: api_result.toptracks.track,
+        meta: {
+            itemType: 'Tracks',
+            sourceName: 'Last.fm',
+            sourceUrl: 'http://www.last.fm/search?q=' + artist + '&type=track',
+            sourceIconUrl: 'http://cdn.last.fm/flatness/favicon.2.ico'
         },
+        normalize: function(item) {
+            var seconds = item.duration % 60;
+            if (seconds < 10) {
+                seconds = "0" + seconds;
+            }
+ 
+            if (!item.image) {
+                return;
+            }
 
-        
-        
+            return {
+                img: item.image[2]["#text"],
+                heading: item.name,
+                url: item.url,
+                reviewCount: "▶ " + DDG.commifyNumber(item.playcount),
+                price: Math.floor(item.duration / 60) + ":" + seconds,
+            };
+        },
+        templates: {
+            group: 'products',
+            detail: false,
+            item_detail: false,
+            options: {
+                moreAt: true,
+                reviewCount: true
+            }
+        },
+        onShow: function () {
+                Spice.getDOM('lastfm_artist_tracks').find('.stars').hide();
+        }
     });
 };

--- a/share/spice/lastfm/artist_tracks/lastfm_artist_tracks_item.handlebars
+++ b/share/spice/lastfm/artist_tracks/lastfm_artist_tracks_item.handlebars
@@ -1,1 +1,0 @@
-<a href="{{url}}">{{name}}</a>


### PR DESCRIPTION
@jagtalon i think we need another template design, for item (image + two column split).
![lastfmat](https://cloud.githubusercontent.com/assets/1424236/5243529/ca81dac2-7966-11e4-8fa1-6e21579b7f73.png)
