### PR TITLE
AgeOfCelebrity spice instant answer

### DIFF
--- a/lib/DDG/Spice/AgeOfCelebrity.pm
+++ b/lib/DDG/Spice/AgeOfCelebrity.pm
@@ -1,0 +1,40 @@
+package DDG::Spice::AgeOfCelebrity;
+# ABSTRACT: Attempts to parse the age of people with Wikipedia pages
+
+use DDG::Spice;
+
+# Caching - https://duck.co/duckduckhack/spice_advanced_backend#caching
+spice is_cached => 1; 
+
+# Metadata.  See https://duck.co/duckduckhack/metadata for help in filling out this section.
+name "AgeOfCelebrity";
+source "Wikipedia";
+icon_url "http://en.wikipedia.org/favicon.ico";
+description "Returns the age of people with Wikipedia pages";
+primary_example_queries "how old is bill clinton", "how old is jimi hendrix";
+secondary_example_queries "age of vanna white";
+category "q/a";
+topics "social", "trivia", "entertainment";
+code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/AgeOfCelebrity.pm";
+attribution github => ["davidcroda", "Dave Roda"];
+
+# API endpoint - https://duck.co/duckduckhack/spice_attributes#spice-codetocode
+spice to => 'https://en.wikipedia.org/w/api.php?format=json&action=query&prop=extracts|info|pageimages&inprops=url&exintro=&explaintext=&titles=$1&continue=&redirects';
+
+# Triggers - https://duck.co/duckduckhack/spice_triggers
+triggers start => "how old is", "age of", "how old was";
+
+spice wrap_jsonp_callback => 1;
+
+# Handle statement
+handle remainder => sub {
+
+    return unless $_;    # Guard against "no answer"
+
+    # Capitalize the first letter of each word (we are searching for names)
+    $_ = join " ", map {ucfirst} split " ", $_;
+    
+    return $_;
+};
+
+1;

--- a/share/spice/age_of_celebrity/age_of_celebrity.js
+++ b/share/spice/age_of_celebrity/age_of_celebrity.js
@@ -1,0 +1,64 @@
+(function (env) {
+    "use strict";
+    env.ddg_spice_age_of_celebrity = function(api_result){
+
+        // Validate the response (customize for your Spice)
+        if (!api_result || typeof api_result.query.pages['-1'] !== 'undefined') {
+            return Spice.failed('age_of_celebrity');
+        }
+        
+        $.each(api_result.query.pages, function(pageId, page) {
+            var living = page.extract.match(/born([ a-z0-9]*[;,])? ([a-z]* [0-9]*,? [0-9]*)/i),
+                deceased = page.extract.match(/([a-z]* [0-9]*,? [0-9]*)( \[.*\])? [\-–] ([a-z]* [0-9]*,? [0-9]*)/i),
+                celebName = page.title,
+                pageUrl = page.fullurl,
+                thumbnail = false;
+
+            if(typeof page.thumbnail !== "undefined") {
+                thumbnail = page.thumbnail.source;
+            }
+
+            if(deceased) {
+                var birthDate = deceased[1],
+                    birthTimestamp = Date.parse(birthDate),
+                    deathDate = deceased[3],
+                    deathTimestamp = Date.parse(deathDate),
+                    description = celebName + ' was born ' + birthDate + ' and died ' + deathDate,
+                    age = Math.floor((deathTimestamp - birthTimestamp) / (60*60*24*365*1000)); //1 year in milliseconds
+            } else if(living) {
+                var birthDate = living[2],
+                    birthTimestamp = Date.parse(birthDate),
+                    description = celebName + ' was born ' + birthDate,
+                    age = Math.floor((Date.now() - birthTimestamp) / (60*60*24*365*1000)); //1 year in milliseconds
+            } else {
+                return Spice.failed('age_of_celebrity');
+            }
+
+            // Render the response
+            Spice.add({
+                id: "age_of_celebrity",
+                data: {
+                    title: age + ' years old',
+                    icon: thumbnail,
+                    description: description
+                },
+                name: "Age of " + celebName,
+                meta: {
+                    sourceName: "Wikipedia.com",
+                    sourceUrl: pageUrl
+                },
+                templates: {
+                    group: 'icon',
+                    detail: false,
+                    item_detail: false,
+                    options: {
+                        moreAt: true
+                    }
+                }
+            });
+        });
+        
+        return;
+
+    };
+}(this));

--- a/t/AgeOfCelebrity.t
+++ b/t/AgeOfCelebrity.t
@@ -1,0 +1,37 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+spice is_cached => 1;
+
+ddg_spice_test(
+    [qw( DDG::Spice::AgeOfCelebrity)],
+    # At a minimum, be sure to include tests for all:
+    # - primary_example_queries
+    # - secondary_example_queries
+    'how old is bill clinton' => test_spice(
+        '/js/spice/age_of_celebrity/Bill%20Clinton',
+        call_type => 'include',
+        caller => 'DDG::Spice::AgeOfCelebrity'
+    ),
+    'how old is jimi hendrix' => test_spice(
+        '/js/spice/age_of_celebrity/Jimi%20Hendrix',
+        call_type => 'include',
+        caller => 'DDG::Spice::AgeOfCelebrity'
+    ),
+    'age of vanna white' => test_spice(
+        '/js/spice/age_of_celebrity/Vanna%20White',
+        call_type => 'include',
+        caller => 'DDG::Spice::AgeOfCelebrity'
+    ),
+    
+    # Try to include some examples of queries on which it might
+    # appear that your answer will trigger, but does not.
+    'how old is' => undef
+);
+
+done_testing;
+


### PR DESCRIPTION
Hello,

I made this Spice instant answer in response to this request: https://duck.co/ideas/idea/4964/instant-answer .

It triggers on "how old is" and "age of" queries.  It searches wikipedia and tries to parse a birth and / or end date from the description.  If found, it uses the icon_item template to display the wikipedia thumbnail, along with the age and birth date / death date of the person.

It seems kind of ghetto in that it only uses 2 big regexes to parse the dates.  However, mainly due to the fact that I think Wikipedia has relatively strict guidelines on formatting of birth and death years, it seems to be working pretty well.

Let me know what you think.

Thanks,

Dave