### PR TITLE
New spice to return words in specified part of speech

### DIFF
--- a/lib/DDG/Spice/RandPOS.pm
+++ b/lib/DDG/Spice/RandPOS.pm
@@ -1,0 +1,36 @@
+package DDG::Spice::RandPOS;
+# ABSTRACT: Returns a random word or list of words from the specified part of speech using Wordnik.
+
+use DDG::Spice;
+
+name 'Random Part of Speech Words';
+source 'Wordnik';
+description 'Returns one or more random words in the specified part of speech.';
+primary_example_queries 'random noun','example adjectives','adverb example';
+category 'language';
+topics 'words_and_games','everyday';
+code_url 'https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/RandPOS.pm';
+attribution github => ['https://github.com/SueSmith', 'SueSmith'],
+    web => ['http://benormal.info','Sue Smith'],
+    twitter => 'braindeadair';
+
+triggers start => 'random';
+triggers startend => 'example';
+
+spice from => '([^/]+)/?(?:([^/]+)/?(?:([^/]+)|)|)';
+spice to => 'http://api.wordnik.com/v4/words.json/randomWords?includePartOfSpeech=$1&minCorpusCount=10000&limit=$2&api_key={{ENV{DDG_SPICE_WORDNIK_APIKEY}}}&callback={{callback}}';
+
+handle remainder => sub {
+
+    return unless $_ =~ /^(noun|nouns|verb|verbs|adjective|adjectives|pronoun|pronouns|preposition|prepositions|conjunction|conjunctions|adverb|adverbs)$/i;
+
+    if($_ =~ /nouns|verbs|adjectives|pronouns|prepositions|conjunctions|adverbs/){
+        return substr($_, 0, -1), 5;
+    }
+    if ($_ =~ /noun|verb|adjective|pronoun|preposition|conjunction|adverb/){
+        return $_, 1;
+    }
+    return;
+};
+
+1;

--- a/lib/DDG/Spice/RandPOS.pm
+++ b/lib/DDG/Spice/RandPOS.pm
@@ -19,6 +19,7 @@ triggers startend => 'example';
 
 spice from => '([^/]+)/?(?:([^/]+)/?(?:([^/]+)|)|)';
 spice to => 'http://api.wordnik.com/v4/words.json/randomWords?includePartOfSpeech=$1&minCorpusCount=10000&limit=$2&api_key={{ENV{DDG_SPICE_WORDNIK_APIKEY}}}&callback={{callback}}';
