### PR TITLE
TVmaze: Small adjustments

### DIFF
--- a/share/spice/tvmaze/nextepisode/content.handlebars
+++ b/share/spice/tvmaze/nextepisode/content.handlebars
@@ -1,7 +1,0 @@
-The next episode is called <span class="text--primary">{{ _embedded.nextepisode.name }}</span> and will
-{{#if webChannel}}
-be released
-{{else}}
-air
-{{/if}}
-on <span class="text--primary">{{ tvmaze_dateformat _embedded.nextepisode.airdate }}</span> at {{ _embedded.nextepisode.airtime }}.

--- a/share/spice/tvmaze/nextepisode/content.handlebars
+++ b/share/spice/tvmaze/nextepisode/content.handlebars
@@ -1,7 +1,7 @@
-The next episode is called <b>{{ _embedded.nextepisode.name }}</b> and will
+The next episode is called <span class="text--primary">{{ _embedded.nextepisode.name }}</span> and will
 {{#if webChannel}}
 be released
 {{else}}
 air
 {{/if}}
-on <b>{{ tvmaze_dateformat _embedded.nextepisode.airdate }}</b> at {{ _embedded.nextepisode.airtime }}.
+on <span class="text--primary">{{ tvmaze_dateformat _embedded.nextepisode.airdate }}</span> at {{ _embedded.nextepisode.airtime }}.

--- a/share/spice/tvmaze/nextepisode/tvmaze_nextepisode.js
+++ b/share/spice/tvmaze/nextepisode/tvmaze_nextepisode.js
@@ -3,12 +3,12 @@
 
     env.ddg_spice_tvmaze_nextepisode = function(api_result){
         if (!api_result || !api_result._embedded) {
-            return Spice.failed('tvmaze');
+            return Spice.failed('tvmaze_nextepisode');
         }
 
         Spice.add({
             id: "tvmaze_nextepisode",
-            name: "TV Shows",
+            name: "Entertainment",
             data: api_result,
             meta: {
                 sourceName: "TVmaze.com",
@@ -29,11 +29,11 @@
             }
         });
     };
-    
+
     Handlebars.registerHelper("tvmaze_dateformat", function (date) {
         var months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
         var dateObj = new Date(date);
-        
+
         return months[dateObj.getMonth()] + " " + dateObj.getDate() + ", " + dateObj.getFullYear();
     });
 }(this));

--- a/share/spice/tvmaze/nextepisode/tvmaze_nextepisode.js
+++ b/share/spice/tvmaze/nextepisode/tvmaze_nextepisode.js
@@ -14,26 +14,106 @@
                 sourceName: "TVmaze.com",
                 sourceUrl: api_result._embedded.nextepisode.url
             },
+            relevancy: {
+                primary: [
+                    { key: 'name' },
+                    { required: '_embedded.nextepisode.name' },
+                    { required: '_embedded.nextepisode.airdate' },
+                ]
+            },
             normalize: function(item){
+                var infoboxData = [
+                    {
+                        label: 'Show',
+                        value: item.name
+                    },
+                    {   label: 'Airs',
+                        value: dateformat(item._embedded.nextepisode.airdate)
+                    },
+                    {
+                        label: 'Episode',
+                        value: item._embedded.nextepisode.number
+                    },
+                    {
+                        label: 'Season',
+                        value: item._embedded.nextepisode.season
+                    },
+                    {
+                        label: 'Show Type',
+                        value: item.type
+                    },
+                    {
+                        label: 'Show Status',
+                        value: item.status
+                    }
+                ];
+
+                if (item.network) {
+                    infoboxData.push(
+                        {
+                            label: 'Network',
+                            value: item.network.name
+                        },
+                        {
+                            label: 'Country of origin',
+                            value: item.network.country.name
+                        }
+                    );
+                } else if (item.webChannel) {
+                    infoboxData.push(
+                        {
+                            label: 'Web Channel',
+                            value: item.webChannel.name
+                        }
+                    );
+
+                    if (item.webChannel.country) {
+                        infoboxData.push(
+                            {
+                                label: 'Country of origin',
+                                value: item.webChannel.country.name
+                            }
+                        );
+                    }
+                }
+
                 return {
                     image: item.image ? item.image.medium : null,
-                    title: item.name
+                    title: item._embedded.nextepisode.name,
+                    description: DDG.strip_html(item._embedded.nextepisode.summary) || "Episode summary not available.",
+                    infoboxData: infoboxData
                 };
             },
             templates: {
                 group: 'info',
                 options: {
-                    content: Spice.tvmaze_nextepisode.content,
                     moreAt: true
                 }
             }
         });
     };
 
