### PR TITLE
GoWatchIt: Netflix text update (fixes #1514)

### DIFF
--- a/share/spice/go_watch_it/go_watch_it.js
+++ b/share/spice/go_watch_it/go_watch_it.js
@@ -39,7 +39,8 @@
             "Target Ticket": 1,
             "Hulu": 1,
             "Crackle": 1,
-            "Flixster": 1
+            "Flixster": 1,
+            "Netflix": 1
         };
         
         var purchase_providers = {


### PR DESCRIPTION
fixes #1514 
@jagtalon It says "Included in subscription" in footer, which kind of looks odd, since the result does return SD/HD options under formats (but not under format_line, which we use for all footers).
