### PR TITLE
Namecheap Instant Answer

### DIFF
--- a/lib/DDG/Spice/IsItUp.pm
+++ b/lib/DDG/Spice/IsItUp.pm
@@ -2,6 +2,7 @@ package DDG::Spice::IsItUp;
 
 use strict;
 use DDG::Spice;
+use DDG::Util::SpiceConstants;
 
 primary_example_queries "is duckduckgo.com up";
 secondary_example_queries "is reddit.com working?";
@@ -19,7 +20,7 @@ spice to => 'http://isitup.org/$1.json?callback={{callback}}';
 
 spice proxy_cache_valid => "418 1d";
 
-my $regex_domain = qr/\.(c(?:o(?:m|op)?|at?|[iykgdmnxruhcfzvl])|o(?:rg|m)|n(?:et?|a(?:me)?|[ucgozrfpil])|e(?:d?u|[gechstr])|i(?:n(?:t|fo)?|[stqldroem])|m(?:o(?:bi)?|u(?:seum)?|i?l|[mcyvtsqhaerngxzfpwkd])|g(?:ov|[glqeriabtshdfmuywnp])|b(?:iz?|[drovfhtaywmzjsgbenl])|t(?:r(?:avel)?|[ncmfzdvkopthjwg]|e?l)|k[iemygznhwrp]|s[jtvberindlucygkhaozm]|u[gymszka]|h[nmutkr]|r[owesu]|d[kmzoej]|a(?:e(?:ro)?|r(?:pa)?|[qofiumsgzlwcnxdt])|p(?:ro?|[sgnthfymakwle])|v[aegiucn]|l[sayuvikcbrt]|j(?:o(?:bs)?|[mep])|w[fs]|z[amw]|f[rijkom]|y[eut]|qa)$/;
+my $regex_domain = qr/\.(@{[ DDG::Util::SpiceConstants::TLD_REGEX  ]})$/;
 my $regex_ipv4 = qr/^(?:\d{1,3}\.){3}\d{1,3}$/;
 
 handle matches => sub {

--- a/lib/DDG/Spice/Namecheap.pm
+++ b/lib/DDG/Spice/Namecheap.pm
@@ -8,7 +8,7 @@ use List::Util qw(pairmap);
 spice is_cached => 0; # do not cache query
 
 
-my $namecheap_endpoint = $ENV{DDG_SPICE_NAMECHEAP_ENDPOINT} || 'https://api.namecheap.com/xml.response';
+my $namecheap_endpoint = 'http://api.namecheap.com/xml.response';
 
 # environment variables:
 # DDG_SPICE_NAMECHEAP_USERNAME : Namecheap API username

--- a/lib/DDG/Spice/Namecheap.pm
+++ b/lib/DDG/Spice/Namecheap.pm
@@ -25,12 +25,12 @@ my @query_list = (
 );
 
 my $query_url = uri_escape("$namecheap_endpoint?") . join( uri_escape('&'), pairmap {
-	# the param must always be escaped
-	my $param = uri_escape("$a=");
-	# the value must not be escaped if it is part of the environment or argument
-	my $val = $b;
-	"$param$val";
-	} @query_list );
+        # the param must always be escaped
+        my $param = uri_escape("$a=");
+        # the value must not be escaped if it is part of the environment or argument
+        my $val = $b;
+        "$param$val";
+    } @query_list );
 spice to => "https://duckduckgo.com/x.js?u=" . $query_url;
 
 spice wrap_jsonp_callback => 1;

--- a/lib/DDG/Spice/Namecheap.pm
+++ b/lib/DDG/Spice/Namecheap.pm
@@ -5,6 +5,7 @@ use DDG::Spice;
 use Data::Validate::Domain qw(is_domain);
 use List::Util qw(pairmap);
 use URI::Escape;
+use DDG::Util::SpiceConstants;
 
 spice proxy_cache_valid => '418 1d';
 
