### PR TITLE
currency.css: Hovering / clicking on mobile has ugly underline.

### DIFF
--- a/share/spice/currency/currency.css
+++ b/share/spice/currency/currency.css
@@ -245,6 +245,7 @@
     padding-top: 1.5em;
     padding-bottom: 1.5em;
     color: inherit;
+    text-decoration: none;
 }
 
 .is-mobile .zci--currency .zci__metabar__more-at.custom {


### PR DESCRIPTION
![screen shot 2015-02-26 at 2 23 54 pm](https://cloud.githubusercontent.com/assets/81969/6399873/39e0d4a4-bdc3-11e4-8b16-75036cbc9b67.png)

![screen recording 2015-02-26 at 02 18 pm](https://cloud.githubusercontent.com/assets/81969/6399882/4a28fd00-bdc3-11e4-9c44-700d66499de6.gif)
