### PR TITLE
Packagist.js - Normalizing downloads with DDG function.

### DIFF
--- a/share/spice/packagist/packagist.js
+++ b/share/spice/packagist/packagist.js
@@ -35,7 +35,7 @@
             normalize: function(item) {
                 return {
                     title: item.name,
-                    downloads: item.downloads.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")
+                    downloads: DDG.commifyNumber(item.downloads)
                 };
             }
         });


### PR DESCRIPTION
Changing normalization of download # from regex to DDG.commifyNumber()