### PR TITLE
Remove all trigger words except for "weather"

### DIFF
--- a/lib/DDG/Spice/Forecast.pm
+++ b/lib/DDG/Spice/Forecast.pm
@@ -12,21 +12,6 @@ secondary_example_queries "weather 12180";
 topics "everyday", "travel";
 code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/Forecast.pm";
 
-# my @temperatures = qw(temp temperature);
-# my @connectors   = qw(in for at);
-# my @descriptors  = qw(current);
-# 
-# my @temps_triggers;
-# 
-# foreach my $temp (@temperatures) {
-#     foreach my $conn (@connectors) {
-#         push @temps_triggers, $temp . ' ' . $conn;    # temperature for, temp at
-#         foreach my $desc (@descriptors) {
-#             push @temps_triggers, join(' ', $desc, $temp, $conn), $desc . ' ' . $temp;    # current temperature in; current temp
-#         }
-#     }
-# }
-
 my @forecast_words = qw(weather);
 my @triggers = (@forecast_words);
 triggers startend => @triggers;

--- a/lib/DDG/Spice/Forecast.pm
+++ b/lib/DDG/Spice/Forecast.pm
@@ -12,23 +12,23 @@ secondary_example_queries "weather 12180";
 topics "everyday", "travel";
 code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/Forecast.pm";
 
-my @temperatures = qw(temp temperature);
-my @connectors   = qw(in for at);
-my @descriptors  = qw(current);
+# my @temperatures = qw(temp temperature);
+# my @connectors   = qw(in for at);
+# my @descriptors  = qw(current);
+# 
+# my @temps_triggers;
+# 
+# foreach my $temp (@temperatures) {
+#     foreach my $conn (@connectors) {
+#         push @temps_triggers, $temp . ' ' . $conn;    # temperature for, temp at
+#         foreach my $desc (@descriptors) {
+#             push @temps_triggers, join(' ', $desc, $temp, $conn), $desc . ' ' . $temp;    # current temperature in; current temp
+#         }
+#     }
+# }
 
-my @temps_triggers;
-
-foreach my $temp (@temperatures) {
-    foreach my $conn (@connectors) {
-        push @temps_triggers, $temp . ' ' . $conn;    # temperature for, temp at
-        foreach my $desc (@descriptors) {
-            push @temps_triggers, join(' ', $desc, $temp, $conn), $desc . ' ' . $temp;    # current temperature in; current temp
-        }
-    }
-}
-
-my @forecast_words = qw(forecast forcast weather);
-my @triggers = (@forecast_words, @temps_triggers, 'meteo');
+my @forecast_words = qw(weather);
+my @triggers = (@forecast_words);
 triggers startend => @triggers;
 
 spice from => '([^/]*)/?([^/]*)';

--- a/lib/DDG/Spice/Forecast.pm
+++ b/lib/DDG/Spice/Forecast.pm
@@ -34,6 +34,8 @@ triggers startend => @triggers;
 spice from => '([^/]*)/?([^/]*)';
 spice to => 'http://forecast.io/ddg?apikey={{ENV{DDG_SPICE_FORECAST_APIKEY}}}&q=$1&callback={{callback}}';
 