-    Handlebars.registerHelper("tvmaze_dateformat", function (date) {
-        var months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
-        var dateObj = new Date(date);
+    function dateformat (date) {
+        var months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'],
+            dateObj = new Date(date),
+            hours = dateObj.getHours(),
+            minutes = dateObj.getMinutes(),
+            date = dateObj.toDateString();
 
-        return months[dateObj.getMonth()] + " " + dateObj.getDate() + ", " + dateObj.getFullYear();
-    });
+        date = date.substring(0, date.lastIndexOf(" "));
+
+        // AM or PM?
+        var suffix = (hours >= 12) ? "PM" : "AM";
+        // Convert to 12-hour time.
+        if(hours > 12) {
+            hours -= 12;
+        } else if(hours === 0) {
+            hours = 12;
+        }
+        // Add leading zeroes.
+        minutes = minutes < 10 ? "0" + minutes : minutes;
+
+        return months[dateObj.getMonth()] + " " + dateObj.getDate() + ", " + dateObj.getFullYear() + " at " + hours + ":" + minutes + " " + suffix;
+    };
+
 }(this));

--- a/share/spice/tvmaze/previousepisode/content.handlebars
+++ b/share/spice/tvmaze/previousepisode/content.handlebars
@@ -1,7 +1,7 @@
-The previous episode is called <b>{{ _embedded.previousepisode.name }}</b> and
+The previous episode is called <span class="text--primary">{{ _embedded.previousepisode.name }}</span> and
 {{#if webChannel}}
 was released
 {{else}}
 aired
 {{/if}}
-on <b>{{ tvmaze_dateformat _embedded.previousepisode.airdate }}</b> at {{ _embedded.previousepisode.airtime }}.
+on <span class="text--primary">{{ tvmaze_dateformat _embedded.previousepisode.airdate }}</span> at {{ _embedded.previousepisode.airtime }}.

--- a/share/spice/tvmaze/previousepisode/content.handlebars
+++ b/share/spice/tvmaze/previousepisode/content.handlebars
@@ -1,7 +1,0 @@
-The previous episode is called <span class="text--primary">{{ _embedded.previousepisode.name }}</span> and
-{{#if webChannel}}
-was released
-{{else}}
-aired
-{{/if}}
-on <span class="text--primary">{{ tvmaze_dateformat _embedded.previousepisode.airdate }}</span> at {{ _embedded.previousepisode.airtime }}.

--- a/share/spice/tvmaze/previousepisode/tvmaze_previousepisode.js
+++ b/share/spice/tvmaze/previousepisode/tvmaze_previousepisode.js
@@ -3,12 +3,12 @@
 
     env.ddg_spice_tvmaze_previousepisode = function(api_result){
         if (!api_result || !api_result._embedded) {
-            return Spice.failed('tvmaze');
+            return Spice.failed('tvmaze_previousepisode');
         }
 
         Spice.add({
             id: "tvmaze_previousepisode",
-            name: "TV Shows",
+            name: "Entertainment",
             data: api_result,
             meta: {
                 sourceName: "TVmaze.com",
@@ -33,7 +33,7 @@
     Handlebars.registerHelper("tvmaze_dateformat", function (date) {
         var months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
         var dateObj = new Date(date);
-        
+
         return months[dateObj.getMonth()] + " " + dateObj.getDate() + ", " + dateObj.getFullYear();
     });
 }(this));

--- a/share/spice/tvmaze/previousepisode/tvmaze_previousepisode.js
+++ b/share/spice/tvmaze/previousepisode/tvmaze_previousepisode.js
@@ -14,26 +14,106 @@
                 sourceName: "TVmaze.com",
                 sourceUrl: api_result._embedded.previousepisode.url
             },
+            relevancy: {
+                primary: [
+                    { key: 'name' },
+                    { required: '_embedded.previousepisode.name' },
+                    { required: '_embedded.previousepisode.airdate' },
+                ]
+            },
             normalize: function(item){
+                var infoboxData = [
+                    {
+                        label: 'Show',
+                        value: item.name
+                    },
+                    {   label: 'Aired',
+                        value: dateformat(item._embedded.previousepisode.airdate)
+                    },
+                    {
+                        label: 'Episode',
+                        value: item._embedded.previousepisode.number
+                    },
+                    {
+                        label: 'Season',
+                        value: item._embedded.previousepisode.season
+                    },
+                    {
+                        label: 'Show Type',
+                        value: item.type
+                    },
+                    {
+                        label: 'Show Status',
+                        value: item.status
+                    }
+                ];
+
+                if (item.network) {
+                    infoboxData.push(
+                        {
+                            label: 'Network',
+                            value: item.network.name
+                        },
+                        {
+                            label: 'Country of origin',
+                            value: item.network.country.name
+                        }
+                    );
+                } else if (item.webChannel) {
+                    infoboxData.push(
+                        {
+                            label: 'Web Channel',
+                            value: item.webChannel.name
+                        }
+                    );
+
+                    if (item.webChannel.country) {
+                        infoboxData.push(
+                            {
+                                label: 'Country of origin',
+                                value: item.webChannel.country.name
+                            }
+                        );
+                    }
+                }
+
                 return {
                     image: item.image ? item.image.medium : null,
-                    title: item.name
+                    title: item._embedded.previousepisode.name,
+                    description: DDG.strip_html(item._embedded.previousepisode.summary) || "No description available.",
+                    infoboxData: infoboxData
                 };
             },
             templates: {
                 group: 'info',
                 options: {
-                    content: Spice.tvmaze_previousepisode.content,
                     moreAt: true
                 }
             }
         });
     };
 
-    Handlebars.registerHelper("tvmaze_dateformat", function (date) {
-        var months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
-        var dateObj = new Date(date);
+    function dateformat (date) {
+        var months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'],
+            dateObj = new Date(date),
+            hours = dateObj.getHours(),
+            minutes = dateObj.getMinutes(),
+            date = dateObj.toDateString();
 
-        return months[dateObj.getMonth()] + " " + dateObj.getDate() + ", " + dateObj.getFullYear();
-    });
+        date = date.substring(0, date.lastIndexOf(" "));
+
+        // AM or PM?
+        var suffix = (hours >= 12) ? "PM" : "AM";
+        // Convert to 12-hour time.
+        if(hours > 12) {
+            hours -= 12;
+        } else if(hours === 0) {
+            hours = 12;
+        }
+        // Add leading zeroes.
+        minutes = minutes < 10 ? "0" + minutes : minutes;
+
+        return months[dateObj.getMonth()] + " " + dateObj.getDate() + ", " + dateObj.getFullYear() + " at " + hours + ":" + minutes + " " + suffix;
+    };
+    
 }(this));

