### PR TITLE
Replaced hard-coded colours with site-wide class names (fixes #1600)

### DIFF
--- a/share/spice/transit/njt/train_item.handlebars
+++ b/share/spice/transit/njt/train_item.handlebars
@@ -1,4 +1,4 @@
-<div class="njt__time">{{departure_time}}</div>
+<div class="njt__time text--primary">{{departure_time}}</div>
 <div class="njt__details">
     {{#if cancelled}}N/A{{else}}Arrives {{arrival_time}}{{/if}}<br/>
     {{line}}<br/>
@@ -10,7 +10,7 @@
     <div class="njt__sep-line"></div>
 </div>
 <div class="njt__status">
-    <div class="one-line {{#if bold_status_text}}njt__bold-status{{/if}}">{{status}}</div>
+    <div class="one-line text--secondary {{#if bold_status_text}}njt__bold-status{{/if}}">{{status}}</div>
     {{#if track}}
         <div class="one-line">Track {{track}}</div>
     {{else}}

--- a/share/spice/transit/njt/transit_njt.css
+++ b/share/spice/transit/njt/transit_njt.css
@@ -9,12 +9,10 @@
 
 .tile--njt .njt__time {
     font-size: 2.3em;
-    color: #333;
     font-weight: 300;
 }
 
 .tile--njt .njt__details {
-    color: #999;
     margin-top: 5px;
     margin-bottom: 10px;
 }
@@ -34,7 +32,6 @@
 }
 
 .tile--njt .njt__status {
-    color: #666;
     margin-top: 10px;
     margin-bottom: 2px;
 }

--- a/share/spice/transit/path/train_item.handlebars
+++ b/share/spice/transit/path/train_item.handlebars
@@ -1,4 +1,4 @@
-<div class="path__time">{{departure_time}}</div>
+<div class="path__time text--primary">{{departure_time}}</div>
 <div class="path__details">
     {{#if cancelled}}N/A{{else}}Arrives {{arrival_time}}{{/if}}<br/>
     {{line}}<br/>

--- a/share/spice/transit/path/transit_path.css
+++ b/share/spice/transit/path/transit_path.css
@@ -11,12 +11,10 @@
 
 .tile--path .path__time {
     font-size: 2.3em;
-    color: #333;
     font-weight: 300;
 }
 
 .tile--path .path__details {
-    color: #999;
     margin-top: 5px;
     margin-bottom: 5px;
 }

--- a/share/spice/transit/septa/train_item.handlebars
+++ b/share/spice/transit/septa/train_item.handlebars
@@ -1,4 +1,4 @@
-<div class="septa__time">{{departure_time}}</div>
+<div class="septa__time text--primary">{{departure_time}}</div>
 <div class="septa__details">
     {{#if cancelled}}N/A{{else}}Arrives {{arrival_time}}{{/if}}<br/>
     {{line}}<br/>
@@ -9,6 +9,6 @@
     <div class="septa__badge {{status_class}}"></div>
     <div class="septa__sep-line"></div>
 </div>
-<div class="septa__status">
+<div class="septa__status text--secondary">
     <div class="one-line">{{status}}</div>
 </div>

--- a/share/spice/transit/septa/transit_septa.css
+++ b/share/spice/transit/septa/transit_septa.css
@@ -5,12 +5,10 @@
 
 .tile--septa .septa__time {
     font-size: 2.3em;
-    color: #333;
     font-weight: 300;
 }
 
 .tile--septa .septa__details {
-    color: #999;
     margin-top: 5px;
     margin-bottom: 10px;
 }
@@ -30,7 +28,6 @@
 }
 
 .tile--septa .septa__status {
-    color: #666;
     margin-top: 10px;
     margin-bottom: 2px;
 }


### PR DESCRIPTION
![ddg_spice_transit_njt_dark](https://cloud.githubusercontent.com/assets/94173/6539757/a74a3d38-c4c0-11e4-9609-58665e906316.png)