### PR TITLE
Removes unused import

### DIFF
--- a/lib/DDG/Spice/Forecast.pm
+++ b/lib/DDG/Spice/Forecast.pm
@@ -1,7 +1,5 @@
 package DDG::Spice::Forecast;
 
-use Data::Dumper;
-
 use DDG::Spice;
 use Text::Trim;
 


### PR DESCRIPTION
removes `use Data::Dumper;`
(#1380)
