### PR TITLE
Standardise Handlebars helpers

### DIFF
--- a/share/spice/betterific/betterific.js
+++ b/share/spice/betterific/betterific.js
@@ -64,7 +64,7 @@
  *     self.gsub(/[^a-z0-9\-\s]/i, '').squeeze(' ').gsub(/\s+/, '-')
  *   end
  */
-Handlebars.registerHelper('dashedS', function(s) {
+Handlebars.registerHelper('betterific_dashedS', function(s) {
     "use strict";
     return s.replace(/[^a-z0-9\-\s]/gi, '').replace(/\s+/g, '-');
 });

--- a/share/spice/betterific/content.handlebars
+++ b/share/spice/betterific/content.handlebars
@@ -6,12 +6,12 @@
             {{#each betterifs.betterifs}}
                 <li>
                   <span class="betterif-name">
-                    <a href="http://betterific.com/{{dashedS user.username}}/{{dashedS name}}/{{id}}" class="name-text" title="Wouldn't it be better if {{name}}">{{condense name maxlen="90"}}</a>
+                    <a href="http://betterific.com/{{betterific_dashedS user.username}}/{{betterific_dashedS name}}/{{id}}" class="name-text" title="Wouldn't it be better if {{name}}">{{condense name maxlen="90"}}</a>
                   </span>
                   <span class="stats block-stats">
                     <small>
                       [{{plural upvotes_count singular="upvote" plural="upvotes" delimeter=","}}]
-                      ({{#with this.user}}by <a href="http://betterific.com/innovator/{{dashedS username}}/{{id}}" title="See more great ideas from {{first_name}} {{last_name}} at http://betterific.com">{{first_name}} {{last_name}}</a>{{/with}})
+                      ({{#with this.user}}by <a href="http://betterific.com/innovator/{{betterific_dashedS username}}/{{id}}" title="See more great ideas from {{first_name}} {{last_name}} at http://betterific.com">{{first_name}} {{last_name}}</a>{{/with}})
                     </small>
                   </span>
                   <span class="clear-both">&nbsp;</span>
@@ -33,7 +33,7 @@
                 {{#each tags.tags}}
                     <li>
                       <span class="tag-name">
-                        <a href="http://betterific.com/{{dashedS name}}/{{id}}" title="See more great ideas about {{name}} at http://betterific.com">{{name}}</a>
+                        <a href="http://betterific.com/{{betterific_dashedS name}}/{{id}}" title="See more great ideas about {{name}} at http://betterific.com">{{name}}</a>
                       </span>
                       <span class="stats">
                         <small>
@@ -63,7 +63,7 @@
                 {{#each users.users}}
                     <li>
                       <span class="user-username">
-                        <a href="http://betterific.com/innovator/{{dashedS username}}/{{id}}" title="See great ideas by {{first_name}} {{last_name}} at http://betterific.com">{{first_name}} {{last_name}}</a>
+                        <a href="http://betterific.com/innovator/{{betterific_dashedS username}}/{{id}}" title="See great ideas by {{first_name}} {{last_name}} at http://betterific.com">{{first_name}} {{last_name}}</a>
                       </span>
                       <span class="stats">
                         <small>

--- a/share/spice/detect_lang/content.handlebars
+++ b/share/spice/detect_lang/content.handlebars
@@ -1,3 +1,3 @@
 <div>
-    This text is {{#if first.isReliable}} definitely {{else}} probably {{/if}} {{expandLang first.language}} ({{DetectLang_toPercent first.confidence}}){{#if second}}, but it could also be {{expandLang second.language}} ({{DetectLang_toPercent second.confidence}}){{/if}}.
+    This text is {{#if first.isReliable}} definitely {{else}} probably {{/if}} {{DetectLang_expandLang first.language}} ({{DetectLang_toPercent first.confidence}}){{#if second}}, but it could also be {{DetectLang_expandLang second.language}} ({{DetectLang_toPercent second.confidence}}){{/if}}.
 </div>

--- a/share/spice/detect_lang/detect_lang.js
+++ b/share/spice/detect_lang/detect_lang.js
@@ -108,7 +108,7 @@ function ddg_spice_detect_lang (api_result) {
 
         return langs[language] || "";
     };
-    Handlebars.registerHelper("expandLang", expandLang);
+    Handlebars.registerHelper("DetectLang_expandLang", expandLang);
 
     if(expandLang(api_result.data.detections[0].language) === "") {
         return;

--- a/share/spice/go_watch_it/content.handlebars
+++ b/share/spice/go_watch_it/content.handlebars
@@ -5,31 +5,31 @@
 
 <div class='data'>
 
-  {{#GoWatchIt_gwi_ifHasBothBuyAndRent buy_line rent_line }}
+  {{#gwi_ifHasBothBuyAndRent buy_line rent_line }}
     <div class="gwi--container">
         <div class="left half">
-            Rent from<br><span class='price tx-clr--dk'>{{GoWatchIt_gwi_price rent_line}}</span>
+            Rent from<br><span class='price tx-clr--dk'>{{gwi_price rent_line}}</span>
         </div>
 
         <div class="right half">
-            Buy from<br><span class='price tx-clr--dk'>{{GoWatchIt_gwi_price buy_line}}</span>
+            Buy from<br><span class='price tx-clr--dk'>{{gwi_price buy_line}}</span>
         </div>
     </div>
   {{else}}
-    {{#GoWatchIt_buyOrRent buy_line rent_line}}
+    {{#gwi_buyOrRent buy_line rent_line}}
         {{#gwi_ifHasPrice buy_line}}
             <div class="single">
-                Buy from<br><span class='price tx-clr--dk'>{{GoWatchIt_gwi_price buy_line}}</span>
+                Buy from<br><span class='price tx-clr--dk'>{{gwi_price buy_line}}</span>
             </div>
         {{else}}
             <div class="single">
                 <span class="price gwi-price--subscription tx-clr--dk">{{buy_line}}</span>
             </div>
         {{/gwi_ifHasPrice}}        
-    {{/GoWatchIt_buyOrRent}}
-  {{/GoWatchIt_gwi_ifHasBothBuyAndRent}}
+    {{/gwi_buyOrRent}}
+  {{/gwi_ifHasBothBuyAndRent}}
 </div>
 
-<div class="{{GoWatchIt_gwi_footerClass buy_line rent_line}} tx-clr--lt one-line">
+<div class="{{gwi_footerClass buy_line rent_line}} tx-clr--lt one-line">
   {{format_line}}
 </div>

--- a/share/spice/go_watch_it/content.handlebars
+++ b/share/spice/go_watch_it/content.handlebars
@@ -5,31 +5,31 @@
 
 <div class='data'>
 
-  {{#gwi_ifHasBothBuyAndRent buy_line rent_line }}
+  {{#GoWatchIt_gwi_ifHasBothBuyAndRent buy_line rent_line }}
     <div class="gwi--container">
         <div class="left half">
-            Rent from<br><span class='price tx-clr--dk'>{{gwi_price rent_line}}</span>
+            Rent from<br><span class='price tx-clr--dk'>{{GoWatchIt_gwi_price rent_line}}</span>
         </div>
 
         <div class="right half">
-            Buy from<br><span class='price tx-clr--dk'>{{gwi_price buy_line}}</span>
+            Buy from<br><span class='price tx-clr--dk'>{{GoWatchIt_gwi_price buy_line}}</span>
         </div>
     </div>
   {{else}}
-    {{#buyOrRent buy_line rent_line}}
+    {{#GoWatchIt_buyOrRent buy_line rent_line}}
         {{#gwi_ifHasPrice buy_line}}
             <div class="single">
-                Buy from<br><span class='price tx-clr--dk'>{{gwi_price buy_line}}</span>
+                Buy from<br><span class='price tx-clr--dk'>{{GoWatchIt_gwi_price buy_line}}</span>
             </div>
         {{else}}
             <div class="single">
                 <span class="price gwi-price--subscription tx-clr--dk">{{buy_line}}</span>
             </div>
         {{/gwi_ifHasPrice}}        
-    {{/buyOrRent}}
-  {{/gwi_ifHasBothBuyAndRent}}
+    {{/GoWatchIt_buyOrRent}}
+  {{/GoWatchIt_gwi_ifHasBothBuyAndRent}}
 </div>
 
-<div class="{{gwi_footerClass buy_line rent_line}} tx-clr--lt one-line">
+<div class="{{GoWatchIt_gwi_footerClass buy_line rent_line}} tx-clr--lt one-line">
   {{format_line}}
 </div>

--- a/share/spice/go_watch_it/go_watch_it.js
+++ b/share/spice/go_watch_it/go_watch_it.js
@@ -205,7 +205,7 @@
         });
     };
 
-    Spice.registerHelper("buyOrRent", function(buy_line, rent_line, options) {
+    Spice.registerHelper("GoWatchIt_buyOrRent", function(buy_line, rent_line, options) {
         if(buy_line && buy_line !== "") {
             this.line = buy_line;
             return options.fn(this);
@@ -216,7 +216,7 @@
     });
     
     // Check to see if both buy_line and rent_line are present.
-    Spice.registerHelper("gwi_ifHasBothBuyAndRent", function(buy_line, rent_line, options) {
+    Spice.registerHelper("GoWatchIt_gwi_ifHasBothBuyAndRent", function(buy_line, rent_line, options) {
         if (buy_line && buy_line !== "" && rent_line && rent_line !== "") {
             return options.fn(this);
         } else {
@@ -227,7 +227,7 @@
     // Check to see if the buy_line/rent_line includes a price.
     // This is because some provider formats (like Netflix) have
     // 'Included with Subscription' in their buy line.
-    Spice.registerHelper("gwi_ifHasPrice", function(line, options) {
+    Spice.registerHelper("GoWatchIt_gwi_ifHasPrice", function(line, options) {
         if (line.split("$").length > 1) {
             return options.fn(this);
         } else {
@@ -237,14 +237,14 @@
 
 
     // Grab dollar amount from 'Rent from $X.XX' string.
-    Spice.registerHelper("gwi_price", function(line, options) {
+    Spice.registerHelper("GoWatchIt_gwi_price", function(line, options) {
         var strings = line.split("$")
         return "$" + strings[strings.length - 1]
     });
 
     // Get the class for the footer element based on whether or not both the buy_line
     // and rent_line are present.
-    Spice.registerHelper("gwi_footerClass", function(buy_line, rent_line, options) {
+    Spice.registerHelper("GoWatchIt_gwi_footerClass", function(buy_line, rent_line, options) {
         var klass = 'gwi-footer';
         if (buy_line && buy_line != '' && rent_line && rent_line != '') {
             klass += ' double';

--- a/share/spice/go_watch_it/go_watch_it.js
+++ b/share/spice/go_watch_it/go_watch_it.js
@@ -205,7 +205,7 @@
         });
     };
 
-    Spice.registerHelper("GoWatchIt_buyOrRent", function(buy_line, rent_line, options) {
+    Spice.registerHelper("gwi_buyOrRent", function(buy_line, rent_line, options) {
         if(buy_line && buy_line !== "") {
             this.line = buy_line;
             return options.fn(this);
@@ -216,7 +216,7 @@
     });
     
     // Check to see if both buy_line and rent_line are present.
-    Spice.registerHelper("GoWatchIt_gwi_ifHasBothBuyAndRent", function(buy_line, rent_line, options) {
+    Spice.registerHelper("gwi_ifHasBothBuyAndRent", function(buy_line, rent_line, options) {
         if (buy_line && buy_line !== "" && rent_line && rent_line !== "") {
             return options.fn(this);
         } else {
@@ -227,7 +227,7 @@
     // Check to see if the buy_line/rent_line includes a price.
     // This is because some provider formats (like Netflix) have
     // 'Included with Subscription' in their buy line.
-    Spice.registerHelper("GoWatchIt_gwi_ifHasPrice", function(line, options) {
+    Spice.registerHelper("gwi_ifHasPrice", function(line, options) {
         if (line.split("$").length > 1) {
             return options.fn(this);
         } else {
@@ -237,14 +237,14 @@
 
 
     // Grab dollar amount from 'Rent from $X.XX' string.
-    Spice.registerHelper("GoWatchIt_gwi_price", function(line, options) {
+    Spice.registerHelper("gwi_price", function(line, options) {
         var strings = line.split("$")
         return "$" + strings[strings.length - 1]
     });
 
     // Get the class for the footer element based on whether or not both the buy_line
     // and rent_line are present.
-    Spice.registerHelper("GoWatchIt_gwi_footerClass", function(buy_line, rent_line, options) {
+    Spice.registerHelper("gwi_footerClass", function(buy_line, rent_line, options) {
         var klass = 'gwi-footer';
         if (buy_line && buy_line != '' && rent_line && rent_line != '') {
             klass += ' double';

--- a/share/spice/movie/movie.js
+++ b/share/spice/movie/movie.js
@@ -109,7 +109,7 @@
 
     // Convert minutes to hr. min. format.
     // e.g. {{time 90}} will return 1 hr. 30 min.
-    Handlebars.registerHelper("time", function(runtime) {
+    Handlebars.registerHelper("movie_time", function(runtime) {
         var hours = '',
             minutes = runtime;
         if (runtime >= 60) {

--- a/share/spice/movie/subtitle_content.handlebars
+++ b/share/spice/movie/subtitle_content.handlebars
@@ -11,7 +11,7 @@
 
 <span class="movie--runtime">
   {{#if runtime}}
-    <span>Run Time: {{time runtime}}</span>
+    <span>Run Time: {{movie_time runtime}}</span>
   {{/if}}
   {{#and runtime mpaa_rating}}
     <span class="detail__separator"> | </span>

--- a/share/spice/open_snp/open_snp.handlebars
+++ b/share/spice/open_snp/open_snp.handlebars
@@ -4,11 +4,11 @@
 </div>
 
 <div id='snp-facts'>
-    {{#facts annotations.snpedia}}
+    {{#OpenSNP_facts annotations.snpedia}}
         {{#each this}}
         <a href='{{url}}'>{{reference}}</a>: {{fact}}<br>
         {{/each}}
-    {{/facts}}
+    {{/OpenSNP_facts}}
     [<a id='snpedia-link' href='http://www.snpedia.com/index.php/{{name}}'>
         More at SNPedia
     </a>]
@@ -21,7 +21,7 @@
 <hr class='horizontal_line'>
 
 <div id='snp-annotations'>
-    {{#annotations annotations name}}
+    {{#OpenSNP_annotations annotations name}}
     {{#each this}}
             <br>
             {{author}} <i> et. al.</i>, {{year}}:
@@ -38,5 +38,5 @@
         | More at <a href='{{source}}'>{{publication}}</a>
         <br>
     {{/with}}{{/if}}
-    {{/annotations}}
+    {{/OpenSNP_annotations}}
 </div>

--- a/share/spice/open_snp/open_snp.js
+++ b/share/spice/open_snp/open_snp.js
@@ -25,7 +25,7 @@ ddg_spice_open_snp = function(api_result) {
     });
 }
 
-Handlebars.registerHelper('facts', function(facts, options) {
+Handlebars.registerHelper('OpenSNP_facts', function(facts, options) {
     "use strict";
 
     return options.fn(
@@ -40,7 +40,7 @@ Handlebars.registerHelper('facts', function(facts, options) {
     );
 });
 
-Handlebars.registerHelper('annotations', function(annotations, name, options) {
+Handlebars.registerHelper('OpenSNP_annotations', function(annotations, name, options) {
     "use strict";
 
     var mendeley = annotations.mendeley;

--- a/share/spice/translate/detect/translate_detect.js
+++ b/share/spice/translate/detect/translate_detect.js
@@ -21,7 +21,7 @@ function ddg_spice_translate_detect (api_result) {
 
 
 // Helper to get only unique translations
-Handlebars.registerHelper('getTerms', function(input, options){
+Handlebars.registerHelper('translate_getTerms', function(input, options){
     var translations = [];
     var unique = {};
 

--- a/share/spice/translate/from_to/translate_from_to.js
+++ b/share/spice/translate/from_to/translate_from_to.js
@@ -3,7 +3,7 @@
 if (!Handlebars.helpers.getTerms) {
 
     // Helper to get only unique translations
-    Handlebars.registerHelper('getTerms', function(input, options){
+    Handlebars.registerHelper('translate_getTerms', function(input, options){
         var translations = [];
         var unique = {};
 

--- a/share/spice/translate/translate_from_to.handlebars
+++ b/share/spice/translate/translate_from_to.handlebars
@@ -1,7 +1,7 @@
 <ul>
-	{{#getTerms term0.PrincipalTranslations}}
+	{{#translate_getTerms term0.PrincipalTranslations}}
 		{{#each this}}
 			<li>{{word}}</li>
 		{{/each}}
-	{{/getTerms}}
+	{{/translate_getTerms}}
 </ul>


### PR DESCRIPTION
Fixing #1480

- [x] betterific/betterific.js:H`andlebars.registerHelper('dashedS',`
- [x] detect_lang/detect_lang.js: `Handlebars.registerHelper("expandLang",`
- [x] go_watch_it/go_watch_it.js: `Spice.registerHelper("buyOrRent",`
- [x] movie/movie.js: `Handlebars.registerHelper("time", function(runtime)`
- [x] open_snp/open_snp.js:H`andlebars.registerHelper('facts',`
- [x] translate/from_to/translate_from_to.js: `Handlebars.registerHelper('getTerms',`