### PR TITLE
BBC: Use header_service_type for name field

### DIFF
--- a/share/spice/bbc/bbc.js
+++ b/share/spice/bbc/bbc.js
@@ -49,7 +49,7 @@
 
         Spice.add({
             id: 'bbc',
-            name: 'TV',
+            name: header_service_type,
             data: programmes,
             meta: {
                 sourceName: 'BBC',


### PR DESCRIPTION
This was an already-declared variable set to either 'TV' or 'Radio'
depending on which type of station the user asked for.