### PR TITLE
(forecast) Daily Snippet Length

### DIFF
--- a/share/spice/forecast/forecast.css
+++ b/share/spice/forecast/forecast.css
@@ -151,6 +151,7 @@
 	
 	.fe_day .fe_summary {
 		margin-top: 1em;
+		max-height: 5.4em;
 	}
 	
 	.fe_alert {


### PR DESCRIPTION
Was previously limited to 2 lines, the same as the 'current' tile.  This allows for more text.

cc @chrismorast @bsstoner 
