### PR TITLE
Scarer: Add plain scarer that shows "scary" queries

### DIFF
--- a/lib/DDG/Spice/Rainfall.pm
+++ b/lib/DDG/Spice/Rainfall.pm
@@ -64,10 +64,14 @@ handle remainder_lc => sub {
 
     return unless defined $countryName;
 
-    # Check if the country string has a comma, split the string and only include the first element
-
+    # Check if the country string has a comma (e.g.: 'Bolivia, Plurinational
+    # State of'), or a parenthesis (e.g.: 'Bolivia (Plurinational State of)'),
+    # split the string and only include the first element
     if (index($countryName, ',') != -1) {
         ($countryName) = split(',', $countryName);
+    }
+    if (index($countryName, ' (') != -1) {
+        ($countryName) = split(' \(', $countryName);
     }
 
     # Loop to check valid reporting dates against current date

--- a/lib/DDG/Spice/Rainfall.pm
+++ b/lib/DDG/Spice/Rainfall.pm
@@ -1,9 +1,9 @@
 package DDG::Spice::Rainfall;
-# ABSTRACT: Returns the annual rainfall (precipitation) of the country searched 
+# ABSTRACT: Returns the annual rainfall (precipitation) of the country searched
 
 use strict;
 use DDG::Spice;
-use Locale::Country; 
+use Locale::Country;
 
 primary_example_queries "rainfall australia";
 secondary_example_queries "australia annual rainfall";
@@ -28,8 +28,8 @@ Locale::Country::add_country_alias('Russian Federation'   => 'Russia');
 Locale::Country::rename_country('ae' => 'the United Arab Emirates');
 Locale::Country::rename_country('do' => 'the Dominican Republic');
 Locale::Country::rename_country('gb' => 'the United Kingdom');
-Locale::Country::rename_country('kr' => "the Republic of Korea");                    
-Locale::Country::rename_country('kp' => "the Democratic People's Republic of Korea"); 
+Locale::Country::rename_country('kr' => "the Republic of Korea");
+Locale::Country::rename_country('kp' => "the Democratic People's Republic of Korea");
 Locale::Country::rename_country('ky' => 'the Cayman Islands');
 Locale::Country::rename_country('mp' => 'the Northern Mariana Islands');
 Locale::Country::rename_country('nl' => 'the Netherlands');
@@ -51,33 +51,34 @@ my @reportingDates = (2012,2017,2022,2027,2032);
 handle remainder_lc => sub {
     my ($validDate, $countryName, $countryCode, $countryCodeTwo);
     return if ($_ eq '');
-    
+
     $countryName = shift;
-    $countryCode = country2code($countryName, LOCALE_CODE_ALPHA_3); # Return alpha-3 country code 
-    
+    $countryCode = country2code($countryName, LOCALE_CODE_ALPHA_3); # Return alpha-3 country code
+
     if($countryCode) {
         $countryName = code2country(country2code($countryName, LOCALE_CODE_ALPHA_2), LOCALE_CODE_ALPHA_2);
     } else {
         $countryName = code2country(country2code(code2country($countryName, LOCALE_CODE_ALPHA_3), LOCALE_CODE_ALPHA_2), LOCALE_CODE_ALPHA_2);
         $countryCode = country2code($countryName, LOCALE_CODE_ALPHA_3);
     }
-  
+
     return unless defined $countryName;
-    
+
     # Check if the country string has a comma, split the string and only include the first element
+
     if (index($countryName, ',') != -1) {
         ($countryName) = split(',', $countryName);
     }
-     
+
     # Loop to check valid reporting dates against current date
     foreach my $date (@reportingDates){
           if($curYear >= $date) {
           $validDate = join(':', $date,$date);
          }
-    }      
+    }
     # Ensure variables are defined before returning a result
     return unless (defined $countryCode and defined $validDate and defined $countryName);
     return uc $countryCode, $validDate, $countryName;
-    
+
 };
 1;

--- a/lib/DDG/Spice/Scarer.pm
+++ b/lib/DDG/Spice/Scarer.pm
@@ -1,0 +1,22 @@
+package DDG::Spice::Scarer;
+
+use strict;
+use DDG::Spice;
+
+name 'Scarer';
+description 'Shows scary queries';
+primary_example_queries 'scare me';
+category 'special';
+code_url 'https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/Scarer.pm';
+attribution
+    github => ['pfirsichbluete', 'Pfirsichbluete'];
+
+triggers start => ['scare me', 'show me something scary'];
+
+spice call_type => 'self';
+
+handle remainder => sub {
+    return '';
+};
+
+1;

