### PR TITLE
InEveryLang: Avoid false positives by looking for extra words

### DIFF
--- a/lib/DDG/Spice/InEveryLang.pm
+++ b/lib/DDG/Spice/InEveryLang.pm
@@ -67,6 +67,8 @@ handle query_lc => sub {
         $language =~ s/plus/\+/g;
         $language =~ s/dash/\-/g;
 
+        $raw_language =~ s/\+/\\\+/g;
+
         $_ =~ s/$raw_language//;
         $_ =~ s/in|examples?|solutions?|code|help|bugs?|\s//g;
 


### PR DESCRIPTION
@moollaza 

Summary of change:
1. strip out the matched puzzle name from the `query_lc`
2. strip out the raw language named from `query_lc`
3. strip out whitespace, as well as the words `in`, `example`, `solutions`, `code`, `help`, and `bug` from `query_lc`
4. If `query_lc` still has any characters in it, fail. Otherwise, return the puzzle and language
