### PR TITLE
GoWatchIt: Don't display if we don't have any images for them

### DIFF
--- a/share/spice/go_watch_it/go_watch_it.css
+++ b/share/spice/go_watch_it/go_watch_it.css
@@ -7,8 +7,8 @@
 }
 
 .tile--go_watch_it .tile__body .image-holder img {
-  padding-top: 0.5em;
-  padding-bottom: 1.8em;
+  padding-top: 0.8em;
+  padding-bottom: 1.5em;
   width: 145px;
 }
 

--- a/share/spice/go_watch_it/go_watch_it.js
+++ b/share/spice/go_watch_it/go_watch_it.js
@@ -121,7 +121,7 @@
             21: {
                 dark: DDG.get_asset_path('go_watch_it', path + 'vhx'),
                 light: DDG.get_asset_path('go_watch_it', path + 'vhx-alt')
-            },
+            }
         };
         
         var skip_providers = {

--- a/share/spice/go_watch_it/go_watch_it.js
+++ b/share/spice/go_watch_it/go_watch_it.js
@@ -118,7 +118,7 @@
                 dark: DDG.get_asset_path('go_watch_it', path + 'fandango'),
                 light: DDG.get_asset_path('go_watch_it', path + 'fandango')
             },
-            21: {
+            23: {
                 dark: DDG.get_asset_path('go_watch_it', path + 'vhx'),
                 light: DDG.get_asset_path('go_watch_it', path + 'vhx-alt')
             }

--- a/share/spice/go_watch_it/go_watch_it.js
+++ b/share/spice/go_watch_it/go_watch_it.js
@@ -121,6 +121,10 @@
             23: {
                 dark: DDG.get_asset_path('go_watch_it', path + 'vhx'),
                 light: DDG.get_asset_path('go_watch_it', path + 'vhx-alt')
+            },
+            14: {
+                dark: DDG.get_asset_path('go_watch_it', path + 'hulu'),
+                light: DDG.get_asset_path('go_watch_it', path + 'hulu')
             }
         };
         

--- a/share/spice/go_watch_it/go_watch_it.js
+++ b/share/spice/go_watch_it/go_watch_it.js
@@ -118,6 +118,10 @@
                 dark: DDG.get_asset_path('go_watch_it', path + 'fandango'),
                 light: DDG.get_asset_path('go_watch_it', path + 'fandango')
             },
+            21: {
+                dark: DDG.get_asset_path('go_watch_it', path + 'vhx'),
+                light: DDG.get_asset_path('go_watch_it', path + 'vhx-alt')
+            },
         };
         
         var skip_providers = {

--- a/share/spice/go_watch_it/go_watch_it.js
+++ b/share/spice/go_watch_it/go_watch_it.js
@@ -178,6 +178,8 @@
                     item.provider_format_logos = provider_icons[item.provider_format_id];
                     item.provider_format_logos.light += append;
                     item.provider_format_logos.dark += append;
+                } else {
+                    return null;
                 }
                 
                 return {


### PR DESCRIPTION
This is a dirty fix, but the UI breaks when we display images that's not from us:

![screen shot 2015-01-31 at 1 04 37 pm](https://cloud.githubusercontent.com/assets/81969/5989101/d6875212-a949-11e4-9fe0-2cd3681b70b0.png)

Easiest fix is to remove them for now until we either have:

- Better images
- Resize their image so that it doesn't break the UI (this is also easy but requires extensive testing. Also GoWatchIt's images don't work well on retina screens)