### PR TITLE
WordMap: Design update

### DIFF
--- a/share/spice/word_map/content.handlebars
+++ b/share/spice/word_map/content.handlebars
@@ -1,1 +1,1 @@
-<i>Related to {{entry}}:</i> {{{wordmap_link}}}.
+{{{wordmap_link}}}

--- a/share/spice/word_map/word_map.js
+++ b/share/spice/word_map/word_map.js
@@ -9,17 +9,20 @@
         Spice.add({
             id: 'word_map',
             name: 'Answer',
-            data: api_result,
+            data: {
+                wordmap_link: api_result.wordmap_link,
+                title: "Related to " + api_result.entry + ":",
+            },
             meta: {
                 sourceUrl: 'http://levelpump.com/graph-dictionary.php?mailLink=' + encodeURIComponent(api_result.encrypt_entry) + '&from=ddg',
                 sourceName: 'Levelpump',
                 sourceIconUrl: 'http://icons.duckduckgo.com/ip/www.levelpump.com.ico'
             },
             templates: {
-                group: 'base',
+                group: 'text',
                 options: {
                     content: Spice.word_map.content,
-		    moreAt: true
+		            moreAt: true
                 }
             }
         });


### PR DESCRIPTION
**What did I fix?**
- I fixed the problems from this issue, #1312. In brief, I added a title, moved the template to the `text` group and removed the italics.

![untitled](https://cloud.githubusercontent.com/assets/964245/5327392/c5edd80e-7d43-11e4-8ca7-ee8c9e434054.png)

cc @moollaza 
