### PR TITLE
movie.js: remove the use of is_retina because it's being deprecated.

### DIFF
--- a/share/spice/movie/movie.js
+++ b/share/spice/movie/movie.js
@@ -76,7 +76,7 @@
                     img: image,
                     img_m: image,
                     url: item.links.alternate,
-                    is_retina: is_retina ? "is_retina" : "no_retina"
+                    is_retina: (DDG.is3x || DDG.is2x) ? "is_retina" : "no_retina"
                 };
             },
             templates: {


### PR DESCRIPTION
We're moving to `DDG.is3x` and `DDG.is2x` now.