### PR TITLE
BBC: link to schedule

### DIFF
--- a/lib/DDG/Spice/BBC.pm
+++ b/lib/DDG/Spice/BBC.pm
@@ -14,7 +14,8 @@ source "BBC";
 code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/BBC.pm";
 topics "everyday";
 category "entertainment";
-attribution github => ['https://github.com/tophattedcoder','Tom Bebbington'];
+attribution github => ['https://github.com/tophattedcoder','Tom Bebbington'],
+             email => ['tim@retout.co.uk','Tim Retout'];
 
 spice to => 'http://www.bbc.co.uk/$1/programmes/schedules/$2.json';
 

--- a/share/spice/bbc/bbc.js
+++ b/share/spice/bbc/bbc.js
@@ -23,6 +23,7 @@
             header_date,
             header_service_type,
             re = /today|tomorrow|yesterday|tonight|last/,
+            source_url,
             match;
 
         if (re.test(query)){
@@ -47,13 +48,34 @@
 
         header_service_type = api_result.schedule.service.type == "radio" ? "Radio" : "TV";
 
+        // Build a 'More at' link for this schedule - this can be the same
+        // as the JSON URL minus the extension, but given the information
+        // we have, it's easier to use a full date instead of 'today' etc.
+        source_url = 'http://www.bbc.co.uk/'
+            + api_result.schedule.service.key
+            + '/programmes/schedules';
+
+        if ("outlet" in api_result.schedule.service) {
+            source_url += '/' + api_result.schedule.service.outlet.key;
+        }
+
+        source_url += '/' + fulldate.getFullYear()
+            + '/' + ("0" + (fulldate.getMonth() + 1)).slice(-2)
+            + '/' + ("0" + fulldate.getDate()).slice(-2);
+
+        // Adding this URL fragment to schedules not in the past will take
+        // the user to the right part of the page.
+        if (!inPast) {
+            source_url += '#on-now';
+        }
+
         Spice.add({
             id: 'bbc',
             name: header_service_type,
             data: programmes,
             meta: {
                 sourceName: 'BBC',
-                sourceUrl: 'http://www.bbc.co.uk',
+                sourceUrl: source_url,
                 itemType: 'Programmes'
             },
             normalize: function(item) {


### PR DESCRIPTION
At the moment with the BBC results, the "More at" link goes to the BBC homepage.  This PR makes that link go to the relevant schedule page.