### PR TITLE
Use provider name for Env APIKEY variable

### DIFF
--- a/lib/DDG/Spice/RandWord.pm
+++ b/lib/DDG/Spice/RandWord.pm
@@ -15,7 +15,7 @@ attribution web => ['http://dylansserver.com','Dylan Lloyd'],
             email => ['dylan@dylansserver.com','Dylan Lloyd'];
 
 spice from => '(?:([0-9]+)\-([0-9]+)|)';
-spice to => 'http://api.wordnik.com/v4/words.json/randomWord?minLength=$1&maxLength=$2&api_key={{ENV{DDG_SPICE_RANDWORD_APIKEY}}}&callback={{callback}}';
+spice to => 'http://api.wordnik.com/v4/words.json/randomWord?minLength=$1&maxLength=$2&api_key={{ENV{DDG_SPICE_WORDNIK_APIKEY}}}&callback={{callback}}';
 spice proxy_cache_valid => "418 1d";
 
 triggers any => "random word";


### PR DESCRIPTION
The canonical naming convention is to reference the provider name, not the Spice name. We're using this APIKEY in other Instant Answers so it makes sense to reference the Provider and not the IA name.

Note: There is a corresponding change to the close-source code

/cc @jagtalon 