### PR TITLE
Explicitly spell out months for overnight flights

### DIFF
--- a/share/spice/flights/route/flights_route.js
+++ b/share/spice/flights/route/flights_route.js
@@ -24,6 +24,10 @@
             "NO": "Not Operational",
             "DN": "Data Needed"
         },
+        MONTH: [
+        	"Jan.", "Feb.", "March", "April", "May", "June",
+        	"July", "Aug.", "Sept.", "Oct.", "Nov.", "Dec." 
+        ],
 
 
         // this function parses the initial query and sends out additional queries
@@ -355,7 +359,7 @@
         minutes = minutes < 10 ? "0" + minutes : minutes;
 
         if ((arrivalDate.getDate() != departureDate.getDate()) && (!isDeparture)) {
-            return hours + ":" + minutes + " " + suffix + " (" + (dateObject.getMonth()+1) + "/" + dateObject.getDate() + ")";
+            return hours + ":" + minutes + " " + suffix + " (" + ddg_spice_flights.MONTH[dateObject.getMonth()] + " " + dateObject.getDate() + ")";
         } else
             return hours + ":" + minutes + " " + suffix;
     });


### PR DESCRIPTION
Currently, the flights by route IA displays a month and day in the arrival time for overnight flights. However, the display uses a numerical representation for months, which can be hard to interpret given the adjacent location to the arrival time. This PR explicitly spells out each month.

![](https://cloud.githubusercontent.com/assets/5326740/5626127/dc30ce86-953b-11e4-9206-160a02b662de.png)
