### PR TITLE
Updating Github Spice

### DIFF
--- a/lib/DDG/Spice/Github.pm
+++ b/lib/DDG/Spice/Github.pm
@@ -33,7 +33,6 @@ handle query_lc => sub {
     
     my $query = $_;
     my $l; 
-    #if (/ ($langs) /|| /^($langs) / || / ($langs)$/) {
     if (/\b($langs)\b/) {
         $l = $1;
         $query =~ s/ ($langs) |^($langs) | ($langs)$//;
@@ -47,7 +46,9 @@ handle query_lc => sub {
         # Github. You specify language as a part of the raw query string
         # passed to the api like on the web form interface. 
         return "${query} language:\"${l}\"" unless /^jobs\b|\bjobs$|^status\b|\bstatus$/;
-    } 
+    } else {
+	return $query;
+    }
     
     return;
 };

--- a/lib/DDG/Spice/Github.pm
+++ b/lib/DDG/Spice/Github.pm
@@ -2,6 +2,7 @@ package DDG::Spice::Github;
 # ABSTRACT: Search for information about GitHub repositories
 
 use DDG::Spice;
+use String::Trim;
 
 primary_example_queries "github zeroclickinfo";
 description "Github info";
@@ -37,13 +38,9 @@ handle query_lc => sub {
         $query =~ s/ ($langs) |^($langs) | ($langs)$//;
 
         # make sure there is an actual query, and not just a language term search
-        for ($query) {
-            $query =~ s/^\s*//; 
-            $query =~ s/\s*$//;
-            if ($query eq "") {
-                return;
-            }
-        }
+        trim($query);  # need to add `use String::Trim`
+        s/\s+/ /g;     # squash down multiple spaces
+        return unless length $_;
 
         # These is no separate language parameter for the query to 
         # Github. You specify language as a part of the raw query string

--- a/lib/DDG/Spice/Github.pm
+++ b/lib/DDG/Spice/Github.pm
@@ -33,7 +33,8 @@ handle query_lc => sub {
     
     my $query = $_;
     my $l; 
-    if (/\b($langs)\b/) {
+    # can't use standard \b word boundary here. It will fail for languages with characters like c++
+    if (/ ($langs) / or /^($langs) / or / ($langs)$/) {
         $l = $1;
         $query =~ s/ ($langs) |^($langs) | ($langs)$//;
 

--- a/lib/DDG/Spice/Github.pm
+++ b/lib/DDG/Spice/Github.pm
@@ -33,35 +33,30 @@ spice proxy_cache_valid => '200 30d';
 
 handle query_lc => sub {
     s/^github\s+|\s+github$//;
+    if ($_ eq "") {
+        return;
+    }
     
     my $query = $_;
     my $l; 
-    # structuring the search this way gives the first langauge specified
-    # precedence. So have 'python javascript' passes the query
-    # 'javascript language:python' to github.
-    if (/($langs) /||/ ($langs)/ || /^($langs)/ || /($langs)$/) {
+    if (/ ($langs) /|| /^($langs) / || / ($langs)$/) {
         $l = $1;
-        $query =~ s/($langs) | ($langs)|^($langs)|($langs)$//;
+        $query =~ s/ ($langs) |^($langs) | ($langs)$//;
 
         # make sure there is an actual query, and not just a language term search
-        #for ($query) {
-        #    $query =~ s/^\s*//; 
-        #    $query =~ s/\s*$//;
-        #    if ($query eq "") {
-        #        # playing around with the main site, the live version does load
-        #        # something for just 'github bash' so go ahead and pass the query
-        #        return $_;
-        #    }
-        #}
+        for ($query) {
+            $query =~ s/^\s*//; 
+            $query =~ s/\s*$//;
+            if ($query eq "") {
+                return;
+            }
+        }
 
         # These is no separate language parameter for the query to 
         # Github. You specify language as a part of the raw query string
         # passed to the api like on the web form interface. 
-        return "${query} language:\"${l}\"";
+        return "${query} language:\"${l}\"" unless /^jobs\b|\bjobs$|^status\b|\bstatus$/;
     } 
-    
-    
-    
     
     return $_ unless /^jobs\b|\bjobs$|^status\b|\bstatus$/;
     return;

--- a/lib/DDG/Spice/Github.pm
+++ b/lib/DDG/Spice/Github.pm
@@ -16,7 +16,7 @@ attribution web => ['http://dylansserver.com','Dylan Lloyd'],
 triggers startend => "github";
 
 my @triggers = share("triggers.txt")->slurp;
-triggers startend => @triggers;
+triggers startend => "github";
 
 chomp(@triggers);
 my $langs = join("|", map(quotemeta, @triggers));

--- a/lib/DDG/Spice/Github.pm
+++ b/lib/DDG/Spice/Github.pm
@@ -13,13 +13,59 @@ attribution web => ['http://dylansserver.com','Dylan Lloyd'],
             email => ['dylan@dylansserver.com','Dylan Lloyd'];
 
 triggers startend => "github";
-spice to => 'https://api.github.com/legacy/repos/search/$1?callback={{callback}}';
+#spice to => 'https://api.github.com/legacy/repos/search/$1?callback={{callback}}';
+
+my @triggers = share("triggers.txt")->slurp;
+triggers startend => @triggers;
+
+chomp(@triggers);
+my $langs = join("|", map(quotemeta, @triggers));
+
+spice to => 'https://api.github.com/search/repositories?q=$1&sort=stars&callback={{callback}}';
+
 spice proxy_cache_valid => '200 30d';
 
-handle remainder_lc => sub {
-    return unless $_;
+#handle remainder_lc => sub {
+#    return unless $_;
+#    return $_ unless /^jobs\b|\bjobs$|^status\b|\bstatus$/;
+#    return;
+#};
+
+handle query_lc => sub {
+    s/^github\s+|\s+github$//;
+    
+    my $query = $_;
+    my $l; 
+    # structuring the search this way gives the first langauge specified
+    # precedence. So have 'python javascript' passes the query
+    # 'javascript language:python' to github.
+    if (/($langs) /||/ ($langs)/ || /^($langs)/ || /($langs)$/) {
+        $l = $1;
+        $query =~ s/($langs) | ($langs)|^($langs)|($langs)$//;
+
+        # make sure there is an actual query, and not just a language term search
+        #for ($query) {
+        #    $query =~ s/^\s*//; 
+        #    $query =~ s/\s*$//;
+        #    if ($query eq "") {
+        #        # playing around with the main site, the live version does load
+        #        # something for just 'github bash' so go ahead and pass the query
+        #        return $_;
+        #    }
+        #}
+
+        # These is no separate language parameter for the query to 
+        # Github. You specify language as a part of the raw query string
+        # passed to the api like on the web form interface. 
+        return "${query} language:\"${l}\"";
+    } 
+    
+    
+    
+    
     return $_ unless /^jobs\b|\bjobs$|^status\b|\bstatus$/;
     return;
 };
+
 
 1;

--- a/lib/DDG/Spice/Github.pm
+++ b/lib/DDG/Spice/Github.pm
@@ -13,7 +13,6 @@ attribution web => ['http://dylansserver.com','Dylan Lloyd'],
             email => ['dylan@dylansserver.com','Dylan Lloyd'];
 
 triggers startend => "github";
-#spice to => 'https://api.github.com/legacy/repos/search/$1?callback={{callback}}';
 
 my @triggers = share("triggers.txt")->slurp;
 triggers startend => @triggers;
@@ -24,12 +23,6 @@ my $langs = join("|", map(quotemeta, @triggers));
 spice to => 'https://api.github.com/search/repositories?q=$1&sort=stars&callback={{callback}}';
 
 spice proxy_cache_valid => '200 30d';
-
-#handle remainder_lc => sub {
-#    return unless $_;
-#    return $_ unless /^jobs\b|\bjobs$|^status\b|\bstatus$/;
-#    return;
-#};
 
 handle query_lc => sub {
     s/^github\s+|\s+github$//;
@@ -61,6 +54,4 @@ handle query_lc => sub {
     return $_ unless /^jobs\b|\bjobs$|^status\b|\bstatus$/;
     return;
 };
-
-
 1;

--- a/lib/DDG/Spice/Github.pm
+++ b/lib/DDG/Spice/Github.pm
@@ -33,7 +33,8 @@ handle query_lc => sub {
     
     my $query = $_;
     my $l; 
-    if (/ ($langs) /|| /^($langs) / || / ($langs)$/) {
+    #if (/ ($langs) /|| /^($langs) / || / ($langs)$/) {
+    if (/\b($langs)\b/) {
         $l = $1;
         $query =~ s/ ($langs) |^($langs) | ($langs)$//;
 

--- a/lib/DDG/Spice/Github.pm
+++ b/lib/DDG/Spice/Github.pm
@@ -26,7 +26,7 @@ spice proxy_cache_valid => '200 30d';
 
 handle query_lc => sub {
     s/^github\s+|\s+github$//;
-    if ($_ eq "") {
+    if ($_ eq "" || m/\bjobs\b|\bstatus\b/) {
         return;
     }
     
@@ -51,7 +51,6 @@ handle query_lc => sub {
         return "${query} language:\"${l}\"" unless /^jobs\b|\bjobs$|^status\b|\bstatus$/;
     } 
     
-    return $_ unless /^jobs\b|\bjobs$|^status\b|\bstatus$/;
     return;
 };
 1;

--- a/share/spice/github/footer.handlebars
+++ b/share/spice/github/footer.handlebars
@@ -1,6 +1,6 @@
 <div class="tile__update__info one-line">
   <i class="star starIcon"></i>
-  {{watchers}} &middot; Updated {{GitHub_last_pushed pushed}}
+  {{watchers}} &middot; Updated {{GitHub_last_pushed pushed_at}}
 </div>
 
 

--- a/share/spice/github/github.js
+++ b/share/spice/github/github.js
@@ -11,7 +11,6 @@
                     source = $(script).attr("src"),
                     query = source.match(/github\/([^\/]+)/)[1];
 
-        //var results = api_result.data.repositories;
         var results = api_result.data.items;
 
         if (!results) {
@@ -42,7 +41,8 @@
             normalize: function(item) {
                 return {
                     title: item.name,
-                    subtitle: item.owner + "/" + item.name
+                    subtitle: item.owner + "/" + item.name,
+		    url: item.html_url
                 };
             },
             relevancy: {

--- a/share/spice/github/github.js
+++ b/share/spice/github/github.js
@@ -41,7 +41,7 @@
             normalize: function(item) {
                 return {
                     title: item.name,
-                    subtitle: item.owner + "/" + item.name,
+                    subtitle: item.owner.login + "/" + item.name,
 		    url: item.html_url
                 };
             },

--- a/share/spice/github/github.js
+++ b/share/spice/github/github.js
@@ -11,7 +11,8 @@
                     source = $(script).attr("src"),
                     query = source.match(/github\/([^\/]+)/)[1];
 
-        var results = api_result.data.repositories;
+        //var results = api_result.data.repositories;
+        var results = api_result.data.items;
 
         if (!results) {
             return Spice.failed('github');

--- a/share/spice/github/github.js
+++ b/share/spice/github/github.js
@@ -63,10 +63,10 @@
 }(this));
 
 // Make sure we display only three items.
-Handlebars.registerHelper("GitHub_last_pushed", function(pushed) {
+Handlebars.registerHelper("GitHub_last_pushed", function(pushed_at) {
     "use strict";
 
-    var last_pushed = Math.floor((new Date() - new Date(pushed)) / (1000*60*60*24));
+    var last_pushed = Math.floor((new Date() - new Date(pushed_at)) / (1000*60*60*24));
 
     var years_ago = Math.floor(last_pushed / 365);
     if (years_ago >= 1) {
@@ -81,3 +81,4 @@ Handlebars.registerHelper("GitHub_last_pushed", function(pushed) {
 
     return last_pushed;
 });
+

--- a/share/spice/github/github.js
+++ b/share/spice/github/github.js
@@ -10,6 +10,11 @@
         var script = $('[src*="/js/spice/github/"]')[0],
                     source = $(script).attr("src"),
                     query = source.match(/github\/([^\/]+)/)[1];
+        if (/language:".*?"/.test(unescape(query))) {
+            var itemType = "Git Repositories (" + unescape(query).match(/language:"(.*?)"/)[1] + ")";
+        } else {
+            var itemType = "Git Repositories";
+        }
 
         var results = api_result.data.items;
 
@@ -26,7 +31,7 @@
             name: "Software",
             data: results,
             meta: {
-                itemType: "Git Repositories",
+                itemType: itemType,
                 sourceUrl: 'http://www.github.com/search?q=' +  encodeURIComponent(query),
                 sourceName: 'GitHub'
             },

--- a/share/spice/github/triggers.txt
+++ b/share/spice/github/triggers.txt
@@ -1,0 +1,315 @@
+actionscript
+c#
+c++
+clojure
+coffeescript
+common lisp
+css
+c
+diff
+emacs lisp
+erlang
+haskell
+html
+javascript
+java
+lua
+objective-c
+perl
+php
+python
+ruby
+scala
+scheme
+sql
+abap
+ada
+agda
+ags script
+alloy
+ant build system
+antlr
+apacheconf
+apex
+apl
+applescript
+arc
+arduino
+asciidoc
+aspectj
+asp
+assembly
+ats
+augeas
+autohotkey
+autoit
+awk
+batchfile
+befunge
+bison
+blitzbasic
+blitzmax
+bluespec
+boo
+brainfuck
+brightscript
+bro
+c-objdump
+c2hs haskell
+cap'n proto
+ceylon
+chapel
+chuck
+cirru
+clean
+clips
+cmake
+cobol
+coldfusion
+coldfusion cfc
+component pascal
+coq
+cpp-objdump
+creole
+crystal
+cucumber
+cuda
+cycript
+cython
+d-objdump
+darcs patch
+dart
+dm
+dockerfile
+dogescript
+dylan
+d
+e
+eagle
+ecere projects
+ecl
+ec
+edn
+eiffel
+elixir
+elm
+emberscript
+f#
+factor
+fancy
+fantom
+fish
+flux
+forth
+fortran
+frege
+g-code
+game maker language
+gams
+gap
+gas
+gdscript
+genshi
+gentoo ebuild
+gentoo eclass
+gettext catalog
+glsl
+glyph
+gnuplot
+golo
+gosu
+go
+grace
+grammatical framework
+graph modeling language
+graphviz (dot)
+groff
+groovy server pages
+groovy
+hack
+haml
+handlebars
+harbour
+haxe
+html+django
+http
+hy
+idl
+idris
+igor pro
+inform 7
+ini
+inno setup
+ioke
+io
+irc log
+isabelle
+jade
+java server pages
+json5
+jsoniq
+jsonld
+json
+julia
+j
+kit
+kotlin
+krl
+labview
+lasso
+latte
+less
+lfe
+lilypond
+liquid
+literate agda
+literate coffeescript
+literate haskell
+livescript
+llvm
+logos
+logtalk
+lolcode
+lookml
+lsl
+makefile
+mako
+markdown
+mask
+mathematica
+matlab
+maven pom
+max
+mediawiki
+mercury
+minid
+mirah
+monkey
+moocode
+moonscript
+mtml
+mupad
+myghty
+m
+nemerle
+nesc
+netlogo
+nginx
+nimrod
+ninja
+nit
+nix
+nsis
+nu
+numpy
+objdump
+objective-c++
+objective-j
+ocaml
+omgrofl
+ooc
+opa
+opal
+opencl
+openedge abl
+openscad
+org
+oxygene
+ox
+pan
+papyrus
+parrot assembly
+parrot internal representation
+parrot
+pascal
+pawn
+perl6
+piglatin
+pike
+pod
+pogoscript
+postscript
+powershell
+processing
+prolog
+propeller spin
+protocol buffer
+puppet
+pure data
+purescript
+python traceback
+python
+qmake
+qml
+racket
+ragel in ruby host
+raw token data
+rdoc
+realbasic
+rebol
+redcode
+red
+restructuredtext
+rhtml
+rmarkdown
+robotframework
+rouge
+rust
+r
+sage
+sas
+sass
+scaml
+scilab
+scss
+self
+shellsession
+shell
+shen
+slash
+slim
+smalltalk
+smarty
+sourcepawn
+sqf
+squirrel
+standard ml
+stata
+ston
+stylus
+supercollider
+swift
+systemverilog
+tcl
+tcsh
+tea
+textile
+tex
+thrift
+toml
+turing
+twig
+txl
+typescript
+unified parallel c
+unrealscript
+vala
+vcl
+verilog
+vhdl
+viml
+visual basic
+volt
+wisp
+xbase
+xc
+xml
+xojo
+xproc
+xquery
+xslt
+xs
+xtend
+yaml
+zephir
+zimpl

--- a/share/spice/github/triggers.txt
+++ b/share/spice/github/triggers.txt
@@ -10,7 +10,6 @@ diff
 emacs lisp
 erlang
 haskell
-html
 javascript
 java
 lua
@@ -146,10 +145,8 @@ irc log
 isabelle
 jade
 java server pages
-json5
 jsoniq
 jsonld
-json
 julia
 j
 kit

--- a/t/Github.t
+++ b/t/Github.t
@@ -18,8 +18,7 @@ ddg_spice_test(
         caller => 'DDG::Spice::Github'
     ),
     
-    'github status' => undef,
-    'github' => undef
+    'github status' => undef
 );
 
 done_testing;

--- a/t/Github.t
+++ b/t/Github.t
@@ -17,6 +17,16 @@ ddg_spice_test(
         call_type => 'include',
         caller => 'DDG::Spice::Github'
     ),
+    'c++ test github' => test_spice(
+        '/js/spice/github/test%20language%3A%22c%22',
+        call_type => 'include',
+        caller => 'DDG::Spice::Github'
+    ),
+    'github test c++' => test_spice(
+        '/js/spice/github/test%20language%3A%22c%22',
+        call_type => 'include',
+        caller => 'DDG::Spice::Github'
+    ),
     
     'github status' => undef
 );

--- a/t/Github.t
+++ b/t/Github.t
@@ -18,12 +18,12 @@ ddg_spice_test(
         caller => 'DDG::Spice::Github'
     ),
     'c++ test github' => test_spice(
-        '/js/spice/github/test%20language%3A%22c%22',
+        '/js/spice/github/test%20language%3A%22c%2B%2B%22',
         call_type => 'include',
         caller => 'DDG::Spice::Github'
     ),
     'github test c++' => test_spice(
-        '/js/spice/github/test%20language%3A%22c%22',
+        '/js/spice/github/test%20language%3A%22c%2B%2B%22',
         call_type => 'include',
         caller => 'DDG::Spice::Github'
     ),


### PR DESCRIPTION
This does the following:

 - Updates the Github Spice to use the current version of the Github API
 - Adds language detection to the query parser, adds detected languages as the language parameter passed to Github
 - Does remove the bare github search test, my testing shows it was working correctly showing Github status.

This is in lieu of the previous GithubLanguages Spice I was working on.