### PR TITLE
Adding GithubLanguages search

### DIFF
--- a/lib/DDG/Spice/GithubLanguages.pm
+++ b/lib/DDG/Spice/GithubLanguages.pm
@@ -1,0 +1,40 @@
+package DDG::Spice::GithubLanguages;
+# ABSTRACT: Write an abstract here
+# Start at https://duck.co/duckduckhack/spice_overview if you are new
+# to instant answer development
+
+use DDG::Spice;
+
+spice is_cached => 1;
+
+# Metadata.  See https://duck.co/duckduckhack/metadata for help in filling out this section.
+name "GithubLanguages";
+source "";
+icon_url "https://github.com/favicon.ico";
+description "Succinct explanation of what this instant answer does";
+primary_example_queries "first example query", "second example query";
+secondary_example_queries "optional -- demonstrate any additional triggers";
+# Uncomment and complete: https://duck.co/duckduckhack/metadata#category
+# category "";
+# Uncomment and complete: https://duck.co/duckduckhack/metadata#topics
+# topics "";
+code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/GithubLanguages.pm";
+attribution github => ["GitHubAccount", "Friendly Name"],
+            twitter => "twitterhandle";
+
+# Triggers
+my @triggers = share("triggers.txt")->slurp;
+triggers startend => @triggers;
+
+# Handle statement
+handle remainder => sub {
+
+    # optional - regex guard
+    # return unless qr/^\w+/;
+
+    return unless $_;    # Guard against "no answer"
+
+    return $_;
+};
+
+1;

