### PR TITLE
RxInfo: Update to use isRelevant to avoid returning invaild results

### DIFF
--- a/lib/DDG/Spice/RxInfo.pm
+++ b/lib/DDG/Spice/RxInfo.pm
@@ -17,8 +17,13 @@ triggers startend => 'pill', 'rxinfo', 'capsule', 'tablet', 'softgel', 'caplets'
 spice to => 'http://rximage.nlm.nih.gov/api/rximage/1/rxbase?resolution=300&includeIngredients=true&parse=$1';
 spice wrap_jsonp_callback => 1;
 
+my $triggerWords = join "|", share('triggerWords.txt')->slurp(chomp => 1);
+
 handle remainder => sub {
-    return $_ if $_;
+    my $attributes = 0;
+    return unless $_;   
+    $attributes = 1 if (/$triggerWords/);
+    return $_,$attributes;
     return;
 };
 1;

--- a/lib/DDG/Spice/RxInfo.pm
+++ b/lib/DDG/Spice/RxInfo.pm
@@ -15,15 +15,14 @@ attribution web => ['http://www.medicosconsultants.com', 'Medicos Consultants, L
 triggers startend => 'pill', 'rxinfo', 'capsule', 'tablet', 'softgel', 'caplets';
 
 spice to => 'http://rximage.nlm.nih.gov/api/rximage/1/rxbase?resolution=300&includeIngredients=true&parse=$1';
+spice from => '(.*?)/(\d)';
 spice wrap_jsonp_callback => 1;
 
 my $triggerWords = join "|", share('triggerWords.txt')->slurp(chomp => 1);
 
 handle remainder => sub {
-    my $attributes = 0;
-    return unless $_;   
-    $attributes = 1 if (/$triggerWords/);
-    return $_,$attributes;
+    return unless $_;
+    return $_, (/$triggerWords/) ? "0" : "1"; # return 0 if match in triggerWords file found
     return;
 };
 1;

--- a/share/spice/rx_info/rx_info.js
+++ b/share/spice/rx_info/rx_info.js
@@ -72,7 +72,7 @@
             relevancy: {
                 skip_words : skip_words,
                 primary: [
-                    { key: 'name' }
+                    { key: 'name' }, { key: 'ndc11' }
                 ]
             },
         });

--- a/share/spice/rx_info/rx_info.js
+++ b/share/spice/rx_info/rx_info.js
@@ -25,6 +25,19 @@
             return Spice.failed('rx_info');
         }
 
+        // Filter irrelevant results using DDG.isRelevant.
+        var skip_words = ['pill', 'rxinfo', 'capsule', 'tablet', 'softgel', 'caplets'];
+        var results = [];
+        for(var i = 0; i < api_result.nlmRxImages.length; i++) {
+            if(DDG.isRelevant(api_result.nlmRxImages[i].name, skip_words)) {
+                results.push(api_result.nlmRxImages[i]);
+            }
+        }
+
+        if(results.length === 0) {
+            return Spice.failed('rx_info');
+        }
+
         var sourceName = "More at DailyMed",
             sourceUrl  = "http://dailymed.nlm.nih.gov/";
 

--- a/share/spice/rx_info/rx_info.js
+++ b/share/spice/rx_info/rx_info.js
@@ -24,11 +24,28 @@
         if (!api_result || api_result.error || !api_result.replyStatus || !api_result.replyStatus.totalImageCount || api_result.replyStatus.totalImageCount < 1) {
             return Spice.failed('rx_info');
         }
+        
+        var script = $('[src*="/js/spice/rx_info/"]')[0],
+            source = $(script).attr("src"),
+            triggerWordMatch = parseInt(source.match(/rx_info\/[^\/]+\/(\d)/)[1]),
+            relCheck;
+        
 
+        // meta information
         var sourceName = "More at DailyMed",
             sourceUrl  = "http://dailymed.nlm.nih.gov/",
             skip_words = ['pill', 'rxinfo', 'capsule', 'tablet', 'softgel', 'caplets'];