+spice proxy_cache_valid => '418 1d';
 
 handle remainder => sub {
 

--- a/share/spice/rand_pos/content.handlebars
+++ b/share/spice/rand_pos/content.handlebars
@@ -1,0 +1,1 @@
+ {{#concat words sep=" "}}<a href="http://wordnik.com/words/{{word}}">{{word}}</a>{{/concat}}

--- a/share/spice/rand_pos/content.handlebars
+++ b/share/spice/rand_pos/content.handlebars
@@ -1,1 +1,1 @@
- {{#concat words sep=" "}}<a href="http://wordnik.com/words/{{word}}">{{word}}</a>{{/concat}}
+ {{#concat words sep=", "}}<a href="http://wordnik.com/words/{{word}}">{{word}}</a>{{/concat}}

--- a/share/spice/rand_pos/rand_pos.js
+++ b/share/spice/rand_pos/rand_pos.js
@@ -1,0 +1,31 @@
+(function(env){
+    "use strict";
+    
+    env.ddg_spice_rand_pos = function(api_result){
+        if (api_result.error) {
+            return Spice.failed('rand_pos');
+        }
+        var words = [];
+        var len = api_result.length;
+        for(var i=0; i<len; i++) {
+            words.push(api_result[i]);
+        }
+        Spice.add({
+            id: "rand_pos",
+            data: {words:words},
+            name: "Answer",
+            meta: {
+                sourceUrl: 'http://wordnik.com',
+                sourceName: 'Wordnik',
+                sourceIcon: true
+            },
+            templates: {
+                group: 'base',
+                options: {
+                    content: Spice.rand_pos.content,
+                    moreAt: true
+                }
+            }
+        });
+    }
+}(this));

--- a/t/RandPOS.t
+++ b/t/RandPOS.t
@@ -1,0 +1,105 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+ddg_spice_test(
+    [qw( DDG::Spice::RandPOS )],
+    'random noun' => test_spice(
+        '/js/spice/rand_pos/noun/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::RandPOS',
+    ),
+    'random verb' => test_spice(
+        '/js/spice/rand_pos/verb/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::RandPOS',
+    ),
+    'random adverb' => test_spice(
+        '/js/spice/rand_pos/adverb/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::RandPOS',
+    ),
+    'random adjective' => test_spice(
+        '/js/spice/rand_pos/adjective/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::RandPOS',
+    ),
+    'random pronouns' => test_spice(
+        '/js/spice/rand_pos/pronoun/5',
+        call_type => 'include',
+        caller => 'DDG::Spice::RandPOS',
+    ),
+    'random prepositions' => test_spice(
+        '/js/spice/rand_pos/preposition/5',
+        call_type => 'include',
+        caller => 'DDG::Spice::RandPOS',
+    ),
+    'random conjunctions' => test_spice(
+        '/js/spice/rand_pos/conjunction/5',
+        call_type => 'include',
+        caller => 'DDG::Spice::RandPOS',
+    ),
+    'example nouns' => test_spice(
+        '/js/spice/rand_pos/noun/5',
+        call_type => 'include',
+        caller => 'DDG::Spice::RandPOS',
+    ),
+    'example verbs' => test_spice(
+        '/js/spice/rand_pos/verb/5',
+        call_type => 'include',
+        caller => 'DDG::Spice::RandPOS',
+    ),
+    'example adverbs' => test_spice(
+        '/js/spice/rand_pos/adverb/5',
+        call_type => 'include',
+        caller => 'DDG::Spice::RandPOS',
+    ),
+    'example adjectives' => test_spice(
+        '/js/spice/rand_pos/adjective/5',
+        call_type => 'include',
+        caller => 'DDG::Spice::RandPOS',
+    ),
+    'example pronoun' => test_spice(
+        '/js/spice/rand_pos/pronoun/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::RandPOS',
+    ),
+    'example preposition' => test_spice(
+        '/js/spice/rand_pos/preposition/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::RandPOS',
+    ),
+    'example conjunction' => test_spice(
+        '/js/spice/rand_pos/conjunction/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::RandPOS',
+    ),
+    'adjective example' => test_spice(
+        '/js/spice/rand_pos/adjective/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::RandPOS',
+    ),
+    'pronoun example' => test_spice(
+        '/js/spice/rand_pos/pronoun/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::RandPOS',
+    ),
+    'preposition example' => test_spice(
+        '/js/spice/rand_pos/preposition/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::RandPOS',
+    ),
+    'conjunction example' => test_spice(
+        '/js/spice/rand_pos/conjunction/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::RandPOS',
+    ),
+    'random noun phrase' => undef,
+    'random funny nouns' => undef,
+    'bad noun example' => undef,
+    'examples of nouns' => undef
+);
+done_testing;


### PR DESCRIPTION
**What does your Instant Answer do?**
This is my first attempt at a Spice so excuse any daft mistakes.. :wink: It uses Wordnik to return random words in particular parts of speech (noun, verb, adjective, pronoun, adverb, preposition and conjunction). If the query includes the part of speech in plural it returns five words, otherwise is returns one.

**What problem does your Instant Answer solve (Why is it better than organic links)?**
It gives people examples of words in a part of speech, which can be helpful when learning grammar. Rather than seeing a description of a grammatical idea, seeing examples is often the easiest way to understand what e.g. a noun, verb or whatever is.

**What is the data source for your Instant Answer? (Provide a link if possible)**
Wordnik https://www.wordnik.com/

**Why did you choose this data source?**
It's already being used and provides endpoints which allow you to specify the part of speech.

**Are there any other alternative (better) data sources?**
I couldn't see any that would allow you to specify the part of speech and would return JSON.

**What are some example queries that trigger this Instant Answer?**
* noun example
* random adjective
* random verbs
* example adverbs

**Which communities will this Instant Answer be especially useful for? (gamers, book lovers, etc)**
Anyone learning English grammar or who likes random stuff.

**Is this Instant Answer connected to a DuckDuckHack [Instant Answer idea](https://duck.co/ideas)?**
No.

**Which existing Instant Answers will this one supersede/overlap with?**
I'm unsure what happens when triggers use the same words - see below, but it may interfere with the random name and random word answers.

**Are you having any problems? Do you need our help with anything?**
Yes please!
* I'm not clear on whether this will interfere with existing Instant Answers with "random" in their triggers, e.g. the random name and random word triggers..? If so, should I alter my triggers to cover the full phrases e.g. "random noun" (rather than "random" with the handle function picking up the part of speech from the remainder)..? There would be a load of possible phrases, so in that case I'm wondering if it would be better to go down the regex route..? I could also extend this to cover other phrases e.g. "noun examples", which would also require a bit more processing, but the approach will depend on what I should do with the triggers generally so any guidance is appreciated!
* I'm totally new to Perl so please let me know if my code is inefficient or whatever :grimacing: 
* At the front end I've used the random word and rhyme Instant Answers as the basis for the layout, if it doesn't look right give me a shout!
* I've included the API key using the code in the dictionary Instant Answers, assuming you'll want to use the same key..? This is it: `{{ENV{DDG_SPICE_WORDNIK_APIKEY}}}` (Tested it with my own key..)
* I've built a minimum corpus count into the Wordnik query to weed out the more obscure words which might confuse people.. I've also only included seven parts of speech as the rest are a bit trickier to implement, but I could certainly look at extending this.

**What are the terms of use for the API? Will DuckDuckGo need specific authorization (e.g. an API key)? Are there any costs associated with API usage?**
DuckDuckGo already uses the API.

**What does the Instant Answer look like? (Provide a screenshot for new or updated Instant Answers)**
![random_single](https://cloud.githubusercontent.com/assets/6666370/5999646/b83e057a-aacb-11e4-8fdc-4463751b1e79.png)
![random_list](https://cloud.githubusercontent.com/assets/6666370/5999647/bb793c78-aacb-11e4-8f50-b7d5435fec3c.png)

## Checklist
Please place an 'X' where appropriate.

```
[x] Added metadata and attribution information
[x] Wrote test file and added to t/ directory
[x] Verified that instant answer adheres to design guidelines (https://duck.co/duckduckhack/design_styleguide)
[x] Verified that instant answer adheres to code styleguide (https://duck.co/duckduckhack/code_styleguide)
[] Tested cross-browser compatibility
    - Ubuntu
        [x] Firefox

```