--- a/lib/DDG/Spice/GithubLanguages.pm
+++ b/lib/DDG/Spice/GithubLanguages.pm
@@ -31,7 +31,8 @@ handle query_lc => sub {
     # structuring the search this way gives the first langauge specified
     # precedence. So have 'python javascript' passes the query
     # 'javascript language:python' to github.
-    if ($query =~ /^["']*($langs)\b/ || $query =~ /\b($langs)["']*$/) {
+    #if ($query =~ /^["']*($langs)\b/ || $query =~ /\b($langs)["']*$/) {
+    if (/^["' ]*($langs)\b/ || /\b($langs)["' ]*$/) {
         $l = $1;
     } 
     

--- a/lib/DDG/Spice/GithubLanguages.pm
+++ b/lib/DDG/Spice/GithubLanguages.pm
@@ -28,6 +28,8 @@ triggers startend => @triggers;
 
 my $langs = join("|", @triggers);
 
+spice to => 'https://api.github.com/search/repositories?q=$1&callback={{callback}}';
+
 # Handle statement
 handle query_lc => sub {
 
@@ -35,7 +37,7 @@ handle query_lc => sub {
 
     # optional - regex guard
     # return unless qr/^\w+/;
-    my $lang = m/^\b$langs\b|\b$langs\b$/;
+    my $lang = $query =~ /^$langs\b/;
     $query =~ s/^\b$langs\b|\b$langs\b$//;
     #return unless $_;    # Guard against "no answer"
 

--- a/lib/DDG/Spice/GithubLanguages.pm
+++ b/lib/DDG/Spice/GithubLanguages.pm
@@ -9,39 +9,39 @@ spice is_cached => 1;
 
 # Metadata.  See https://duck.co/duckduckhack/metadata for help in filling out this section.
 name "GithubLanguages";
-source "";
+source "GitHub";
 icon_url "https://github.com/favicon.ico";
-description "Succinct explanation of what this instant answer does";
-primary_example_queries "first example query", "second example query";
-secondary_example_queries "optional -- demonstrate any additional triggers";
+description "Github search by language";
+primary_example_queries "javascript redis", "mongodb javascript";
 # Uncomment and complete: https://duck.co/duckduckhack/metadata#category
-# category "";
+category "programming";
 # Uncomment and complete: https://duck.co/duckduckhack/metadata#topics
-# topics "";
+topics "programming";
 code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/GithubLanguages.pm";
-attribution github => ["GitHubAccount", "Friendly Name"],
-            twitter => "twitterhandle";
+attribution github => ["https://github.com/joerussbowman", "Joe Bowman"],
+            twitter => "joerussbowman";
 
 # Triggers
 my @triggers = share("triggers.txt")->slurp;
 triggers startend => @triggers;
 
+chomp(@triggers);
 my $langs = join("|", @triggers);
 
-spice to => 'https://api.github.com/search/repositories?q=$1&callback={{callback}}';
+spice to => 'https://api.github.com/search/repositories?q=$1&sort=stars&callback={{callback}}';
 
 # Handle statement
 handle query_lc => sub {
 
     my $query = $_;
+    my $l = ""; 
+    if ($query =~ /^($langs)\b/ || $query =~ /\b($langs)$/) {
+        $l = $1;
+    } 
+    
+    $query =~ s/^($langs)\b|(\b$langs)$//;
 
-    # optional - regex guard
-    # return unless qr/^\w+/;
-    my $lang = $query =~ /^$langs\b/;
-    $query =~ s/^\b$langs\b|\b$langs\b$//;
-    #return unless $_;    # Guard against "no answer"
-
-    return "$query language:$lang";
+    return "$query language:$l";
 };
 
 1;

--- a/lib/DDG/Spice/GithubLanguages.pm
+++ b/lib/DDG/Spice/GithubLanguages.pm
@@ -20,7 +20,7 @@ my @triggers = share("triggers.txt")->slurp;
 triggers startend => @triggers;
 
 chomp(@triggers);
-my $langs = join("|", @triggers);
+my $langs = join("|", map(quotemeta, @triggers));
 
 spice to => 'https://api.github.com/search/repositories?q=$1&sort=stars&callback={{callback}}';
 
@@ -28,11 +28,11 @@ handle query_lc => sub {
 
     my $query = $_;
     my $l; 
-    if ($query =~ /^($langs)\b/ || $query =~ /\b($langs)$/) {
+    if ($query =~ /^["']*($langs)\b/ || $query =~ /\b($langs)["']*$/) {
         $l = $1;
     } 
     
-    $query =~ s/^($langs)\b|\b($langs)$//;
+    $query =~ s/^["']*($langs)\b["']*|["']*\b($langs)["']*$//;
     
     # make sure there is an actual query, and not just a language term search
     for ($query) {
@@ -43,7 +43,7 @@ handle query_lc => sub {
         }
     }
     
-    return "$query language:\"$l\"";
+    return "${query} language:\"${l}\"";
 };
 
 1;

--- a/lib/DDG/Spice/GithubLanguages.pm
+++ b/lib/DDG/Spice/GithubLanguages.pm
@@ -26,15 +26,20 @@ attribution github => ["GitHubAccount", "Friendly Name"],
 my @triggers = share("triggers.txt")->slurp;
 triggers startend => @triggers;
 
+my $langs = join("|", @triggers);
+
 # Handle statement
-handle remainder => sub {
+handle query_lc => sub {
+
+    my $query = $_;
 
     # optional - regex guard
     # return unless qr/^\w+/;
+    my $lang = m/^\b$langs\b|\b$langs\b$/;
+    $query =~ s/^\b$langs\b|\b$langs\b$//;
+    #return unless $_;    # Guard against "no answer"
 
-    return unless $_;    # Guard against "no answer"
-
-    return $_;
+    return "$query language:$lang";
 };
 
 1;

--- a/lib/DDG/Spice/GithubLanguages.pm
+++ b/lib/DDG/Spice/GithubLanguages.pm
@@ -32,11 +32,11 @@ handle query_lc => sub {
     # precedence. So have 'python javascript' passes the query
     # 'javascript language:python' to github.
     #if ($query =~ /^["']*($langs)\b/ || $query =~ /\b($langs)["']*$/) {
-    if (/^["' ]*($langs)\b/ || /\b($langs)["' ]*$/) {
+    if (/^["' ]*($langs)/ || /\b($langs)["' ]*$/) {
         $l = $1;
     } 
     
-    $query =~ s/^["']*($langs)\b["']*|["']*\b($langs)["']*$//;
+    $query =~ s/^["']*($langs)["']*|["']*\b($langs)["']*$//;
     
     # make sure there is an actual query, and not just a language term search
     for ($query) {

--- a/lib/DDG/Spice/GithubLanguages.pm
+++ b/lib/DDG/Spice/GithubLanguages.pm
@@ -31,7 +31,6 @@ handle query_lc => sub {
     # structuring the search this way gives the first langauge specified
     # precedence. So have 'python javascript' passes the query
     # 'javascript language:python' to github.
-    #if ($query =~ /^["']*($langs)\b/ || $query =~ /\b($langs)["']*$/) {
     if (/^["' ]*($langs)/ || /\b($langs)["' ]*$/) {
         $l = $1;
     } 

--- a/lib/DDG/Spice/GithubLanguages.pm
+++ b/lib/DDG/Spice/GithubLanguages.pm
@@ -33,7 +33,16 @@ handle query_lc => sub {
     } 
     
     $query =~ s/^($langs)\b|\b($langs)$//;
-
+    
+    # make sure there is an actual query, and not just a language term search
+    for ($query) {
+        s/^\s*//; 
+        s/\s*$//;
+        if ($_ eq "") {
+            return;
+        }
+    }
+    
     return "$query language:\"$l\"";
 };
 

--- a/lib/DDG/Spice/GithubLanguages.pm
+++ b/lib/DDG/Spice/GithubLanguages.pm
@@ -28,6 +28,9 @@ handle query_lc => sub {
 
     my $query = $_;
     my $l; 
+    # structuring the search this way gives the first langauge specified
+    # precedence. So have 'python javascript' passes the query
+    # 'javascript language:python' to github.
     if ($query =~ /^["']*($langs)\b/ || $query =~ /\b($langs)["']*$/) {
         $l = $1;
     } 
@@ -43,6 +46,9 @@ handle query_lc => sub {
         }
     }
     
+    # These is no separate language parameter for the query to 
+    # Github. You specify language as a part of the raw query string
+    # passed to the api like on the web form interface. 
     return "${query} language:\"${l}\"";
 };
 

--- a/lib/DDG/Spice/GithubLanguages.pm
+++ b/lib/DDG/Spice/GithubLanguages.pm
@@ -1,27 +1,21 @@
 package DDG::Spice::GithubLanguages;
-# ABSTRACT: Write an abstract here
-# Start at https://duck.co/duckduckhack/spice_overview if you are new
-# to instant answer development
+# ABSTRACT: Search Github for respositories by language
 
 use DDG::Spice;
 
 spice is_cached => 1;
 
-# Metadata.  See https://duck.co/duckduckhack/metadata for help in filling out this section.
 name "GithubLanguages";
 source "GitHub";
 icon_url "https://github.com/favicon.ico";
 description "Github search by language";
 primary_example_queries "javascript redis", "mongodb javascript";
-# Uncomment and complete: https://duck.co/duckduckhack/metadata#category
 category "programming";
-# Uncomment and complete: https://duck.co/duckduckhack/metadata#topics
 topics "programming";
 code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/GithubLanguages.pm";
 attribution github => ["https://github.com/joerussbowman", "Joe Bowman"],
             twitter => "joerussbowman";
 
-# Triggers
 my @triggers = share("triggers.txt")->slurp;
 triggers startend => @triggers;
 
@@ -30,18 +24,17 @@ my $langs = join("|", @triggers);
 
 spice to => 'https://api.github.com/search/repositories?q=$1&sort=stars&callback={{callback}}';
 
-# Handle statement
 handle query_lc => sub {
 
     my $query = $_;
-    my $l = ""; 
+    my $l; 
     if ($query =~ /^($langs)\b/ || $query =~ /\b($langs)$/) {
         $l = $1;
     } 
     
-    $query =~ s/^($langs)\b|(\b$langs)$//;
+    $query =~ s/^($langs)\b|\b($langs)$//;
 
-    return "$query language:$l";
+    return "$query language:\"$l\"";
 };
 
 1;

--- a/share/spice/github_languages/footer.handlebars
+++ b/share/spice/github_languages/footer.handlebars
@@ -1,0 +1,7 @@
+<div class="tile__update__info one-line">
+  <i class="star starIcon"></i>
+  {{watchers}} &middot; Updated {{GitHub_last_pushed pushed_at}}
+</div>
+
+
+

--- a/share/spice/github_languages/github_languages.css
+++ b/share/spice/github_languages/github_languages.css
@@ -1,0 +1,20 @@
+.tile--github_languages .star.starIcon {
+    margin-top: -5px;
+}
+
+.tile--github_languages .tile__title__sub {
+    text-transform: none;
+    color: #999;
+}
+
+.tile--github_languages .tile__body {
+    height: 14em;
+}
+
+.tile--github_languages .tile__content {
+    height: 6.4em;
+}
+
+.is-mobile_languages .tile--github .tile__content {
+    height: 7em;
+}

--- a/share/spice/github_languages/github_languages.handlebars
+++ b/share/spice/github_languages/github_languages.handlebars
@@ -1,0 +1,4 @@
+<span>{{name}}</span>
+<a href="http://some.url/profile/data1">
+   <img src="/iu/?u=Place a image url here">
+</a>

--- a/share/spice/github_languages/github_languages.js
+++ b/share/spice/github_languages/github_languages.js
@@ -24,7 +24,7 @@
             data: api_result.data.items,
             meta: {
                 sourceName: "GitHub",
-                sourceUrl: sourceUrl,
+                sourceUrl: sourceUrl
             },
             templates:{
                 group: 'text',

--- a/share/spice/github_languages/github_languages.js
+++ b/share/spice/github_languages/github_languages.js
@@ -6,6 +6,9 @@
           return Spice.failed('github');
         }
 
+        // There's a next linkpage link provided by the api, this converts it
+        // to a link to the next page on the actual github search, so by clicking
+        // More on Github you automatically get taken to the next page of results
         var sourceUrl = api_result.meta.Link[0][0].
             replace(/api.github.com\/search\/repositories/, "github.com/search").
             replace("&callback=ddg_spice_github_languages", "").
@@ -43,6 +46,9 @@
     };
 }(this));
 
+// I grabbed this from the GitHub Spice, as well as the css and footer files
+// in an attempt to try and have consistency for GitHub related results. The
+// GitHub Spice was written by Dylan Lloyd.
 Handlebars.registerHelper("GitHub_last_pushed", function(pushed) {
     "use strict";
 

--- a/share/spice/github_languages/github_languages.js
+++ b/share/spice/github_languages/github_languages.js
@@ -9,10 +9,16 @@
         // There's a next linkpage link provided by the api, this converts it
         // to a link to the next page on the actual github search, so by clicking
         // More on Github you automatically get taken to the next page of results
-        var sourceUrl = api_result.meta.Link[0][0].
-            replace(/api.github.com\/search\/repositories/, "github.com/search").
-            replace("&callback=ddg_spice_github_languages", "").
-            replace("&page=2", "&p=2");
+        if (api_result.meta.Link) {
+            var sourceUrl = api_result.meta.Link[0][0].
+                replace(/api.github.com\/search\/repositories/, "github.com/search").
+                replace("&callback=ddg_spice_github_languages", "").
+                replace("&page=2", "&p=2");
+        } else {
+            // Github doesn't include that Link tag if there's only a single page of results.
+            // I don't see a way to grab the query at all, so just send them to GitHub.
+            var sourceUrl = "https://github.com/"
+        }
         
 
         // Render the response

--- a/share/spice/github_languages/github_languages.js
+++ b/share/spice/github_languages/github_languages.js
@@ -1,0 +1,30 @@
+(function (env) {
+    "use strict";
+    env.ddg_spice_github_languages = function(api_result){
+
+        // Validate the response (customize for your Spice)
+        if (api_result.error) {
+            return Spice.failed('github_languages');
+        }
+
+        // Render the response
+        Spice.add({
+            id: "github_languages",
+
+            // Customize these properties
+            name: "AnswerBar title",
+            data: api_result,
+            meta: {
+                sourceName: "Example.com",
+                sourceUrl: 'http://example.com/url/to/details/' + api_result.name
+            },
+            templates: {
+                group: 'your-template-group',
+                options: {
+                    content: Spice.github_languages.content,
+                    moreAt: true
+                }
+            }
+        });
+    };
+}(this));

--- a/share/spice/github_languages/github_languages.js
+++ b/share/spice/github_languages/github_languages.js
@@ -12,17 +12,22 @@
             id: "github_languages",
 
             // Customize these properties
-            name: "AnswerBar title",
-            data: api_result,
+            name: "GitHub Language Search",
+            data: api_result.data.items,
             meta: {
-                sourceName: "Example.com",
-                sourceUrl: 'http://example.com/url/to/details/' + api_result.name
+                sourceName: "GitHub",
+                sourceUrl: 'https://github.com'
             },
-            templates: {
-                group: 'your-template-group',
-                options: {
-                    content: Spice.github_languages.content,
-                    moreAt: true
+            templates:{
+                group: 'text',
+                detail: false,
+		        item_detail: false
+            },
+            normalize : function(item){
+                return{
+                    title: item.name,
+                    url: item.html_url,
+                    description: item.description
                 }
             }
         });

--- a/share/spice/github_languages/triggers.txt
+++ b/share/spice/github_languages/triggers.txt
@@ -1,11 +1,11 @@
 actionscript
-c
 c#
 c++
 clojure
 coffeescript
 common lisp
 css
+c
 diff
 emacs lisp
 erlang
@@ -36,8 +36,8 @@ applescript
 arc
 arduino
 asciidoc
-asp
 aspectj
+asp
 assembly
 ats
 augeas
@@ -76,7 +76,6 @@ cucumber
 cuda
 cycript
 cython
-d
 d-objdump
 darcs patch
 dart
@@ -84,11 +83,12 @@ dm
 dockerfile
 dogescript
 dylan
+d
 e
 eagle
-ec
 ecere projects
 ecl
+ec
 edn
 eiffel
 elixir
@@ -116,16 +116,16 @@ gettext catalog
 glsl
 glyph
 gnuplot
-go
 golo
 gosu
+go
 grace
 grammatical framework
 graph modeling language
 graphviz (dot)
 groff
-groovy
 groovy server pages
+groovy
 hack
 haml
 handlebars
@@ -140,18 +140,18 @@ igor pro
 inform 7
 ini
 inno setup
-io
 ioke
+io
 irc log
 isabelle
-j
 jade
 java server pages
-json
 json5
 jsoniq
 jsonld
+json
 julia
+j
 kit
 kotlin
 krl
@@ -172,7 +172,6 @@ logtalk
 lolcode
 lookml
 lsl
-m
 makefile
 mako
 markdown
@@ -191,6 +190,7 @@ moonscript
 mtml
 mupad
 myghty
+m
 nemerle
 nesc
 netlogo
@@ -214,13 +214,13 @@ opencl
 openedge abl
 openscad
 org
-ox
 oxygene
+ox
 pan
 papyrus
-parrot
 parrot assembly
 parrot internal representation
+parrot
 pascal
 pawn
 perl6
@@ -238,23 +238,24 @@ puppet
 pure data
 purescript
 python traceback
+python
 qmake
 qml
-r
 racket
 ragel in ruby host
 raw token data
 rdoc
 realbasic
 rebol
-red
 redcode
+red
 restructuredtext
 rhtml
 rmarkdown
 robotframework
 rouge
 rust
+r
 sage
 sas
 sass
@@ -262,8 +263,8 @@ scaml
 scilab
 scss
 self
-shell
 shellsession
+shell
 shen
 slash
 slim
@@ -282,8 +283,8 @@ systemverilog
 tcl
 tcsh
 tea
-tex
 textile
+tex
 thrift
 toml
 turing
@@ -306,8 +307,8 @@ xml
 xojo
 xproc
 xquery
-xs
 xslt
+xs
 xtend
 yaml
 zephir

--- a/share/spice/github_languages/triggers.txt
+++ b/share/spice/github_languages/triggers.txt
@@ -1,0 +1,314 @@
+actionscript
+c
+c#
+c++
+clojure
+coffeescript
+common lisp
+css
+diff
+emacs lisp
+erlang
+haskell
+html
+javascript
+java
+lua
+objective-c
+perl
+php
+python
+ruby
+scala
+scheme
+sql
+abap
+ada
+agda
+ags script
+alloy
+ant build system
+antlr
+apacheconf
+apex
+apl
+applescript
+arc
+arduino
+asciidoc
+asp
+aspectj
+assembly
+ats
+augeas
+autohotkey
+autoit
+awk
+batchfile
+befunge
+bison
+blitzbasic
+blitzmax
+bluespec
+boo
+brainfuck
+brightscript
+bro
+c-objdump
+c2hs haskell
+cap'n proto
+ceylon
+chapel
+chuck
+cirru
+clean
+clips
+cmake
+cobol
+coldfusion
+coldfusion cfc
+component pascal
+coq
+cpp-objdump
+creole
+crystal
+cucumber
+cuda
+cycript
+cython
+d
+d-objdump
+darcs patch
+dart
+dm
+dockerfile
+dogescript
+dylan
+e
+eagle
+ec
+ecere projects
+ecl
+edn
+eiffel
+elixir
+elm
+emberscript
+f#
+factor
+fancy
+fantom
+fish
+flux
+forth
+fortran
+frege
+g-code
+game maker language
+gams
+gap
+gas
+gdscript
+genshi
+gentoo ebuild
+gentoo eclass
+gettext catalog
+glsl
+glyph
+gnuplot
+go
+golo
+gosu
+grace
+grammatical framework
+graph modeling language
+graphviz (dot)
+groff
+groovy
+groovy server pages
+hack
+haml
+handlebars
+harbour
+haxe
+html+django
+http
+hy
+idl
+idris
+igor pro
+inform 7
+ini
+inno setup
+io
+ioke
+irc log
+isabelle
+j
+jade
+java server pages
+json
+json5
+jsoniq
+jsonld
+julia
+kit
+kotlin
+krl
+labview
+lasso
+latte
+less
+lfe
+lilypond
+liquid
+literate agda
+literate coffeescript
+literate haskell
+livescript
+llvm
+logos
+logtalk
+lolcode
+lookml
+lsl
+m
+makefile
+mako
+markdown
+mask
+mathematica
+matlab
+maven pom
+max
+mediawiki
+mercury
+minid
+mirah
+monkey
+moocode
+moonscript
+mtml
+mupad
+myghty
+nemerle
+nesc
+netlogo
+nginx
+nimrod
+ninja
+nit
+nix
+nsis
+nu
+numpy
+objdump
+objective-c++
+objective-j
+ocaml
+omgrofl
+ooc
+opa
+opal
+opencl
+openedge abl
+openscad
+org
+ox
+oxygene
+pan
+papyrus
+parrot
+parrot assembly
+parrot internal representation
+pascal
+pawn
+perl6
+piglatin
+pike
+pod
+pogoscript
+postscript
+powershell
+processing
+prolog
+propeller spin
+protocol buffer
+puppet
+pure data
+purescript
+python traceback
+qmake
+qml
+r
+racket
+ragel in ruby host
+raw token data
+rdoc
+realbasic
+rebol
+red
+redcode
+restructuredtext
+rhtml
+rmarkdown
+robotframework
+rouge
+rust
+sage
+sas
+sass
+scaml
+scilab
+scss
+self
+shell
+shellsession
+shen
+slash
+slim
+smalltalk
+smarty
+sourcepawn
+sqf
+squirrel
+standard ml
+stata
+ston
+stylus
+supercollider
+swift
+systemverilog
+tcl
+tcsh
+tea
+tex
+textile
+thrift
+toml
+turing
+twig
+txl
+typescript
+unified parallel c
+unrealscript
+vala
+vcl
+verilog
+vhdl
+viml
+visual basic
+volt
+wisp
+xbase
+xc
+xml
+xojo
+xproc
+xquery
+xs
+xslt
+xtend
+yaml
+zephir
+zimpl

--- a/t/GithubLanguages.t
+++ b/t/GithubLanguages.t
@@ -28,22 +28,22 @@ ddg_spice_test(
         caller => 'DDG::Spice::GithubLanguages'
     ),
     'f# test' => test_spice(
-        '/js/spice/github_languages/test%20language%3A%22c%2B%2B%22',
+        '/js/spice/github_languages/test%20language%3A%22f%23%22',
         call_type => 'include',
         caller => 'DDG::Spice::GithubLanguages'
     ),
     'test f#' => test_spice(
-        '/js/spice/github_languages/test%20language%3A%22c%2B%2B%22',
+        '/js/spice/github_languages/test%20language%3A%22f%23%22',
         call_type => 'include',
         caller => 'DDG::Spice::GithubLanguages'
     ),
     'graphviz (dot) test' => test_spice(
-        '/js/spice/github_languages/test%20language%3A%22c%2B%2B%22',
+        '/js/spice/github_languages/test%20language%3A%22graphviz%20%28dot%29%22',
         call_type => 'include',
         caller => 'DDG::Spice::GithubLanguages'
     ),
     'test graphviz (dot)' => test_spice(
-        '/js/spice/github_languages/test%20language%3A%22c%2B%2B%22',
+        '/js/spice/github_languages/test%20language%3A%22graphviz%20%28dot%29%22',
         call_type => 'include',
         caller => 'DDG::Spice::GithubLanguages'
     ),

--- a/t/GithubLanguages.t
+++ b/t/GithubLanguages.t
@@ -1,0 +1,26 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+spice is_cached => 1;
+
+ddg_spice_test(
+    [qw( DDG::Spice::GithubLanguages)],
+    # At a minimum, be sure to include tests for all:
+    # - primary_example_queries
+    # - secondary_example_queries
+    'example query' => test_spice(
+        '/js/spice/github_languages/query',
+        call_type => 'include',
+        caller => 'DDG::Spice:GithubLanguages'
+    ),
+    # Try to include some examples of queries on which it might
+    # appear that your answer will trigger, but does not.
+    'bad example query' => undef,
+);
+
+done_testing;
+

--- a/t/GithubLanguages.t
+++ b/t/GithubLanguages.t
@@ -5,21 +5,19 @@ use warnings;
 use Test::More;
 use DDG::Test::Spice;
 
-spice is_cached => 1;
-
 ddg_spice_test(
     [qw( DDG::Spice::GithubLanguages)],
-    # At a minimum, be sure to include tests for all:
-    # - primary_example_queries
-    # - secondary_example_queries
-    'example query' => test_spice(
-        '/js/spice/github_languages/query',
+    'javascript redis' => test_spice(
+        '/js/spice/github_languages/%20redis%20language%3Ajavascript',
         call_type => 'include',
-        caller => 'DDG::Spice:GithubLanguages'
+        caller => 'DDG::Spice::GithubLanguages'
     ),
-    # Try to include some examples of queries on which it might
-    # appear that your answer will trigger, but does not.
-    'bad example query' => undef,
+    'redis javascript' => test_spice(
+        '/js/spice/github_languages/redis%20%20language%3Ajavascript',
+        call_type => 'include',
+        caller => 'DDG::Spice::GithubLanguages'
+    ),
+    'redis javascript client' => undef,
 );
 
 done_testing;

--- a/t/GithubLanguages.t
+++ b/t/GithubLanguages.t
@@ -17,6 +17,36 @@ ddg_spice_test(
         call_type => 'include',
         caller => 'DDG::Spice::GithubLanguages'
     ),
+    'test c++' => test_spice(
+        '/js/spice/github_languages/test%20language%3A%22c%2B%2B%22',
+        call_type => 'include',
+        caller => 'DDG::Spice::GithubLanguages'
+    ),
+    'c++ test' => test_spice(
+        '/js/spice/github_languages/test%20language%3A%22c%2B%2B%22',
+        call_type => 'include',
+        caller => 'DDG::Spice::GithubLanguages'
+    ),
+    'f# test' => test_spice(
+        '/js/spice/github_languages/test%20language%3A%22c%2B%2B%22',
+        call_type => 'include',
+        caller => 'DDG::Spice::GithubLanguages'
+    ),
+    'test f#' => test_spice(
+        '/js/spice/github_languages/test%20language%3A%22c%2B%2B%22',
+        call_type => 'include',
+        caller => 'DDG::Spice::GithubLanguages'
+    ),
+    'graphviz (dot) test' => test_spice(
+        '/js/spice/github_languages/test%20language%3A%22c%2B%2B%22',
+        call_type => 'include',
+        caller => 'DDG::Spice::GithubLanguages'
+    ),
+    'test graphviz (dot)' => test_spice(
+        '/js/spice/github_languages/test%20language%3A%22c%2B%2B%22',
+        call_type => 'include',
+        caller => 'DDG::Spice::GithubLanguages'
+    ),
     'redis javascript client' => undef,
 );
 

--- a/t/GithubLanguages.t
+++ b/t/GithubLanguages.t
@@ -7,13 +7,13 @@ use DDG::Test::Spice;
 
 ddg_spice_test(
     [qw( DDG::Spice::GithubLanguages)],
-    'javascript redis' => test_spice(
-        '/js/spice/github_languages/%20redis%20language%3Ajavascript',
+    'javascript test' => test_spice(
+        '/js/spice/github_languages/test%20language%3A%22javascript%22',
         call_type => 'include',
         caller => 'DDG::Spice::GithubLanguages'
     ),
-    'redis javascript' => test_spice(
-        '/js/spice/github_languages/redis%20%20language%3Ajavascript',
+    'test javascript' => test_spice(
+        '/js/spice/github_languages/test%20language%3A%22javascript%22',
         call_type => 'include',
         caller => 'DDG::Spice::GithubLanguages'
     ),


### PR DESCRIPTION
This adds an instant answer functionality where queries that start or end with a known computer language will automatically do a search for repositories matching the rest of that query, with the language paramater, on GitHub. So, 'javascript redis' would find any repositories for projects written in javascript that relate to redis.

I was asked to submit an Instant Answer by Caine Tighe. Approval and suggestions for approach were provided by @yegg and mr.Shu.

Thank you