### PR TITLE
Rating now aligns with cloud icon as per Issue #1486

### DIFF
--- a/share/spice/book/book.css
+++ b/share/spice/book/book.css
@@ -64,7 +64,7 @@
     float: right;
     line-height: 1;
     font-size: 2em;
-    margin-top: -0.47em;
+    margin-top: -0.20em;
     margin-right: 2.5em;
     vertical-align: top;
     color: #0099CB;


### PR DESCRIPTION
Addressed Issue #1486 

Before:

![screen shot 2015-02-07 at 10 56 16](https://cloud.githubusercontent.com/assets/468118/6091862/12d7ebdc-aeb8-11e4-8038-febb72ff1230.png)

After:
![screen shot 2015-02-07 at 10 56 06](https://cloud.githubusercontent.com/assets/468118/6091861/08f621f6-aeb8-11e4-87dc-b38a27e8575b.png)

