### PR TITLE
Update airlines IA display to mirror flights_route

### DIFF
--- a/share/spice/airlines/airlines.js
+++ b/share/spice/airlines/airlines.js
@@ -23,7 +23,7 @@
         if (!api_result || !api_result.flight) {
             return Spice.failed('airlines');
         }
- 
+        
         // Check if flight is an array or not.
         var flight = [];
         if (!($.isArray(api_result.flight))) {
@@ -73,6 +73,8 @@
 
             results.push({
                 flight: flight[i],
+                airlineName: flight[i].Airline.Name,
+                flightNumber: flight[i].FlightNumber,
                 departing: departing,
                 arriving: arriving,
                 departureDate: departureDate,

--- a/share/spice/airlines/content.handlebars
+++ b/share/spice/airlines/content.handlebars
@@ -3,9 +3,12 @@
     <div class="tile__week">{{departing.weekday}}</div>
     <div class="tile__day">{{departing.day}}</div>
   </div>
-  <h5 class="tile__location">
-    {{departing.airport.AirportCode}} to {{arriving.airport.AirportCode}}
+  <h5 class="tile__flightID">
+    {{airlineName}} {{flightNumber}}
   </h5>
+  <div class="tile__airports">
+    {{departing.airport.AirportCode}} to {{arriving.airport.AirportCode}}
+  </div>
   <div>
     <span class="tile__status">
       {{{status flight departureDate arrivalDate}}}


### PR DESCRIPTION
Addresses #1436 

![screen shot 2015-01-25 at 1 34 36 am](https://cloud.githubusercontent.com/assets/5326740/5890649/934c5602-a433-11e4-9a11-0a3cd5ac7c62.png)


Currently, the airlines IA (which searches by airline code and flight numbers) and the flights_route IA (which searches by airline and source/destination cities) do not share any code. This PR unifies the appearance of the two IAs. Eventually, we should try to unify the two IAs to avoid having to maintain two different sets of code. (This is on my list of weekend projects to attempt :)