### PR TITLE
Template: Add error checking of api_result

### DIFF
--- a/template/share/spice/example/example.js
+++ b/template/share/spice/example/example.js
@@ -3,7 +3,7 @@
     env.ddg_spice_<: $lia_name :> = function(api_result){
 
         // Validate the response (customize for your Spice)
-        if (api_result.error) {
+        if (!api_result || api_result.error) {
             return Spice.failed('<: $lia_name :>');
         }
 


### PR DESCRIPTION
@moollaza I see this come up a lot in PR requests, `api_result` not being checked. Might as well add it to the template.