### PR TITLE
Update sourceName removing FQDN extention

### DIFF
--- a/share/spice/bible/bible.js
+++ b/share/spice/bible/bible.js
@@ -14,7 +14,7 @@
             name: 'Answer',
             data: result,
             meta: {
-                sourceName: 'Bible.org',
+                sourceName: 'Bible',
                 sourceUrl: 'http://bible.org/',
                 sourceIconUrl: 'http://bible.org/sites/bible.org/files/borg6_favicon.ico'
             },

--- a/share/spice/bitcoin_balance/bitcoin_balance.js
+++ b/share/spice/bitcoin_balance/bitcoin_balance.js
@@ -15,7 +15,7 @@
                 //The balance field on the API returns satoshis, so we divide by 100000000 to convert to BTC.
             },
             meta: {
-                sourceName: "Chain.com",
+                sourceName: "Chain",
                 sourceUrl: "https://chain.com/bitcoin/addresses/" + api_result.hash
             },
             templates: {

--- a/share/spice/book/book.js
+++ b/share/spice/book/book.js
@@ -22,7 +22,7 @@
             name: 'Books',
             data: api_result.books,
             meta: {
-                sourceName: "idreambooks.com", // More at ...
+                sourceName: "iDreamBooks", // More at ...
                 sourceUrl: api_result.books[0].detail_link
             },
 

--- a/share/spice/fedora_project_package_db/fedora_project_package_db.js
+++ b/share/spice/fedora_project_package_db/fedora_project_package_db.js
@@ -16,7 +16,7 @@
             name: "Software",
             data: api_result.packages,
             meta: {
-                sourceName: "FedoraProject.org",
+                sourceName: "Fedora Project",
                 sourceUrl: 'https://admin.fedoraproject.org/pkgdb/packages/' + query + '/'
             },
             templates: {

--- a/share/spice/in_every_lang/in_every_lang.js
+++ b/share/spice/in_every_lang/in_every_lang.js
@@ -31,7 +31,7 @@
             name: "Code Snippet",
             data: solution,
             meta: {
-                sourceName: "ineverylang.com",
+                sourceName: "In Every Language",
                 sourceUrl: solutionUrl
             },
 

--- a/share/spice/leak_db/leak_db.js
+++ b/share/spice/leak_db/leak_db.js
@@ -21,7 +21,7 @@
             },
             meta: {
                 sourceUrl: 'http://leakdb.abusix.com/?q='+ encodeURIComponent(query),
-                sourceName: 'leakdb.abusix.com'
+                sourceName: 'Abusix'
             },
             templates: {
                 group: 'base',

--- a/share/spice/maven/maven.js
+++ b/share/spice/maven/maven.js
@@ -12,7 +12,7 @@ function ddg_spice_maven(api_result) {
         name: "Software",
         data: api_result,
         meta: {
-            sourceName: "maven.org",
+            sourceName: "Maven",
             sourceUrl: 'http://search.maven.org/#search%7Cga%7C1%7C' + encodeURIComponent(searchQuery),
         },
         normalize: function(item) {

--- a/share/spice/npm/npm.js
+++ b/share/spice/npm/npm.js
@@ -11,7 +11,7 @@
             name: "Software",
             data: api_result,
             meta: {
-                sourceName: "npmjs.org",
+                sourceName: "npmjs",
                 sourceUrl: 'http://npmjs.org/package/' + api_result.name
             },
             

--- a/share/spice/packagist/packagist.js
+++ b/share/spice/packagist/packagist.js
@@ -18,7 +18,7 @@
             name: "Software",
             data: api_result.results,
             meta: {
-                sourceName: "packagist.org",
+                sourceName: "Packagist",
                 sourceUrl: 'http://packagist.org/search?q=' + encodeURIComponent(query),
                 sourceIconUrl: 'http://packagist.org/favicon.ico',
                 total: api_result.total,

--- a/share/spice/population/population.js
+++ b/share/spice/population/population.js
@@ -25,7 +25,7 @@
             name: "Population",
             data: result,
             meta: {
-                sourceName: "worldbank.org",
+                sourceName: "World Bank",
                 sourceUrl: 'http://data.worldbank.org/country/' + URL_country,
             },
            normalize: function(item) {

--- a/share/spice/rainfall/rainfall.js
+++ b/share/spice/rainfall/rainfall.js
@@ -26,7 +26,7 @@
             name: "Weather",
             data: query_country,
             meta: {
-                sourceName: "worldbank.org",
+                sourceName: "World Bank",
                 sourceUrl: 'http://data.worldbank.org/country/' + URL_country
             },
             normalize: function(item) {

--- a/share/spice/tvmaze/nextepisode/tvmaze_nextepisode.js
+++ b/share/spice/tvmaze/nextepisode/tvmaze_nextepisode.js
@@ -11,7 +11,7 @@
             name: "TV Shows",
             data: api_result,
             meta: {
-                sourceName: "TVmaze.com",
+                sourceName: "TVmaze",
                 sourceUrl: api_result._embedded.nextepisode.url
             },
             normalize: function(item){

--- a/share/spice/tvmaze/previousepisode/tvmaze_previousepisode.js
+++ b/share/spice/tvmaze/previousepisode/tvmaze_previousepisode.js
@@ -11,7 +11,7 @@
             name: "TV Shows",
             data: api_result,
             meta: {
-                sourceName: "TVmaze.com",
+                sourceName: "TVmaze",
                 sourceUrl: api_result._embedded.previousepisode.url
             },
             normalize: function(item){

--- a/share/spice/tvmaze/show/tvmaze_show.js
+++ b/share/spice/tvmaze/show/tvmaze_show.js
@@ -11,7 +11,7 @@
             name: "TV Shows",
             data: api_result,
             meta: {
-                sourceName: "TVmaze.com",
+                sourceName: "TVmaze",
                 sourceUrl: api_result.url
             },
             normalize: function(item){


### PR DESCRIPTION
Possible improvement to `sourceName`. I've left timeanddate.com and xe.com as these are brand names including the extention.

https://github.com/duckduckgo/zeroclickinfo-spice/pull/1474#issuecomment-72935193

CC// @jagtalon 