### PR TITLE
SalesTax: Update title, add subtitle. Standardize design

### DIFF
--- a/share/spice/sales_tax/sales_tax.js
+++ b/share/spice/sales_tax/sales_tax.js
@@ -18,6 +18,7 @@
             apiObjectName,
             taxRate,
             titleResult,
+            subtitleResult,
             statNameTmp
 
         // The API can return multiple rate results
@@ -42,12 +43,9 @@
             return Spice.failed('sales_tax');
         }
 
-        // If sales tax is 0 change the response text
-        if(taxRate == 0) {
-            titleResult = stateName+" does not levy a sales tax";
-        } else {
-            titleResult = "Sales tax for "+stateName+" is "+taxRate+"%";
-        }
+        // title and subtitle
+        titleResult = taxRate+"%";
+        subtitleResult = stateName+" - "+"State Tax"
 
         // Fix for sourceUrl washington d.c => washington-dc
         // clean stateName for use as sourceUrl
@@ -65,6 +63,7 @@
             normalize: function(item) {
                 return {
                     title: titleResult,
+                    subtitle: subtitleResult
                 };
             },
             templates: {


### PR DESCRIPTION
Fixing #1496 | [View online](http://duckpan.mrchris.me/?q=sales+tax+pa&ia=answer)

Currently displaying **0%** for no tax states.

![selection_179](https://cloud.githubusercontent.com/assets/5282264/6094488/a2515434-af66-11e4-8c03-73a3292f01aa.png)

_______________________

![selection_181](https://cloud.githubusercontent.com/assets/5282264/6094492/db4f3c74-af66-11e4-9845-5bb389f08ce6.png)
