### PR TITLE
Keybase Hotfix: Check returned status

### DIFF
--- a/lib/DDG/Spice/Keybase.pm
+++ b/lib/DDG/Spice/Keybase.pm
@@ -16,8 +16,8 @@ description 'Shows user information from keybase.io.';
 category 'computing_tools';
 topics 'cryptography';
 code_url 'https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/Keybase.pm';
-primary_example_queries 'keybase mwolny', 'keybase jeresig';
-secondary_example_queries 'keybase github:mwolny', 'keybase twitter:jeresig';
+primary_example_queries 'keybase chris', 'keybase jeresig';
+secondary_example_queries 'keybase github:maxtaco', 'keybase twitter:jeresig';
 
 triggers startend => 'keybase';
 

--- a/share/spice/keybase/keybase.js
+++ b/share/spice/keybase/keybase.js
@@ -2,7 +2,7 @@
     'use strict';
     env.ddg_spice_keybase = function(api_result){
 
-        if (!api_result || api_result.error) {
+        if (!api_result || api_result.error || api_result.status.code != 0) {
             return Spice.failed('keybase');
         }
 


### PR DESCRIPTION
The Keybase IA attempts to check if an object (`api_result.them`) returned by the keybase API is an array however if this doesn't exist it throws an exception as we're checking an undefined object.

This is currently in production: https://duckduckgo.com/?q=keybase+moollaza
![selection_258](https://cloud.githubusercontent.com/assets/5282264/6524690/5d5ec100-c437-11e4-992c-c0147566d86a.png)


I've also updated the example_queries as discussed in #1581