### PR TITLE
Scarer: Add plain scarer that shows "scary" queries

### DIFF
--- a/lib/DDG/Spice/Scarer.pm
+++ b/lib/DDG/Spice/Scarer.pm
@@ -1,0 +1,23 @@
+package DDG::Spice::Scarer;
+
+use strict;
+use DDG::Spice;
+
+name 'Scarer';
+description 'Shows scary queries';
+primary_example_queries 'scare me';
+category 'special';
+code_url 'https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/Scarer.pm';
+attribution
+    github => ['pfirsichbluete', 'Pfirsichbluete'];
+
+triggers start => ['scare me', 'show me something scary'];
+
+spice call_type => 'self';
+
+handle remainder => sub {
+    return if $_;
+    return '';
+};
+
+1;

--- a/share/spice/scarer/scarer.css
+++ b/share/spice/scarer/scarer.css
@@ -1,0 +1,57 @@
+/* Most of this CSS got copied from Timer Spice */
+.zci--scarer .scarer__modal {
+    display: inline-block;
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background: rgba(128,128,128,0.4);
+    z-index: 9999;
+}
+
+.zci--scarer .scarer__modal > div {
+    width: 300px;
+    border-radius: 3px;
+    position: relative;
+    margin: 127px auto;
+    background-color: #fff;
+    padding: 30px 10px;
+}
+
+.zci--scarer .scarer__modal hr {
+    margin: 2em 0em;
+}
+
+.zci--scarer .scarer__modal h2 {
+    display: block;
+    color: #666;
+    text-align: center;
+    margin-bottom: 30px;
+    font-size: 2em;
+}
+
+@media screen and (max-width: 420px) {
+    .zci--timer .timer__done-modal > div {
+        width: 80%;
+    }
+}
+
+.zci--scarer p {
+    margin: 0em 1em;
+}
+
+.zci--scarer .scarer_btn {
+    margin: 2em 2em 1em 2em;
+    width: 80px;
+    padding: 3px 0;
+    border: 0;
+    border-radius: 2px;
+    background-color: #61AD48;
+    color: #fff;
+    cursor: pointer;
+}
+
+.zci--scarer .scarer_btn_right {
+    float: right;
+}

--- a/share/spice/scarer/scarer.handlebars
+++ b/share/spice/scarer/scarer.handlebars
@@ -1,0 +1,16 @@
+<div id="scarer_container">
+    <p class="is-hidden" id="scarer_modal_remnants_yes_btn"><a href="{{scary_url}}">Show me the really scary things again!</a></p>
+    <p class="is-hidden" id="scarer_modal_remnants_no_btn">I am braver now. <a href="{{scary_url}}">Show me the really scary things!</a></p>
+    <div class="scarer__modal" id="scarer_phase1">
+        <div>
+            <h2>BOOOOOO!</h2>
+            <div class="is-hidden" id="scarer_phase2">
+              <hr/>
+              <p>Meh, ok. That was lame.</p>
+              <p>Wanna see something really scary?</p>
+              <button class="scarer_btn" id="scarer_yes_btn">Yes!</button>
+              <button class="scarer_btn scarer_btn_right" id="scarer_no_btn">No</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/share/spice/scarer/scarer.js
+++ b/share/spice/scarer/scarer.js
@@ -1,0 +1,69 @@
+(function(env) {
+    "use strict";
+
+    // The Scarer is working in three phases:
+    // * Phase 0: Nothing of the Scarer is visible yet. Waiting for initial
+    //     timeout of 5 seconds. Then proceed to Phase 1.
+    // * Phase 1: Show a modal “BOOO!” message and wait for another
+    //     3 seconds. Then proceed to Phase 2.
+    // * Phase 2: Ask whether or not to show something “really scary” to the
+    //     user. If the user clicks “Yes”, take him to a “really scary” query.
+    env.ddg_spice_scarer = function (api_result) {
+        function getScaryUrl() {
+            var scary_search_urls,
+                idx;
+
+            scary_search_urls = [
+                "/?q=%22no+internet+access%22",
+                "/?q=%22power+outage%22",
+                "/?q=%22mother-in-law+moves+in%22"
+            ];
+
+            idx = Math.floor(Math.random() * scary_search_urls.length);
+
+            return scary_search_urls[idx];
+        }
+
+        function clickedYesInPhase2() {
+            $('#scarer_phase1').hide();
+            $('#scarer_modal_remnants_yes_btn').show();
+            window.location.href = getScaryUrl();
+        }
+
+        function clickedNoInPhase2() {
+            $('#scarer_phase1').hide();
+            $('#scarer_modal_remnants_no_btn').show();
+        }
+
+        function showPhase2() {
+            $('#scarer_yes_btn').click(clickedYesInPhase2);
+            $('#scarer_no_btn').click(clickedNoInPhase2);
+            $('#scarer_phase2').removeClass('is-hidden');
+        }
+
+        function showPhase1() {
+            // Late adding of the Spice to avoid early signs of the Scarer.
+            // Adding the Spice is necessary to get the Handlebars template
+            // rendered. Unfortunately, there is no `Spice.remove` to clean up
+            // after Phase 2, so the rendered template will stick around.
+            Spice.add({
+                id: 'scarer',
+                name: 'Scarer',
+                data: {
+                    scary_url: getScaryUrl()
+                },
+                meta: {
+                    sourceName: 'Scarer',
+                    itemType: 'scarer'
+                },
+                templates: {
+                    detail: Spice.scarer.scarer,
+                    wrap_detail: 'base_detail'
+                }
+            });
+            setTimeout(showPhase2, 3000);
+        };
+
+        setTimeout(showPhase1, 5000);
+    };
+}(this));

