### PR TITLE
Namespaced Stocks ZCI CSS

### DIFF
--- a/share/spice/stocks/stocks.css
+++ b/share/spice/stocks/stocks.css
@@ -4,35 +4,35 @@
     font-weight: 400;
     margin-bottom: .25em;
 }
-.stocks__sub.zci__header__sub {
+.zci--stocks .stocks__sub.zci__header__sub {
     font-weight: 300;
     padding-left: 0;
     font-size: .95em;
     text-transform: none;
 }
-.stocks__symbol {
+.zci--stocks .stocks__symbol {
     font-weight: 400;
 }
 
-.stocks__quotes {
+.zci--stocks .stocks__quotes {
     font-size: 1.5em;
 }
 .stocks__quote,
 .stocks__change {
     font-weight: 600;
 }
-.stocks__change-pct {
+.zci--stocks .stocks__change-pct {
     font-weight: 300;
 }
-.stocks__change-sep.detail__sep {
+.zci--stocks .stocks__change-sep.detail__sep {
     margin: 0;
     height: .78em;
 }
-.stocks__quote-up .stocks__change,
-.stocks__quote-up .stocks__change-pct {
+.zci--stocks .stocks__quote-up .stocks__change,
+.zci--stocks .stocks__quote-up .stocks__change-pct {
     color: #60ae50;
 }
-.stocks__quote-up .stocks__change:before {
+.zci--stocks .stocks__quote-up .stocks__change:before {
     content: '';
     border: 3px solid transparent;
     border-bottom-color: #60ae50;
@@ -45,11 +45,11 @@
     position: relative;
     top: -5px;
 }
-.stocks__quote-down .stocks__change,
-.stocks__quote-down .stocks__change-pct {
+.zci--stocks .stocks__quote-down .stocks__change,
+.zci--stocks .stocks__quote-down .stocks__change-pct {
     color: #c9481c;
 }
-.stocks__quote-down .stocks__change:before {
+.zci--stocks .stocks__quote-down .stocks__change:before {
     content: '';
     border: 3px solid transparent;
     border-top-color: #c9481c;


### PR DESCRIPTION
Prepended relevant styles with `.zci--stocks` to namespace the CSS.
Fixes #1284