### PR TITLE
HOTFIX: CourseBuffet: API endpoint is down because it's using HTTPS

### DIFF
--- a/lib/DDG/Spice/Coursebuffet.pm
+++ b/lib/DDG/Spice/Coursebuffet.pm
@@ -4,7 +4,7 @@ use strict;
 use DDG::Spice;
 use Text::Trim;
 
-spice to => 'http://www.coursebuffet.com/ddg/$1/$2';
+spice to => 'https://www.coursebuffet.com/ddg/$1/$2';
 spice from => '(.*?)/(.*)';
 spice wrap_jsonp_callback => 1;
 

--- a/share/spice/coursebuffet/coursebuffet.js
+++ b/share/spice/coursebuffet/coursebuffet.js
@@ -12,7 +12,7 @@
             meta: {
                 itemType: "Courses",
                 sourceName: "CourseBuffet",
-                sourceUrl: "http://www.coursebuffet.com"+api_result["more_link"]
+                sourceUrl: "https://www.coursebuffet.com"+api_result["more_link"]
             },
             normalize: function(item) {
                 name = item.name;
@@ -29,7 +29,7 @@
                 return {
                     title: name,
                     description: professors,
-                    url: "http://www.coursebuffet.com"+item.create_new_link,
+                    url: "https://www.coursebuffet.com"+item.create_new_link,
                     image: "https://www.coursebuffet.com"+item.course_image,
 //                     rating: item.cb_sub_level_display,
                     ratingText: item.offeredvia

--- a/share/spice/coursebuffet/coursebuffet.js
+++ b/share/spice/coursebuffet/coursebuffet.js
@@ -30,7 +30,7 @@
                     title: name,
                     description: professors,
                     url: "http://www.coursebuffet.com"+item.create_new_link,
-                    image: "http://www.coursebuffet.com"+item.course_image,
+                    image: "https://www.coursebuffet.com"+item.course_image,
 //                     rating: item.cb_sub_level_display,
                     ratingText: item.offeredvia
                 };


### PR DESCRIPTION
HTTP endpoint not working anymore. HTTPS is working so we're moving there.

I had to change the image endpoint as well so that it wouldn't break:

![screen shot 2015-02-24 at 2 38 44 pm](https://cloud.githubusercontent.com/assets/81969/6357546/46b3ce8e-bc33-11e4-98cb-f0ccf5bc15f6.png)

![screen shot 2015-02-24 at 2 42 13 pm](https://cloud.githubusercontent.com/assets/81969/6357560/5a9bf516-bc33-11e4-8fb7-ef48f29c34a2.png)