@@ -66,6 +67,9 @@ handle remainder => sub {
     # get the domain part out
     $remainder =~ $domain_part_regex;
     my $domain = $+{domain};
+
+    # Namecheap API does not allow for subdomains
+    return unless $domain =~ /^[^.]+\.@{[ DDG::Util::SpiceConstants::TLD_REGEX ]}$/;
 
     # must be a valid domain
     return unless is_domain($domain);

--- a/lib/DDG/Spice/Namecheap.pm
+++ b/lib/DDG/Spice/Namecheap.pm
@@ -49,7 +49,7 @@ attribution github => ["tejas-manohar", "Tejas Manohar"],
             twitter => "tejasmanohar";
 
 # Triggers
-triggers any => "namecheap";
+triggers startend => "namecheap";
 
 my $domain_part_regex = qr|
                           (?:http://)?       # HTTP protocol scheme part [optional]

--- a/lib/DDG/Spice/Namecheap.pm
+++ b/lib/DDG/Spice/Namecheap.pm
@@ -8,8 +8,7 @@ use List::Util qw(pairmap);
 spice is_cached => 0; # do not cache query
 
 
-#my $namecheap_endpoint = 'https://api.namecheap.com/xml.response';
-my $namecheap_endpoint = 'https://api.sandbox.namecheap.com/xml.response'; # sandbox access for testing
+my $namecheap_endpoint = $ENV{DDG_SPICE_NAMECHEAP_ENDPOINT} || 'https://api.namecheap.com/xml.response';
 
 # environment variables:
 # DDG_SPICE_NAMECHEAP_USERNAME : Namecheap API username

--- a/lib/DDG/Spice/Namecheap.pm
+++ b/lib/DDG/Spice/Namecheap.pm
@@ -26,7 +26,7 @@ my @query_list = (
 my $query_url = "$namecheap_endpoint?". join('&', pairmap { "$a=$b" } @query_list );
 spice to => "https://duckduckgo.com/x.js?u=$query_url";
 
-spice wrap_string_callback => 1;
+spice wrap_jsonp_callback => 1;
 
 # Metadata for this spice
 name "Namecheap DNS";

--- a/lib/DDG/Spice/Namecheap.pm
+++ b/lib/DDG/Spice/Namecheap.pm
@@ -1,0 +1,70 @@
+package DDG::Spice::Namecheap;
+# ABSTRACT: Queries Namecheap for available domain names.
+
+use DDG::Spice;
+use Data::Validate::Domain qw(is_domain);
+use List::Util qw(pairmap);
+
+spice is_cached => 0; # do not cache query
+
+
+#my $namecheap_endpoint = 'https://api.namecheap.com/xml.response';
+my $namecheap_endpoint = 'https://api.sandbox.namecheap.com/xml.response'; # sandbox access for testing
+
+# environment variables:
+# DDG_SPICE_NAMECHEAP_USERNAME : Namecheap API username
+# DDG_SPICE_NAMECHEAP_APIKEY   : Namecheap API key
+# DDG_SPICE_NAMECHEAP_IP_ADDR  : Allowed end-User IP address
+my @query_list = (
+    ApiUser    => '{{ENV{DDG_SPICE_NAMECHEAP_USERNAME}}}', # Username required to access the API
+    ApiKey     => '{{ENV{DDG_SPICE_NAMECHEAP_APIKEY}}}',   # Password required used to access the API
+    UserName   => '{{ENV{DDG_SPICE_NAMECHEAP_USERNAME}}}', # same as ApiUser
+    Command    => 'namecheap.domains.check',               # API method
+    ClientIp   => '{{ENV{DDG_SPICE_NAMECHEAP_IP_ADDR}}}',  # End-user IP address
+    DomainList => '$1',                                    # argument to method
+);
+
+my $query_url = "$namecheap_endpoint?". join('&', pairmap { "$a=$b" } @query_list );
+spice to => $query_url;
+
+spice wrap_string_callback => 1;
+
+# Metadata for this spice
+name "Namecheap DNS";
+source "Namecheap";
+icon_url "https://www.namecheap.com/favicon.ico";
+description "Searches for DNS name availability";
+primary_example_queries "namecheap example.com", "namecheap ddg.gg";
+secondary_example_queries "namecheap http://example.com"; # a query that includes HTTP protocol scheme
+category "programming";
+topics 'computing', 'geek', 'programming', 'sysadmin';
+code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/Namecheap.pm";
+attribution github => ["tejas-manohar", "Tejas Manohar"],
+            twitter => "tejasmanohar";
+
+# Triggers
+triggers any => "namecheap";
+
+my $domain_part_regex = qr|
+                          (?:http://)?       # HTTP protocol scheme part [optional]
+                          (?<domain> [^/]* ) # domain part
+                          (?:[^\s]*)         # any path part (e.g., /path/to/file)
+                          |x;
+
+# Handle statement
+handle remainder => sub {
+    my ($remainder) = @_;
+
+    return unless $remainder;    # Guard against "no answer"
+
+    # get the domain part out
+    $remainder =~ $domain_part_regex;
+    my $domain = $+{domain};
+
+    # must be a valid domain
+    return unless is_domain($domain);
+
+    return $domain;
+};
+
+1;

--- a/lib/DDG/Spice/Namecheap.pm
+++ b/lib/DDG/Spice/Namecheap.pm
@@ -24,7 +24,7 @@ my @query_list = (
 );
 
 my $query_url = "$namecheap_endpoint?". join('&', pairmap { "$a=$b" } @query_list );
-spice to => $query_url;
+spice to => "https://duckduckgo.com/x.js?u=$query_url";
 
 spice wrap_string_callback => 1;
 

--- a/lib/DDG/Spice/Namecheap.pm
+++ b/lib/DDG/Spice/Namecheap.pm
@@ -4,6 +4,7 @@ package DDG::Spice::Namecheap;
 use DDG::Spice;
 use Data::Validate::Domain qw(is_domain);
 use List::Util qw(pairmap);
+use URI::Escape;
 
 spice is_cached => 0; # do not cache query
 

--- a/lib/DDG/Spice/Namecheap.pm
+++ b/lib/DDG/Spice/Namecheap.pm
@@ -6,7 +6,7 @@ use Data::Validate::Domain qw(is_domain);
 use List::Util qw(pairmap);
 use URI::Escape;
 
-spice is_cached => 0; # do not cache query
+spice proxy_cache_valid => '418 1d';
 
 
 my $namecheap_endpoint = 'http://api.namecheap.com/xml.response';

--- a/lib/DDG/Spice/Namecheap.pm
+++ b/lib/DDG/Spice/Namecheap.pm
@@ -23,8 +23,14 @@ my @query_list = (
     DomainList => '$1',                                    # argument to method
 );
 
-my $query_url = "$namecheap_endpoint?". join('&', pairmap { "$a=$b" } @query_list );
-spice to => "https://duckduckgo.com/x.js?u=$query_url";
+my $query_url = uri_escape("$namecheap_endpoint?") . join( uri_escape('&'), pairmap {
+	# the param must always be escaped
+	my $param = uri_escape("$a=");
+	# the value must not be escaped if it is part of the environment or argument
+	my $val = $b;
+	"$param$val";
+	} @query_list );
+spice to => "https://duckduckgo.com/x.js?u=" . $query_url;
 
 spice wrap_jsonp_callback => 1;
 

--- a/lib/DDG/Util/SpiceConstants.pm
+++ b/lib/DDG/Util/SpiceConstants.pm
@@ -1,0 +1,9 @@
+package DDG::Util::SpiceConstants;
+
+use strict;
+use warnings;
+
+# regex for allowed TLDS (grabbed from DDG core repo, in /lib/DDG/Util/Constants.pm)
+use constant TLD_REGEX => qr/(?:c(?:o(?:m|op)?|at?|[iykgdmnxruhcfzvl])|o(?:rg|m)|n(?:et?|a(?:me)?|[ucgozrfpil])|e(?:d?u|[gechstr])|i(?:n(?:t|fo)?|[stqldroem])|m(?:o(?:bi)?|u(?:seum)?|i?l|[mcyvtsqhaerngxzfpwkd])|g(?:ov|[glqeriabtshdfmuywnp])|b(?:iz?|[drovfhtaywmzjsgbenl])|t(?:r(?:avel)?|[ncmfzdvkopthjwg]|e?l)|k[iemygznhwrp]|s[jtvberindlucygkhaozm]|u[gymszka]|h[nmutkr]|r[owesu]|d[kmzoej]|a(?:e(?:ro)?|r(?:pa)?|[qofiumsgzlwcnxdt])|p(?:ro?|[sgnthfymakwle])|v[aegiucn]|l[sayuvikcbrt]|j(?:o(?:bs)?|[mep])|w[fs]|z[amw]|f[rijkom]|y[eut]|qa)/i;
+
+1;

--- a/share/spice/namecheap/namecheap.css
+++ b/share/spice/namecheap/namecheap.css
@@ -1,0 +1,14 @@
+@media (max-width: 600px) {
+    .zci--namecheap table {
+        table-layout: fixed;
+        width: 100%;
+    }
+
+    .zci--namecheap table td {
+        word-wrap: break-word;
+    }
+}
+
+.zci--namecheap .zci__more-at {
+    padding-top: 0.75em;
+}

--- a/share/spice/namecheap/namecheap.handlebars
+++ b/share/spice/namecheap/namecheap.handlebars
@@ -6,7 +6,7 @@
 {{else}}
     {{! The domain name can be obtained through DomainAgents. }}
     The domain '<strong>{{domainName}}</strong>' is not available.
-    You can visit <a href="https://domainagents.com/affiliate.php?domain={{domainName}}&code=nc" target="_blank">DomainAgents</a> to negotiate the domain from a seller.
+    You can visit <a href="https://domainagents.com/affiliate.php?domain={{domainName}}&code=nc" target="_blank">DomainAgents</a> to make an offer.
 {{/if}}
 <br />
 </div>

--- a/share/spice/namecheap/namecheap.handlebars
+++ b/share/spice/namecheap/namecheap.handlebars
@@ -1,7 +1,7 @@
 <div>
 {{#if domainAvailable}}
     {{! The domain name can registered through Namecheap. }}
-    The domain '<strong>{{domainName}}</strong>' may be available!
+    The domain '<strong>{{domainName}}</strong>' is available!
     You can visit <a href="https://www.namecheap.com/domains/registration/results.aspx?domain={{domainName}}">Namecheap</a> to register the domain.
 {{else}}
     {{! The domain name can be obtained through DomainAgents. }}

--- a/share/spice/namecheap/namecheap.handlebars
+++ b/share/spice/namecheap/namecheap.handlebars
@@ -1,0 +1,12 @@
+<div>
+{{#if domainAvailable}}
+    {{! The domain name can registered through Namecheap. }}
+    The domain '<strong>{{domainName}}</strong>' may be available!
+    You can visit <a href="https://www.namecheap.com/domains/registration/results.aspx?domain={{domainName}}">Namecheap</a> to register the domain.
+{{else}}
+    {{! The domain name can be obtained through DomainAgents. }}
+    The domain '<strong>{{domainName}}</strong>' is not available.
+    You can visit <a href="https://domainagents.com/affiliate.php?domain={{domainName}}&code=nc" target="_blank">DomainAgents</a> to negotiate the domain from a seller.
+{{/if}}
+<br />
+</div>

--- a/share/spice/namecheap/namecheap.js
+++ b/share/spice/namecheap/namecheap.js
@@ -33,7 +33,7 @@
 
         Spice.add({
             id               : 'namecheap',
-            name             : 'Namecheap domain name',
+            name             : 'Namecheap',
             data             : data,
             header1          : domainName + ' (Namecheap domain name)',
             meta             : {

--- a/share/spice/namecheap/namecheap.js
+++ b/share/spice/namecheap/namecheap.js
@@ -35,7 +35,6 @@
             id               : 'namecheap',
             name             : 'Namecheap',
             data             : data,
-            header1          : domainName + ' (Namecheap domain name)',
             meta             : {
                 sourceName       : 'Namecheap',
                 sourceUrl        : "https://www.namecheap.com/domains/registration/results.aspx?domain=" + domainName

--- a/share/spice/namecheap/namecheap.js
+++ b/share/spice/namecheap/namecheap.js
@@ -1,0 +1,52 @@
+(function (env) {
+    "use strict";
+    env.ddg_spice_namecheap = function(api_result){
+        // turns on/off debugging output
+        var is_debug = false;
+
+        if (!api_result) {
+            if(is_debug) console.log('No API response');/*DEBUG*/
+            return Spice.failed('namecheap');
+        }
+
+        var item = $( $.parseXML(api_result) ).find('DomainCheckResult');
+
+        if (!item) {
+            if(is_debug) console.log('Parsed response does not contain DomainCheckResult');/*DEBUG*/
+            return Spice.failed('namecheap');
+        }
+
+        /* extract data from XML attributes */
+        var available = item.attr('Available');
+        var domainName = item.attr('Domain');
+
+        if ( !available || !domainName ) {
+            if(is_debug) console.log('DomainCheckResult does not return availability');/*DEBUG*/
+            return Spice.failed('namecheap');
+        }
+
+        var data = {
+            domainAvailable: available === "true",
+            domainName: domainName
+        };
+        if(is_debug) console.log('data for template', data);/*DEBUG*/
+
+        Spice.add({
+            id               : 'namecheap',
+            name             : 'Namecheap domain name',
+            data             : data,
+            header1          : domainName + ' (Namecheap domain name)',
+            meta             : {
+                sourceName       : 'Namecheap',
+                sourceUrl        : "https://www.namecheap.com/domains/registration/results.aspx?domain=" + domainName
+            },
+            templates: {
+                group: 'base',
+                options:{
+                    content: Spice.namecheap.namecheap,
+                    moreAt: true
+                }
+            }
+        });
+    }
+}(this));

--- a/share/spice/namecheap/namecheap.js
+++ b/share/spice/namecheap/namecheap.js
@@ -17,7 +17,7 @@
             return Spice.failed('namecheap');
         }
 
-        /* extract data from XML attributes */
+        /* extract data from JSON */
         var available = item.Available;
         var domainName = item.Domain;
 

--- a/share/spice/namecheap/namecheap.js
+++ b/share/spice/namecheap/namecheap.js
@@ -5,7 +5,6 @@
         var is_debug = false;
 
         if (!api_result) {
-            if(is_debug) console.log('No API response');/*DEBUG*/
             return Spice.failed('namecheap');
         }
 
@@ -13,7 +12,6 @@
 
 
         if (!item) {
-            if(is_debug) console.log('Parsed response does not contain DomainCheckResult');/*DEBUG*/
             return Spice.failed('namecheap');
         }
 
@@ -22,7 +20,6 @@
         var domainName = item.Domain;
 
         if ( !available || !domainName ) {
-            if(is_debug) console.log('DomainCheckResult does not return availability');/*DEBUG*/
             return Spice.failed('namecheap');
         }
 
@@ -30,7 +27,6 @@
             domainAvailable: available === "true",
             domainName: domainName
         };
-        if(is_debug) console.log('data for template', data);/*DEBUG*/
 
         Spice.add({
             id               : 'namecheap',

--- a/share/spice/namecheap/namecheap.js
+++ b/share/spice/namecheap/namecheap.js
@@ -9,7 +9,8 @@
             return Spice.failed('namecheap');
         }
 
-        var item = $( $.parseXML(api_result) ).find('DomainCheckResult');
+        var item = api_result.ApiResponse.CommandResponse.DomainCheckResult;
+
 
         if (!item) {
             if(is_debug) console.log('Parsed response does not contain DomainCheckResult');/*DEBUG*/
@@ -17,8 +18,8 @@
         }
 
         /* extract data from XML attributes */
-        var available = item.attr('Available');
-        var domainName = item.attr('Domain');
+        var available = item.Available;
+        var domainName = item.Domain;
 
         if ( !available || !domainName ) {
             if(is_debug) console.log('DomainCheckResult does not return availability');/*DEBUG*/

--- a/share/spice/namecheap/namecheap.js
+++ b/share/spice/namecheap/namecheap.js
@@ -40,8 +40,14 @@
                 sourceName       : 'Namecheap',
                 sourceUrl        : "https://www.namecheap.com/domains/registration/results.aspx?domain=" + domainName
             },
+            normalize: function(item) {
+                return {
+                    title: item.domainName,
+                    subtitle: "Namecheap Domain Search"
+                };
+            },
             templates: {
-                group: 'base',
+                group: 'text',
                 options:{
                     content: Spice.namecheap.namecheap,
                     moreAt: true

--- a/t/Namecheap.t
+++ b/t/Namecheap.t
@@ -1,0 +1,43 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+spice is_cached => 0;
+
+
+ddg_spice_test(
+    [qw(DDG::Spice::Namecheap)],
+    'namecheap ddg.gg'                              => expected_output_for('ddg.gg'),
+    'namecheap http://ddg.gg'                       => expected_output_for('ddg.gg'),
+    'namecheap http://ddg.gg/'                      => expected_output_for('ddg.gg'),
+    'namecheap http://example.com'                  => expected_output_for('example.com'),
+    'namecheap http://example.org'                  => expected_output_for('example.org'),
+    'namecheap http://www.example.org'              => expected_output_for('www.example.org'),
+    'namecheap http://www.example.org/'             => expected_output_for('www.example.org'),
+    'namecheap http://www.example.org/path/to/file' => expected_output_for('www.example.org'),
+
+    # queries which should not trigger
+    'example.com'                    => undef, # no naked domain
+    'namecheap example'              => undef, # does not have a TLD
+    'namecheap test.example.notatld' => undef, # not a valid TLD
+);
+
+# Returns the output we expect to receive from the test
+# when the domain spice is triggered properly.
+sub expected_output_for {
+    # get the domain we expect for the spice trigger
+    my ($domain_expected) = @_;
+    return undef if !defined $domain_expected;
+
+    # return the output we expect for the spice test
+    return test_spice(
+        '/js/spice/namecheap/' . $domain_expected,
+        call_type => 'include',
+        caller => 'DDG::Spice::Namecheap',
+    );
+}
+
+done_testing;

--- a/t/Namecheap.t
+++ b/t/Namecheap.t
@@ -15,11 +15,16 @@ ddg_spice_test(
     'namecheap http://ddg.gg/'                      => expected_output_for('ddg.gg'),
     'namecheap http://example.com'                  => expected_output_for('example.com'),
     'namecheap http://example.org'                  => expected_output_for('example.org'),
-    'namecheap http://www.example.org'              => expected_output_for('www.example.org'),
-    'namecheap http://www.example.org/'             => expected_output_for('www.example.org'),
-    'namecheap http://www.example.org/path/to/file' => expected_output_for('www.example.org'),
+    'namecheap http://moon.io'                      => expected_output_for('moon.io'),
 
     # queries which should not trigger
+    'namecheap http://www.example.org'              => undef, # subdomain is not a domain
+    'namecheap http://www.example.org/'             => undef, # subdomain is not a domain
+    'namecheap http://www.example.org/path/to/file' => undef, # subdomain is not a domain
+    'namecheap http://my.cool.domain.org'           => undef, # subdomain is not a domain
+    'namecheap http://my.cool.domain.co.uk'         => undef, # subdomain is not a domain
+    'namecheap http://jupiters.moon.io'             => undef, # subdomain is not a domain
+
     'example.com'                    => undef, # no naked domain
     'namecheap example'              => undef, # does not have a TLD
     'namecheap test.example.notatld' => undef, # not a valid TLD

--- a/t/Namecheap.t
+++ b/t/Namecheap.t
@@ -5,7 +5,7 @@ use warnings;
 use Test::More;
 use DDG::Test::Spice;
 
-spice is_cached => 0;
+spice is_cached => 1;
 
 
 ddg_spice_test(


### PR DESCRIPTION
**What does your Instant Answer do?**
When a user's query begins with "namecheap", we do a domain lookup to the NC API. If the domain is available, a purchase link to Namecheap is provided. If not, a link to make an offer to the owner is provided via DomainAgents.

**What problem does your Instant Answer solve (Why is it better than organic links)?**
The instant answer provides a simple way of purchasing domains straight from a user's DDG query.

**What is the data source for your Instant Answer? (Provide a link if possible)**
[NameCheap API](https://www.namecheap.com/support/api/intro.aspx)

**Why did you choose this data source?**
It provides responses for TLDs that relate to NameCheap. Modular + expandable :+1: 

**Are there any other alternative (better) data sources?**
Many alternative domain services with APIs... wouldn't say any are better but NameCheap has most relevant data

**What are some example queries that trigger this Instant Answer?**
`namecheap qwoenqwe.com`

**Which communities will this Instant Answer be especially useful for? (gamers, book lovers, etc)**
Domain enthusiasts, web power users, programmers, business owners

**Is this Instant Answer connected to a DuckDuckHack [Instant Answer idea](https://duck.co/ideas)?**
No

**Which existing Instant Answers will this one supersede/overlap with?**
None

**Are you having any problems? Do you need our help with anything?**
We are using jQuery to parse XML into JSON. This works fine, but it may be better as a backend Perl service.

**What are the terms of use for the API? Will DuckDuckGo need specific authorization (e.g. an API key)? Are there any costs associated with API usage?**
No costs. DuckDuckGo needs to acquire [NameCheap API](https://www.namecheap.com/support/api/intro.aspx) keys as instructed in documentation.

**Where did you hear about DuckDuckHack? (For first time contributors)**
Zaahir from DuckDuckGo

### Screenshots
https://imgur.com/I2MHif1,JxbJfEH#0