### PR TITLE
Hotfix airlines CSS selectors

### DIFF
--- a/share/spice/airlines/airlines.css
+++ b/share/spice/airlines/airlines.css
@@ -1,61 +1,61 @@
-.tile--route  {
+.tile--airlines  {
     width: 37em;
 }
 
-.zci--route .tile__schedule {
+.zci--airlines .tile__schedule {
     color: #878787;
     font-size: 12px;
 }
 
-.zci--route .tile__time {
+.zci--airlines .tile__time {
     font-size: 2em;
 }
 
-.zci--route .tile__heading {
+.zci--airlines .tile__heading {
     margin-bottom: 1em;
 }
 
-.zci--route .tile__flightID {
+.zci--airlines .tile__flightID {
     font-size: 2em;
     padding-bottom: 0;
     padding-top: 0;
 }
 
-.zci--route .tile__airports {
+.zci--airlines .tile__airports {
     font-size: 1.5em;
     padding-bottom: 0;
     padding-top: 0;
     margin-top: -0.2em;
 }
 
-.zci--route .tile__ok {
+.zci--airlines .tile__ok {
     color: #60AB5D;
 }
 
-.zci--route .tile__not {
+.zci--airlines .tile__not {
     color: #C14316;
 }
 
-.zci--route .tile__date {
+.zci--airlines .tile__date {
     color: #B3B3B3;
     float: right;
     text-align: center;
     font-weight: 600;
 }
 
-.zci--route .tile__week {
+.zci--airlines .tile__week {
     font-size: 12px;
 }
 
-.zci--route .tile__day {
+.zci--airlines .tile__day {
     line-height: 12px;
     font-size: 1.5em;
 }
 
-.zci--route .na {
+.zci--airlines .na {
     color: #999;
 }
 
-.is-mobile .tile--route {
+.is-mobile .tile--airlines {
     width: 100%;
 }


### PR DESCRIPTION
Something didn't work right in this PR: https://github.com/duckduckgo/zeroclickinfo-spice/pull/1271

HTML is still rendering as `zci--airlines` not `zci--routes`, so it's not getting any styles applied. I'm reverting css back to `zci--airlines` for now.

![screen shot 2014-12-19 at 1 37 43 pm_thumb](https://cloud.githubusercontent.com/assets/126358/5514481/b5e97300-8806-11e4-9aea-1778accf52f4.png)

cc @sdougbrown @moollaza @tommytommytommy 
