### PR TITLE
Xkcd: fixed floating of prev/next buttons for IE8

### DIFF
--- a/share/spice/xkcd/display/xkcd_display.css
+++ b/share/spice/xkcd/display/xkcd_display.css
@@ -30,11 +30,11 @@
 }
 
 /* Float prev/explain link to the left */
-.zci--xkcd .xkcd--buttons a:first-of-type {
+.zci--xkcd .xkcd--buttons .tile-nav--sm--prev {
     float: left;
 }
 
 /* Float explain/next link to the right */
-.zci--xkcd .xkcd--buttons a:last-of-type {
+.zci--xkcd .xkcd--buttons .tile-nav--sm--next {
     float: right;
 }


### PR DESCRIPTION
Fixes #1384.

Not completely sure whether I should update the IA attribution for a quick CSS fix or not.