### PR TITLE
Lastfm (TopTracks): Port to new spice api

### DIFF
--- a/share/spice/lastfm/top_tracks/lastfm_top_tracks.handlebars
+++ b/share/spice/lastfm/top_tracks/lastfm_top_tracks.handlebars
@@ -1,1 +1,0 @@
-<a href="{{url}}">{{name}}</a> by <a href="{{artist.url}}">{{artist.name}}</a>

--- a/share/spice/lastfm/top_tracks/lastfm_top_tracks.js
+++ b/share/spice/lastfm/top_tracks/lastfm_top_tracks.js
@@ -1,48 +1,52 @@
-ddg_spice_lastfm_top_tracks = function (api_result) {
+(function (env) {
+    "use strict";
+    env.ddg_spice_lastfm_top_tracks = function (api_result) {
 
-    if(api_result.error || !api_result.toptracks || !api_result.toptracks.track || api_result.toptracks.track.length === 0) {
-        Spice.failed('lastfm_top_tracks');
-    }
- 
-    Spice.add({
-        id: 'lastfm_top_tracks',
-        name: 'Top Songs (' + api_result.toptracks['@attr'].country + ')',
-        data: api_result.toptracks.track,
-        meta: {
-            itemType: 'Tracks',
-            sourceName: 'Last.fm',
-            sourceUrl: 'http://www.last.fm/charts/tracks/top',
-            sourceIconUrl: 'http://cdn.last.fm/flatness/favicon.2.ico'
-        },
-        normalize: function(item) {
-            var seconds = item.duration % 60;
-            if (seconds < 10) {
-                seconds = "0" + seconds;
-            }
- 
-            if (!item.image) {
-                return;
-            }
-
-            return {
-                img: item.image[2]["#text"],
-                heading: item.name + " - " +item.artist.name,
-                url: item.url,
-                reviewCount: "〜 " + DDG.commifyNumber(item.listeners),
-                price: Math.floor(item.duration / 60) + ":" + seconds,
-            };
-        },
-        templates: {
-            group: 'products',
-            detail: false,
-            item_detail: false,
-            options: {
-                moreAt: true,
-                reviewCount: true
-            }
-        },
-        onShow: function () {
-                Spice.getDOM('lastfm_top_tracks').find('.stars').hide();
+        if(api_result.error || !api_result.toptracks || !api_result.toptracks.track || api_result.toptracks.track.length === 0) {
+            Spice.failed('lastfm_top_tracks');
         }
-    });
-}
+ 
+        Spice.add({
+            id: 'lastfm_top_tracks',
+            name: 'Top Songs (' + api_result.toptracks['@attr'].country + ')',
+            data: api_result.toptracks.track,
+            meta: {
+                itemType: 'Tracks',
+                sourceName: 'Last.fm',
+                sourceUrl: 'http://www.last.fm/charts/tracks/top',
+                sourceIconUrl: 'http://cdn.last.fm/flatness/favicon.2.ico'
+            },
+            normalize: function(item) {
+                var seconds = item.duration % 60;
+                if (seconds < 10) {
+                    seconds = "0" + seconds;
+                }
+ 
+                if (!item.image) {
+                    return;
+                }
+
+                return {
+                    img: item.image[2]["#text"],
+                    heading: item.name + " - " +item.artist.name,
+                    url: item.url,
+                    reviewCount: "♬ " + DDG.commifyNumber(item.listeners),
+                    price: Math.floor(item.duration / 60) + ":" + seconds,
+                };
+            },
+            templates: {
+                group: 'products',
+                detail: false,
+                item_detail: false,
+                options: {
+                    moreAt: true,
+                    reviewCount: true
+                }
+            },
+            onShow: function () {
+                Spice.getDOM('lastfm_top_tracks').find('.stars').hide();
+            }
+        });
+    };
+}(this));
+

--- a/share/spice/lastfm/top_tracks/lastfm_top_tracks.js
+++ b/share/spice/lastfm/top_tracks/lastfm_top_tracks.js
@@ -1,29 +1,48 @@
-function ddg_spice_lastfm_top_tracks(api_result) {
+ddg_spice_lastfm_top_tracks = function (api_result) {
+
+    if(api_result.error || !api_result.toptracks || !api_result.toptracks.track || api_result.toptracks.track.length === 0) {
+        Spice.failed('lastfm_top_tracks');
+    }
+ 
     Spice.add({
-        data             : api_result,
-        header1          : "Top Songs (" + api_result.toptracks["@attr"].country + ")",
-        sourceName      : "Last.fm",
-        sourceUrl       : "http://www.last.fm/charts/tracks/top",
+        id: 'lastfm_top_tracks',
+        name: 'Top Songs (' + api_result.toptracks['@attr'].country + ')',
+        data: api_result.toptracks.track,
+        meta: {
+            itemType: 'Tracks',
+            sourceName: 'Last.fm',
+            sourceUrl: 'http://www.last.fm/charts/tracks/top',
+            sourceIconUrl: 'http://cdn.last.fm/flatness/favicon.2.ico'
+        },
+        normalize: function(item) {
+            var seconds = item.duration % 60;
+            if (seconds < 10) {
+                seconds = "0" + seconds;
+            }
+ 
+            if (!item.image) {
+                return;
+            }
 
-	id       : "lastfm_top_tracks",
-	template_frame   : "list",
-	templates : {
-	    items: api_result.toptracks.track,
-	    item: Spice.lastfm_top_tracks.lastfm_top_tracks,
-	    show: 3,
-	    max: 10,
-	    type: "ul"
-	},
-
-        
-        
+            return {
+                img: item.image[2]["#text"],
+                heading: item.name + " - " +item.artist.name,
+                url: item.url,
+                reviewCount: "〜 " + DDG.commifyNumber(item.listeners),
+                price: Math.floor(item.duration / 60) + ":" + seconds,
+            };
+        },
+        templates: {
+            group: 'products',
+            detail: false,
+            item_detail: false,
+            options: {
+                moreAt: true,
+                reviewCount: true
+            }
+        },
+        onShow: function () {
+                Spice.getDOM('lastfm_top_tracks').find('.stars').hide();
+        }
     });
 }
-
-Handlebars.registerHelper('list', function(items, options) {
-    var out = "";
-    for(var i = 0; i < items.length && i < 5; i += 1) {
-        out += options.fn(items[i]);
-    }
-    return out;
-});

--- a/share/spice/lastfm/top_tracks/lastfm_top_tracks_item.handlebars
+++ b/share/spice/lastfm/top_tracks/lastfm_top_tracks_item.handlebars
@@ -1,1 +1,0 @@
-<a href="{{url}}">{{name}}</a> by <a href="{{artist.url}}">{{artist.name}}</a>


### PR DESCRIPTION
@jagtalon I didnt include the css changes as with #1301, so lmk know your thoughts, comparing this. Also we need a better sign for ~ (it represents listeners, the play button was for playcount). Also should we limit result to 20? or what value?
![toptracks](https://cloud.githubusercontent.com/assets/1424236/5243828/7ee5e294-796a-11e4-81b0-c8588791f781.png)
