### PR TITLE
Remove unused local vars in amazon spice js

### DIFF
--- a/share/spice/amazon/amazon.js
+++ b/share/spice/amazon/amazon.js
@@ -7,13 +7,10 @@
             return Spice.failed('products');
         }
 
-        var items = api_result.results,
-            loadedRatingsData = false;
-
         Spice.add({
             id: 'products',
             name: 'Products',
-            data: items,
+            data: api_result.results,
             allowMultipleCalls: true,
             model: 'Product',
             meta: {


### PR DESCRIPTION
The `loadedRatingsData` var isn't used anymore, and the `items` local var isn't necessary since it's only referenced in one place now.

@moollaza @jagtalon 