-
+        
+        // perform relevancy checking if triggerWordMatch true
+        if(triggerWordMatch) {
+            relCheck = {
+                skip_words : skip_words,
+                primary: [
+                    { key: 'name' }, { key: 'ndc11' }
+                ]
+            };
+        }
+      
         Spice.add({
             id: "rx_info",
             name: "RxInfo",
@@ -69,12 +86,7 @@
                     proxyImageUrl: "https://images.duckduckgo.com/iu/?u=" + encodeURIComponent(item.imageUrl) + "&f=1"
                 }
             },
-            relevancy: {
-                skip_words : skip_words,
-                primary: [
-                    { key: 'name' }, { key: 'ndc11' }
-                ]
-            },
+            relevancy: relCheck,
         });
     };
 }(this));

--- a/share/spice/rx_info/rx_info.js
+++ b/share/spice/rx_info/rx_info.js
@@ -25,21 +25,9 @@
             return Spice.failed('rx_info');
         }
 
-        // Filter irrelevant results using DDG.isRelevant.
-        var skip_words = ['pill', 'rxinfo', 'capsule', 'tablet', 'softgel', 'caplets'];
-        var results = [];
-        for(var i = 0; i < api_result.nlmRxImages.length; i++) {
-            if(DDG.isRelevant(api_result.nlmRxImages[i].name, skip_words)) {
-                results.push(api_result.nlmRxImages[i]);
-            }
-        }
-
-        if(results.length === 0) {
-            return Spice.failed('rx_info');
-        }
-
         var sourceName = "More at DailyMed",
-            sourceUrl  = "http://dailymed.nlm.nih.gov/";
+            sourceUrl  = "http://dailymed.nlm.nih.gov/",
+            skip_words = ['pill', 'rxinfo', 'capsule', 'tablet', 'softgel', 'caplets'];
 
         Spice.add({
             id: "rx_info",
@@ -80,7 +68,13 @@
                     inactive: inactive,
                     proxyImageUrl: "https://images.duckduckgo.com/iu/?u=" + encodeURIComponent(item.imageUrl) + "&f=1"
                 }
-            } 
+            },
+            relevancy: {
+                skip_words : skip_words,
+                primary: [
+                    { key: 'name' }
+                ]
+            },
         });
     };
 }(this));

--- a/share/spice/rx_info/triggerWords.txt
+++ b/share/spice/rx_info/triggerWords.txt
@@ -1,0 +1,25 @@
+white
+clear
+black
+gray
+brown
+tan
+red
+pink
+orange
+peach
+yellow
+green
+blue
+purple
+round
+oblong
+oval
+square
+rectangle
+diamond
+3 sided
+5 sided
+6 sided
+7 sided
+8 sided

--- a/t/RxInfo.t
+++ b/t/RxInfo.t
@@ -12,25 +12,25 @@ ddg_spice_test(
     ],
     # multiple filters (color, shape) that returns multiple results
     'pill red round' => test_spice(
-        '/js/spice/rx_info/red%20round',
+        '/js/spice/rx_info/red%20round/0',
         call_type => 'include',
         caller => 'DDG::Spice::RxInfo',
     ),
     # returns a single result via NDC search
     'rxinfo 68180-0481-01' => test_spice(
-        '/js/spice/rx_info/68180-0481-01',
+        '/js/spice/rx_info/68180-0481-01/1',
         call_type => 'include',
         caller => 'DDG::Spice::RxInfo',
     ),
     # multiple filters (imprint, color) that returns multiple results
     'pill LL blue' => test_spice(
-        '/js/spice/rx_info/LL%20blue',
+        '/js/spice/rx_info/LL%20blue/0',
         call_type => 'include',
         caller => 'DDG::Spice::RxInfo',
     ),
     # no results
     'rxinfo gibberish' => test_spice(
-        '/js/spice/rx_info/gibberish',
+        '/js/spice/rx_info/gibberish/1',
         call_type => 'include',
         caller => 'DDG::Spice::RxInfo',
     ),


### PR DESCRIPTION
Fixing #1542 

Currently the RxInfo Spice triggers on small English two letter/three letter words: `aa ad ae am an as at be by do go ha he hi id if in is it me no of ok on or pi so to up us we`. 

Examples:
https://duckduckgo.com/?q=tablet+of+blue+color
https://duckduckgo.com/?q=tablet+is
https://duckduckgo.com/?q=capsule+age

Use DDG.isRelevant and call Spice.failed if no relevant results are found
