### PR TITLE
use new ddg-wrapped jsonp api endpoints

### DIFF
--- a/lib/DDG/Spice/InEveryLang.pm
+++ b/lib/DDG/Spice/InEveryLang.pm
@@ -32,9 +32,8 @@ attribution github  => ['https://github.com/josephwegner', 'josephwegner'],
 
 triggers startend => "fizz buzz", "fizzbuzz", "quine", "fibonacci sequence", "binary search";
 
-spice to => 'http://www.ineverylang.com/$1.json';
+spice to => 'http://www.ineverylang.com/ddg-$1.json';
 spice from => '(^[^\/]+)';
-spice wrap_jsonp_callback => 1;
 
 handle query_lc => sub {
     $_ =~ m/(fizz ?buzz)|(quine)|(fibonacci sequence)|(binary search)/;


### PR DESCRIPTION
Solves the gzip issue on my API - now the DDG api responses come pre-wrapped with the JSONP callback. It's a bit brittle and coupled, so things will blow up if the callback naming format ever changes, but we can cross that bridge when we get there.