### PR TITLE
Add Spice.failed to videos

### DIFF
--- a/share/spice/videos/videos.js
+++ b/share/spice/videos/videos.js
@@ -1,5 +1,9 @@
 function ddg_spice_videos(apiResult) {
 
+    if (!apiResult || !apiResult.results || !apiResult.results.length) {
+        return Spice.failed('videos');
+    }
+
     Spice.add({
         id: 'videos',
         name: 'Videos',


### PR DESCRIPTION
We should return Spice.failed() if there are no useful results so that the back-end knows to either not show the tab or to show that there are no results.