--- a/share/spice/scarer/scarer.js
+++ b/share/spice/scarer/scarer.js
@@ -1,0 +1,28 @@
+(function(env) {
+    "use strict";
+
+    env.ddg_spice_scarer = function () {
+        // Shows a "BOOO" message after 5s and then optionally
+        // forwards to a random "scary" search.
+        function scare() {
+            var scary_search_urls, // Will hold urls that we may forward to
+                idx;               // Index into scary_search_urls
+
+            alert("BOOOOOO!");
+
+            if (confirm("Meh, ok.\nThat was lame.\n\nWanna see something really scary?\n\n\n")) {
+                scary_search_urls = [
+                    "/?q=%22no+internet+access%22",
+                    "/?q=%22power+outage%22",
+                    "/?q=%22mother-in-law+moves+in%22"
+                ];
+
+                idx = Math.floor(Math.random() * scary_search_urls.length);
+
+                // Go to the reeeaaally scary page
+                window.location.href = scary_search_urls[idx];
+            }
+        };
+        setTimeout(scare, 5000);
+    };
+}(this));

--- a/t/Scarer.t
+++ b/t/Scarer.t
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+ddg_spice_test(
+    [qw( DDG::Spice::Scarer )],
+    'scare me' => test_spice(
+        '',
+        call_type => 'self',
+        caller => 'DDG::Spice::Scarer',
+    ),
+    'show me something scary' => test_spice(
+        '',
+        call_type => 'self',
+        caller => 'DDG::Spice::Scarer',
+    ),
+);
+
+done_testing;


### PR DESCRIPTION
**What does your Instant Answer do?**

Pops up a dialog saying “BOOO!” after 5 seconds. Then optionally forwards to a “scary” query like “no internet access”.

**What problem does your Instant Answer solve (Why is it better than organic links)?**

organic links cannot wait 5 seconds.

**What is the data source for your Instant Answer? (Provide a link if possible)**

No datasource is needed.

**Why did you choose this data source?**

n/a

**Are there any other alternative (better) data sources?**

n/a

**What are some example queries that trigger this Instant Answer?**

`scare me`

**Which communities will this Instant Answer be especially useful for? (gamers, book lovers, etc)**

easter-egg-hunters

**Is this Instant Answer connected to a DuckDuckHack [Instant Answer idea](https://duck.co/ideas)?**

Yes:
https://duck.co/ideas/idea/312/if-you-put-in-scary-in-the-bar-after-5-seconds

**Which existing Instant Answers will this one supersede/overlap with?**

None

**Are you having any problems? Do you need our help with anything?**

No.

**What are the terms of use for the API? Will DuckDuckGo need specific authorization (e.g. an API key)? Are there any costs associated with API usage?**

No.

**What does the Instant Answer look like? (Provide a screenshot for new or updated Instant Answers)**

![scarer_workflow](https://cloud.githubusercontent.com/assets/11176073/6469100/1be3f2a4-c1da-11e4-86b4-57a6e62ec834.png)


## Checklist
```
[X] Added metadata and attribution information
[X] Wrote test file and added to t/ directory
[X] Verified that instant answer adheres to design guidelines (https://duck.co/duckduckhack/design_styleguide)
[X] Verified that instant answer adheres to code styleguide (https://duck.co/duckduckhack/code_styleguide)
[X] Tested cross-browser compatibility

    Please let us know which browsers/devices you've tested on:
    - Windows 8
        [] Google Chrome
        [] Firefox
        [] Opera
        [] IE 10

    - Windows 7
        [] Google Chrome
        [] Firefox
        [] Opera
        [] IE 8
        [] IE 9
        [] IE 10

    - Windows XP
        [] IE 8

    - Mac OSX
        [] Google Chrome
        [] Firefox
        [] Opera
        [] Safari

    - iOS (iPhone)
        [] Safari Mobile
        [] Google Chrome
        [] Opera

    - iOS (iPad)
        [] Safari Mobile
        [] Google Chrome
        [] Opera

    - Android
        [] Firefox
        [] Native Browser
        [] Google Chrome
        [] Opera

Tested on Firefox, Chromium, and Opera (each on GNU/Linux).