+# skip synonyms for "weather" because of overtriggering
+my @weather_synonyms =qw(forecast);
 my @bbc_words     = qw(bbc shipping);
 my @finance_words = qw(sales finance financial market bond treasure pension fund tbill t-bill stock government strategy strategies analytics market);
 my @commodities_words = (
@@ -43,7 +45,7 @@ my @commodities_words = (
 );
 my @sports_words = map { ($_, $_ . ' game', $_ . ' match') } qw(football golf soccer tennis basketball hockey nba ncaa nfl nhl cricket);
 
-my $skip_words = join('|', @bbc_words, @finance_words, @commodities_words, @sports_words);
+my $skip_words = join('|', @bbc_words, @finance_words, @commodities_words, @sports_words, @weather_synonyms);
 my $forecasts = join('|', @forecast_words);
 my $skip_forecasts_re = qr/(?:\b(?:$skip_words)\s+(?:$forecasts)\b)|(?:\b(?:$forecasts)\s+(?:$skip_words)\b)/;
 

--- a/t/Forecast.t
+++ b/t/Forecast.t
@@ -12,24 +12,6 @@ my $loc = test_location('de');
 
 ddg_spice_test(
     ['DDG::Spice::Forecast'],
-    #     DDG::Request->new(
-    #         query_raw => 'weather forecast',
-    #         location => $loc
-    #     ) => test_spice(
-    #         "/js/spice/forecast/" . uri_escape_utf8(${\$loc->loc_str}) . "/current",
-    #         call_type => 'include',
-    #         caller => 'DDG::Spice::Forecast',
-    #         is_cached => 0
-    #     ),
-    #     DDG::Request->new(
-    #         query_raw => 'forecast',
-    #         location => $loc
-    #     ) => test_spice(
-    #         "/js/spice/forecast/" . uri_escape_utf8(${\$loc->loc_str}) . "/current",
-    #         call_type => 'include',
-    #         caller => 'DDG::Spice::Forecast',
-    #         is_cached => 0
-    #     ),
     DDG::Request->new(
         query_raw => 'weather',
         location => $loc
@@ -66,82 +48,24 @@ ddg_spice_test(
         caller => 'DDG::Spice::Forecast',
         is_cached => 0
     ),
-    #     DDG::Request->new(
-    #         query_raw => 'forecast today',
-    #         location => $loc
-    #     ) => test_spice(
-    #         "/js/spice/forecast/" . uri_escape_utf8(${\$loc->loc_str}) . "/current",
-    #         call_type => 'include',
-    #         caller => 'DDG::Spice::Forecast',
-    #         is_cached => 0
-    #     ),
     'weather for Troy, NY' => test_spice(
     	'/js/spice/forecast/troy%2C%20ny',
     	call_type => 'include',
     	caller => 'DDG::Spice::Forecast',
         is_cached => 1
     ),
-    #     'forecast for Troy, NY' => test_spice(
-    #         '/js/spice/forecast/troy%2C%20ny',
-    #         call_type => 'include',
-    #         caller => 'DDG::Spice::Forecast',
-    #         is_cached => 1
-    #     ),
     'weather Troy, NY' => test_spice(
         '/js/spice/forecast/troy%2C%20ny',
         call_type => 'include',
         caller => 'DDG::Spice::Forecast',
         is_cached => 1
     ),
-    #     'forecast Troy, NY' => test_spice(
-    #         '/js/spice/forecast/troy%2C%20ny',
-    #         call_type => 'include',
-    #         caller => 'DDG::Spice::Forecast',
-    #         is_cached => 1
-    #     ),
     'Philadelphia weather' => test_spice(
     	'/js/spice/forecast/philadelphia',
     	call_type => 'include',
     	caller => 'DDG::Spice::Forecast',
         is_cached => 1
     ),
-    #     'Philadelphia weather forecast' => test_spice(
-    #     	'/js/spice/forecast/philadelphia',
-    #     	call_type => 'include',
-    #     	caller => 'DDG::Spice::Forecast',
-    #         is_cached => 1
-    #     ),
-    # Added test to ensure our financial (and other)
-    # regexes don't create false negatives
-    #
-    # "weather stockholm" was failing because
-    # "m/stock/" was true when we meant
-    # "m/\bstock\b" in the case of
-    # "blackberry stock forecast"
-    #     'weather stockholm' => test_spice(
-    #     	'/js/spice/forecast/stockholm',
-    #     	call_type => 'include',
-    #     	caller => 'DDG::Spice::Forecast',
-    #         is_cached => 1
-    #     ),
-    #     'temperature in stockholm' => test_spice(
-    #     	'/js/spice/forecast/stockholm',
-    #     	call_type => 'include',
-    #     	caller => 'DDG::Spice::Forecast',
-    #         is_cached => 1
-    #     ),
-    #     'current temp stockholm' => test_spice(
-    #     	'/js/spice/forecast/stockholm',
-    #     	call_type => 'include',
-    #     	caller => 'DDG::Spice::Forecast',
-    #         is_cached => 1
-    #     ),
-    #     'meteo paris' => test_spice(
-    #     	'/js/spice/forecast/paris',
-    #     	call_type => 'include',
-    #     	caller => 'DDG::Spice::Forecast',
-    #         is_cached => 1
-    #     ),
     'temperature stockholm' => undef,
     'shipping forecast' => undef,
     'weather forecast bbc' => undef,

--- a/t/Forecast.t
+++ b/t/Forecast.t
@@ -12,24 +12,24 @@ my $loc = test_location('de');
 
 ddg_spice_test(
     ['DDG::Spice::Forecast'],
-    DDG::Request->new(
-        query_raw => 'weather forecast',
-        location => $loc
-    ) => test_spice(
-        "/js/spice/forecast/" . uri_escape_utf8(${\$loc->loc_str}) . "/current",
-        call_type => 'include',
-        caller => 'DDG::Spice::Forecast',
-        is_cached => 0
-    ),
-    DDG::Request->new(
-        query_raw => 'forecast',
-        location => $loc
-    ) => test_spice(
-        "/js/spice/forecast/" . uri_escape_utf8(${\$loc->loc_str}) . "/current",
-        call_type => 'include',
-        caller => 'DDG::Spice::Forecast',
-        is_cached => 0
-    ),
+    #     DDG::Request->new(
+    #         query_raw => 'weather forecast',
+    #         location => $loc
+    #     ) => test_spice(
+    #         "/js/spice/forecast/" . uri_escape_utf8(${\$loc->loc_str}) . "/current",
+    #         call_type => 'include',
+    #         caller => 'DDG::Spice::Forecast',
+    #         is_cached => 0
+    #     ),
+    #     DDG::Request->new(
+    #         query_raw => 'forecast',
+    #         location => $loc
+    #     ) => test_spice(
+    #         "/js/spice/forecast/" . uri_escape_utf8(${\$loc->loc_str}) . "/current",
+    #         call_type => 'include',
+    #         caller => 'DDG::Spice::Forecast',
+    #         is_cached => 0
+    #     ),
     DDG::Request->new(
         query_raw => 'weather',
         location => $loc
@@ -66,51 +66,51 @@ ddg_spice_test(
         caller => 'DDG::Spice::Forecast',
         is_cached => 0
     ),
-    DDG::Request->new(
-        query_raw => 'forecast today',
-        location => $loc
-    ) => test_spice(
-        "/js/spice/forecast/" . uri_escape_utf8(${\$loc->loc_str}) . "/current",
-        call_type => 'include',
-        caller => 'DDG::Spice::Forecast',
-        is_cached => 0
-    ),
+    #     DDG::Request->new(
+    #         query_raw => 'forecast today',
+    #         location => $loc
+    #     ) => test_spice(
+    #         "/js/spice/forecast/" . uri_escape_utf8(${\$loc->loc_str}) . "/current",
+    #         call_type => 'include',
+    #         caller => 'DDG::Spice::Forecast',
+    #         is_cached => 0
+    #     ),
     'weather for Troy, NY' => test_spice(
     	'/js/spice/forecast/troy%2C%20ny',
     	call_type => 'include',
     	caller => 'DDG::Spice::Forecast',
         is_cached => 1
     ),
-    'forecast for Troy, NY' => test_spice(
-        '/js/spice/forecast/troy%2C%20ny',
-        call_type => 'include',
-        caller => 'DDG::Spice::Forecast',
-        is_cached => 1
-    ),
+    #     'forecast for Troy, NY' => test_spice(
+    #         '/js/spice/forecast/troy%2C%20ny',
+    #         call_type => 'include',
+    #         caller => 'DDG::Spice::Forecast',
+    #         is_cached => 1
+    #     ),
     'weather Troy, NY' => test_spice(
         '/js/spice/forecast/troy%2C%20ny',
         call_type => 'include',
         caller => 'DDG::Spice::Forecast',
         is_cached => 1
     ),
-    'forecast Troy, NY' => test_spice(
-        '/js/spice/forecast/troy%2C%20ny',
-        call_type => 'include',
-        caller => 'DDG::Spice::Forecast',
-        is_cached => 1
-    ),
+    #     'forecast Troy, NY' => test_spice(
+    #         '/js/spice/forecast/troy%2C%20ny',
+    #         call_type => 'include',
+    #         caller => 'DDG::Spice::Forecast',
+    #         is_cached => 1
+    #     ),
     'Philadelphia weather' => test_spice(
     	'/js/spice/forecast/philadelphia',
     	call_type => 'include',
     	caller => 'DDG::Spice::Forecast',
         is_cached => 1
     ),
-    'Philadelphia weather forecast' => test_spice(
-    	'/js/spice/forecast/philadelphia',
-    	call_type => 'include',
-    	caller => 'DDG::Spice::Forecast',
-        is_cached => 1
-    ),
+    #     'Philadelphia weather forecast' => test_spice(
+    #     	'/js/spice/forecast/philadelphia',
+    #     	call_type => 'include',
+    #     	caller => 'DDG::Spice::Forecast',
+    #         is_cached => 1
+    #     ),
     # Added test to ensure our financial (and other)
     # regexes don't create false negatives
     #
@@ -118,30 +118,30 @@ ddg_spice_test(
     # "m/stock/" was true when we meant
     # "m/\bstock\b" in the case of
     # "blackberry stock forecast"
-    'weather stockholm' => test_spice(
-    	'/js/spice/forecast/stockholm',
-    	call_type => 'include',
-    	caller => 'DDG::Spice::Forecast',
-        is_cached => 1
-    ),
-    'temperature in stockholm' => test_spice(
-    	'/js/spice/forecast/stockholm',
-    	call_type => 'include',
-    	caller => 'DDG::Spice::Forecast',
-        is_cached => 1
-    ),
-    'current temp stockholm' => test_spice(
-    	'/js/spice/forecast/stockholm',
-    	call_type => 'include',
-    	caller => 'DDG::Spice::Forecast',
-        is_cached => 1
-    ),
-    'meteo paris' => test_spice(
-    	'/js/spice/forecast/paris',
-    	call_type => 'include',
-    	caller => 'DDG::Spice::Forecast',
-        is_cached => 1
-    ),
+    #     'weather stockholm' => test_spice(
+    #     	'/js/spice/forecast/stockholm',
+    #     	call_type => 'include',
+    #     	caller => 'DDG::Spice::Forecast',
+    #         is_cached => 1
+    #     ),
+    #     'temperature in stockholm' => test_spice(
+    #     	'/js/spice/forecast/stockholm',
+    #     	call_type => 'include',
+    #     	caller => 'DDG::Spice::Forecast',
+    #         is_cached => 1
+    #     ),
+    #     'current temp stockholm' => test_spice(
+    #     	'/js/spice/forecast/stockholm',
+    #     	call_type => 'include',
+    #     	caller => 'DDG::Spice::Forecast',
+    #         is_cached => 1
+    #     ),
+    #     'meteo paris' => test_spice(
+    #     	'/js/spice/forecast/paris',
+    #     	call_type => 'include',
+    #     	caller => 'DDG::Spice::Forecast',
+    #         is_cached => 1
+    #     ),
     'temperature stockholm' => undef,
     'shipping forecast' => undef,
     'weather forecast bbc' => undef,


### PR DESCRIPTION
The weather IA is overtriggering and producing some odd results when we pass Forecast an extracted location that it does not fail on. To try to address this, I would like to limit the keyword triggering for this IA to only "weather," and then handle all other potential weather/forecast-related queries with an internal trigger that looks at search results to infer the user's intent.