### PR TITLE
.travis.yml: Remove sudo: false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 ---
-sudo: false
 before_install:
   - export HARNESS_OPTIONS=j10:c HARNESS_TIMER=1
   - rm .travis.yml


### PR DESCRIPTION
Since .travis.yml is autogenerated by https://github.com/SineSwiper/Dist-Zilla-TravisCI, we can't just modify that file ourselves. We'd have to wait for https://github.com/SineSwiper/Dist-Zilla-TravisCI/issues/25 to get fixed first.

@moollaza 