--- a/share/spice/tvmaze/show/tvmaze_show.js
+++ b/share/spice/tvmaze/show/tvmaze_show.js
@@ -3,12 +3,12 @@
 
     env.ddg_spice_tvmaze_show = function(api_result){
         if (!api_result || !api_result.id) {
-            return Spice.failed('tvmaze');
+            return Spice.failed('tvmaze_show');
         }
 
         Spice.add({
             id: "tvmaze_show",
-            name: "TV Shows",
+            name: "Entertainment",
             data: api_result,
             meta: {
                 sourceName: "TVmaze.com",
@@ -25,7 +25,7 @@
                         value: item.status
                     }
                 ];
-                
+
                 if (item.premiered) {
                     infoboxData.push(
                         {
@@ -78,11 +78,11 @@
                 }
             }
         });
-        
+
         function dateformat(date) {
             var months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
             var dateObj = new Date(date);
-            
+
             return months[dateObj.getMonth()] + " " + dateObj.getDate() + ", " + dateObj.getFullYear();
         }
     };

--- a/share/spice/tvmaze/show/tvmaze_show.js
+++ b/share/spice/tvmaze/show/tvmaze_show.js
@@ -14,6 +14,11 @@
                 sourceName: "TVmaze.com",
                 sourceUrl: api_result.url
             },
+            relevancy: {
+                primary: [
+                    { key: 'name' },
+                ]
+            },
             normalize: function(item){
                 var infoboxData = [
                     {


### PR DESCRIPTION
/cc @jagtalon @tvdavid @abeyang 
- Switched tab name to "Entertainment"
- removed bold tags (we save those for exact matches in results) and opted for `text--primary` class
- fixed `Spice.failed()` calls
- removed some trailing spaces

Pics:

![2015-02-03_20h34_11](https://cloud.githubusercontent.com/assets/873785/6033476/3ff48566-abe4-11e4-92ae-758600512b92.png)
![2015-02-03_20h35_06](https://cloud.githubusercontent.com/assets/873785/6033478/409c20fa-abe4-11e4-9375-856ae6454afb.png)
![2015-02-03_20h35_43](https://cloud.githubusercontent.com/assets/873785/6033480/42202ac0-abe4-11e4-8edf-44217ba7dbf5.png)