--- a/t/Scarer.t
+++ b/t/Scarer.t
@@ -1,0 +1,26 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+ddg_spice_test(
+    [qw( DDG::Spice::Scarer )],
+    'scare me' => test_spice(
+        '',
+        call_type => 'self',
+        caller => 'DDG::Spice::Scarer',
+    ),
+    'show me something scary' => test_spice(
+        '',
+        call_type => 'self',
+        caller => 'DDG::Spice::Scarer',
+    ),
+    'scare me please' => undef,
+    'Please scare me' => undef,
+    'Show me something scary please' => undef,
+    'Show me something really scary' => undef,
+);
+
+done_testing;


### PR DESCRIPTION
(I accidentally closed PR https://github.com/duckduckgo/zeroclickinfo-spice/pull/1588 hence reopening again here)

**What does your Instant Answer do?**

Pops up a dialog saying “BOOO!” after 5 seconds. Then optionally forwards to a “scary” query like “no internet access”.

**What problem does your Instant Answer solve (Why is it better than organic links)?**

organic links cannot wait 5 seconds.

**What is the data source for your Instant Answer? (Provide a link if possible)**

Ther is no datasource.

**Why did you choose this data source?**

n/a

**Are there any other alternative (better) data sources?**

n/a

**What are some example queries that trigger this Instant Answer?**

`scare me`

**Which communities will this Instant Answer be especially useful for? (gamers, book lovers, etc)**

easter-egg-hunters

**Is this Instant Answer connected to a DuckDuckHack [Instant Answer idea](https://duck.co/ideas)?**

Yes:
https://duck.co/ideas/idea/312/if-you-put-in-scary-in-the-bar-after-5-seconds

**Which existing Instant Answers will this one supersede/overlap with?**

None

**Are you having any problems? Do you need our help with anything?**

No.

**What are the terms of use for the API? Will DuckDuckGo need specific authorization (e.g. an API key)? Are there any costs associated with API usage?**

No.

**What does the Instant Answer look like? (Provide a screenshot for new or updated Instant Answers)**

![scarer_workflow](https://cloud.githubusercontent.com/assets/11176073/6472328/d693f89e-c1f1-11e4-82cc-8501ddaa985b.png)
## Checklist

```
[X] Added metadata and attribution information
[X] Wrote test file and added to t/ directory
[X] Verified that instant answer adheres to design guidelines (https://duck.co/duckduckhack/design_styleguide)
[X] Verified that instant answer adheres to code styleguide (https://duck.co/duckduckhack/code_styleguide)
[X] Tested cross-browser compatibility

    Please let us know which browsers/devices you've tested on:
    - Windows 8
        [] Google Chrome
        [] Firefox
        [] Opera
        [] IE 10

    - Windows 7
        [] Google Chrome
        [] Firefox
        [] Opera
        [] IE 8
        [] IE 9
        [] IE 10

    - Windows XP
        [] IE 8

    - Mac OSX
        [] Google Chrome
        [] Firefox
        [] Opera
        [] Safari

    - iOS (iPhone)
        [] Safari Mobile
        [] Google Chrome
        [] Opera

    - iOS (iPad)
        [] Safari Mobile
        [] Google Chrome
        [] Opera

    - Android
        [] Firefox
        [] Native Browser
        [] Google Chrome
        [] Opera

Tested on Firefox, Chromium, and Opera (each on GNU/Linux).
```
