### PR TITLE
Improvement: limited timer digits to a proper value

### DIFF
--- a/share/spice/timer/timer.js
+++ b/share/spice/timer/timer.js
@@ -8,7 +8,7 @@ License: CC BY-NC 3.0 http://creativecommons.org/licenses/by-nc/3.0/
     "use strict";
 
     var started = false;
-    var MAX_TIME = 60039;
+    var MAX_TIME = 59999; // => 999m59s
 
     env.ddg_spice_timer = function(api_result) {
         Spice.add({


### PR DESCRIPTION
As suggested here https://github.com/duckduckgo/zeroclickinfo-spice/issues/1327, I fixed ( limited ) timer value to a max that can be displayed without break the page's layout
