### PR TITLE
Twitter: Improve triggering - Skip words

### DIFF
--- a/lib/DDG/Spice/Twitter.pm
+++ b/lib/DDG/Spice/Twitter.pm
@@ -9,12 +9,12 @@ name "Twitter";
 code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/Twitter.pm";
 topics "everyday", "social";
 category "time_sensitive";
-attribution github => ["https://github.com/duckduckgo/", "DuckDuckGo"],
-    twitter => ["https://twitter.com/duckduckgo", "DuckDuckGo"],
-    github => ["https://github.com/ecounysis/", "Eric Christensen"],
-    twitter => ["https://twitter.com/ecounysis", "Eric Christensen"],
-    github => ["https://github.com/laouji/", "Crimson Thompson"],
-    twitter => ["https://twitter.com/laouji", "Crimson Thompson"];
+attribution github  => ["https://github.com/duckduckgo/", "DuckDuckGo"],
+            twitter => ["https://twitter.com/duckduckgo", "DuckDuckGo"],
+            github  => ["https://github.com/ecounysis/", "Eric Christensen"],
+            twitter => ["https://twitter.com/ecounysis", "Eric Christensen"],
+            github  => ["https://github.com/laouji/", "Crimson Thompson"],
+            twitter => ["https://twitter.com/laouji", "Crimson Thompson"];
 
 spice to => 'https://duckduckgo.com/tw.js?user=$1&callback={{callback}}&current=1';
 triggers query => qr/^(?:twitter\s)?@([a-z0-9_]+)$|^twitter\s([a-z0-9_]+)$/i;

--- a/lib/DDG/Spice/Twitter.pm
+++ b/lib/DDG/Spice/Twitter.pm
@@ -19,17 +19,15 @@ attribution github => ["https://github.com/duckduckgo/", "DuckDuckGo"],
 spice to => 'https://duckduckgo.com/tw.js?user=$1&callback={{callback}}&current=1';
 triggers query => qr/^(?:twitter\s)?@([a-z0-9_]+)$|^twitter\s([a-z0-9_]+)$/i;
 
-# Possibly add skip words to a file for slurping?
-my $skip = join "|", ("apis?",
-		      "developers?",
-		      "users?",
-		      "search(es)?");
+
+# skip words from file
+my $skip = join "|", share('skipwords.txt')->slurp(chomp => 1);
 
 handle matches => sub { 
     if ($1) {
-	return $1;
+	   return $1;
     } elsif ($2) {
-	return $2 unless ($2 =~ m/^($skip)$/i)
+	   return $2 unless ($2 =~ m/^($skip)$/i)
     }
     return;
 }; 

--- a/share/spice/twitter/skipwords.txt
+++ b/share/spice/twitter/skipwords.txt
@@ -1,0 +1,7 @@
+apis?
+developers?
+users?
+search(es)?
+analytics?
+company
+about

--- a/t/Twitter.t
+++ b/t/Twitter.t
@@ -1,0 +1,38 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+ddg_spice_test(
+    [qw( DDG::Spice::Twitter )],
+    '@duckduckgo' => test_spice(
+        '/js/spice/twitter/duckduckgo',
+        call_type => 'include',
+        caller => 'DDG::Spice::Twitter',
+    ),
+
+    'twitter yegg' => test_spice(
+        '/js/spice/twitter/yegg',
+        call_type => 'include',
+        caller => 'DDG::Spice::Twitter',
+    ),
+    
+    'twitter ecounysis' => test_spice(
+        '/js/spice/twitter/ecounysis',
+        call_type => 'include',
+        caller => 'DDG::Spice::Twitter',
+    ),
+
+    'what is twitter' => undef,
+    'twitter analytics' => undef,
+    'twitter company' => undef,
+    'about twitter' => undef,
+    'twitter apis' => undef,
+    'twitter developers' => undef,   
+    'twitter users' => undef,
+    'twitter search' => undef
+);
+
+done_testing;


### PR DESCRIPTION
Fix #1454 (Don't trigger twitter IA for [dictionary match single words])

---

Changes
- Updated to slurp "skip words" from file skipwords.txt.
- Added words: _analytics, company, about_

---

Recommend addtional words to skip; suggestions welcome :smile: 
