### PR TITLE
Add favicon to codesearch. Fixes #1388.

### DIFF
--- a/share/spice/code_search/code_search.js
+++ b/share/spice/code_search/code_search.js
@@ -23,7 +23,7 @@
                 record_keys: keys
             },
             meta: {
-                sourceUrl: 'https://searchco.de/?q=' + query + '&cs=true',
+                sourceUrl: 'https://searchcode.com/?q=' + query + '&cs=true',
                 sourceIconUrl: 'https://searchcode.com/static/favicon.ico'
                 sourceName: 'searchcode'
             },

--- a/share/spice/code_search/code_search.js
+++ b/share/spice/code_search/code_search.js
@@ -23,7 +23,8 @@
                 record_keys: keys
             },
             meta: {
-                sourceUrl: 'http://searchco.de/?q=' + query + '&cs=true',
+                sourceUrl: 'https://searchco.de/?q=' + query + '&cs=true',
+                sourceIconUrl: 'https://searchcode.com/static/favicon.ico'
                 sourceName: 'searchcode'
             },
             templates: {

--- a/share/spice/code_search/code_search.js
+++ b/share/spice/code_search/code_search.js
@@ -24,7 +24,7 @@
             },
             meta: {
                 sourceUrl: 'https://searchcode.com/?q=' + query + '&cs=true',
-                sourceIconUrl: 'https://searchcode.com/static/favicon.ico'
+                sourceIconUrl: 'https://searchcode.com/static/favicon.ico',
                 sourceName: 'searchcode'
             },
             templates: {


### PR DESCRIPTION
I added the `sourceIconUrl` as recommended in #1388. Also changed the `sourceUrl` to use https and the same URL.