### PR TITLE
Timer: add new trigger (time)

### DIFF
--- a/lib/DDG/Spice/Timer.pm
+++ b/lib/DDG/Spice/Timer.pm
@@ -12,6 +12,7 @@ attribution twitter => 'mattr555',
             github => ['https://github.com/mattr555/', 'Matt Ramina'];
 
 triggers startend => ['timer', 'countdown'];
+triggers start => ['time'];
 
 spice call_type => 'self';
 


### PR DESCRIPTION
It makes sense for a search like `time 3 minutes` to bring up the countdown timer.