### PR TITLE
Nutrition: added trigger support for different word order, fixes #1425

### DIFF
--- a/lib/DDG/Spice/Nutrition.pm
+++ b/lib/DDG/Spice/Nutrition.pm
@@ -3,6 +3,7 @@ package DDG::Spice::Nutrition;
 use DDG::Spice;
 
 primary_example_queries "calories in a banana";
+secondary_example_queries "strawberry calories", "tofu how much protein";
 description "Shows nutrition information for food items";
 name "Nutrition";
 code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/Nutrition.pm";
@@ -10,7 +11,10 @@ icon_url "/i/nutritionix.com.ico";
 topics "food_and_drink";
 category "food";
 
+attribution github => ['https://github.com/andrey-p','Andrey Pissantchev'];
+
 my $attribute_regex = qr/(?^:(?^:(?:c(?:a(?:l(?:ories(?: from fat)?|cium|s)|rb(?:ohydrate)?s)|holesterol)|p(?:olyunsaturated fat|rotein)|trans(?: fat(?:ty acid)?|-fat)|s(?:aturated fat|odium|ugar)|monounsaturated fat|dietary fiber|f(?:iber|at)|vitamin [ac]|kcals|iron)))/;
+my $question_regex = qr/(?:how|what)?\s?(?:'s |is |are |many |much )?(?:the |there )?(?:total |amount of |number of )?/;
 
 triggers any => 'kcals', 'cals','calories','fiber','dietary fiber','fat','trans-fat','trans fat','trans fatty acid','calories from fat','saturated fat','monosaturated fat','polyunsaturated fat','cholesterol','sodium','sugar','protein','carbs','carbohydrates','vitamin c','vitamin a','calcium','iron';
 
@@ -20,8 +24,14 @@ spice to => 'http://api.nutritionix.com/v1_1/search/$1?results=0%3A20&brand_id=5
 spice wrap_jsonp_callback => 1;
 
 handle query_lc => sub {
-    if (/^(?:how|what)?\s?(?:'s |is |are |many |much )?(?:the |there )?(?:total |amount of |number of )?$attribute_regex\s?(?:are |contained |is )?(?:there )?(?:in )?(?:a |an )?(.+?)(?:\?)?$/) {
+    # check for queries like "how many calories are in a cucumber"
+    if (/^$question_regex$attribute_regex\s?(?:are |contained |is )?(?:there )?(?:in )?(?:a |an )?(.+?)(?:\?)?$/) {
 		return $1 if $1;
+    }
+
+    # for queries like "cucumber calories" or "tofu how much protein"
+    if (/^(.+?)\s?$question_regex$attribute_regex(?:\?)?/) {
+        return $1 if $1;
     }
 
     return;

--- a/t/Nutrition.t
+++ b/t/Nutrition.t
@@ -76,7 +76,17 @@ ddg_spice_test(
         '/js/spice/nutrition/spam',
         call_type => 'include',
         caller => 'DDG::Spice::Nutrition',
-    )
+    ),
+    'tofu calories' => test_spice(
+        '/js/spice/nutrition/tofu',
+        call_type => 'include',
+        caller => 'DDG::Spice::Nutrition',
+    ),
+    'tofu how much protein' => test_spice(
+        '/js/spice/nutrition/tofu',
+        call_type => 'include',
+        caller => 'DDG::Spice::Nutrition',
+    ),
 );
 
 done_testing;


### PR DESCRIPTION
Hope you don't mind me doing this one.

The IA now supports queries like "tofu calories" and "tofu how many calories". Tests updated, too.