### PR TITLE
Added Spice.failed() to images

### DIFF
--- a/share/spice/images/images.js
+++ b/share/spice/images/images.js
@@ -1,5 +1,9 @@
 function ddg_spice_images(apiResult) {
 
+    if (!apiResult || !apiResult.results || !apiResult.results.length) {
+        return Spice.failed('images');
+    }
+
     Spice.add({
         id: 'images',
         name: 'Images',


### PR DESCRIPTION
We should return Spice.failed() if there are no useful results so that the back-end knows to either not show the tab or to show that there are no results (same change as #1333).
