### PR TITLE
nutrition relevancy

### DIFF
--- a/lib/DDG/Spice/Nutrition.pm
+++ b/lib/DDG/Spice/Nutrition.pm
@@ -17,7 +17,7 @@ attribution github => ['https://github.com/andrey-p','Andrey Pissantchev'];
 my $attribute_regex = qr/(?^:(?^:(?:c(?:a(?:l(?:ories(?: from fat)?|cium|s)|rb(?:ohydrate)?s)|holesterol)|p(?:olyunsaturated fat|rotein)|trans(?: fat(?:ty acid)?|-fat)|s(?:aturated fat|odium|ugar)|monounsaturated fat|dietary fiber|f(?:iber|at)|vitamin [ac]|kcals|iron)))/;
 my $question_regex = qr/(?:how|what)?\s?(?:'s |is |are |many |much )?(?:the |there )?(?:total |amount of |number of )?/;
 
-triggers any => 'kcals', 'cals','calories','dietary fiber','trans-fat','trans fat','trans fatty acid','calories from fat','saturated fat','monosaturated fat','polyunsaturated fat','cholesterol','sodium','sugar','protein','carbs','carbohydrates','vitamin c','vitamin a','calcium';
+triggers any => 'calories';
 
 # brand_id is hard coded to USDA for now. Eventually could support searches across brands (i.e. packaged goods or restaurants, but requires multiple
 # calls to their API so waiting for now):

--- a/lib/DDG/Spice/Nutrition.pm
+++ b/lib/DDG/Spice/Nutrition.pm
@@ -17,7 +17,7 @@ attribution github => ['https://github.com/andrey-p','Andrey Pissantchev'];
 my $attribute_regex = qr/(?^:(?^:(?:c(?:a(?:l(?:ories(?: from fat)?|cium|s)|rb(?:ohydrate)?s)|holesterol)|p(?:olyunsaturated fat|rotein)|trans(?: fat(?:ty acid)?|-fat)|s(?:aturated fat|odium|ugar)|monounsaturated fat|dietary fiber|f(?:iber|at)|vitamin [ac]|kcals|iron)))/;
 my $question_regex = qr/(?:how|what)?\s?(?:'s |is |are |many |much )?(?:the |there )?(?:total |amount of |number of )?/;
 
-triggers any => 'kcals', 'cals','calories','fiber','dietary fiber','fat','trans-fat','trans fat','trans fatty acid','calories from fat','saturated fat','monosaturated fat','polyunsaturated fat','cholesterol','sodium','sugar','protein','carbs','carbohydrates','vitamin c','vitamin a','calcium','iron';
+triggers any => 'kcals', 'cals','calories','dietary fiber','trans-fat','trans fat','trans fatty acid','calories from fat','saturated fat','monosaturated fat','polyunsaturated fat','cholesterol','sodium','sugar','protein','carbs','carbohydrates','vitamin c','vitamin a','calcium';
 
 # brand_id is hard coded to USDA for now. Eventually could support searches across brands (i.e. packaged goods or restaurants, but requires multiple
 # calls to their API so waiting for now):

--- a/t/Nutrition.t
+++ b/t/Nutrition.t
@@ -37,23 +37,8 @@ ddg_spice_test(
         call_type => 'include',
         caller => 'DDG::Spice::Nutrition',
     ),
-    'is there iron in turkey?' => test_spice(
-        '/js/spice/nutrition/turkey',
-        call_type => 'include',
-        caller => 'DDG::Spice::Nutrition',
-    ),
-    'amount of fiber in kale' => test_spice(
-        '/js/spice/nutrition/kale',
-        call_type => 'include',
-        caller => 'DDG::Spice::Nutrition',
-    ),
     'number of calories from fat in a banana' => test_spice(
         '/js/spice/nutrition/banana',
-        call_type => 'include',
-        caller => 'DDG::Spice::Nutrition',
-    ),
-    'monounsaturated fat in chicken breast' => test_spice(
-        '/js/spice/nutrition/chicken%20breast',
         call_type => 'include',
         caller => 'DDG::Spice::Nutrition',
     ),

--- a/t/Nutrition.t
+++ b/t/Nutrition.t
@@ -17,48 +17,8 @@ ddg_spice_test(
         call_type => 'include',
         caller => 'DDG::Spice::Nutrition',
     ),
-    'protein in tilapia' => test_spice(
-        '/js/spice/nutrition/tilapia',
-        call_type => 'include',
-        caller => 'DDG::Spice::Nutrition',
-    ),
-    'vitamin c in an orange' => test_spice(
-        '/js/spice/nutrition/orange',
-        call_type => 'include',
-        caller => 'DDG::Spice::Nutrition',
-    ),
-    'trans-fat in a ribeye steak' => test_spice(
-        '/js/spice/nutrition/ribeye%20steak',
-        call_type => 'include',
-        caller => 'DDG::Spice::Nutrition',
-    ),
-    'how many carbs in brown rice' => test_spice(
-        '/js/spice/nutrition/brown%20rice',
-        call_type => 'include',
-        caller => 'DDG::Spice::Nutrition',
-    ),
     'number of calories from fat in a banana' => test_spice(
         '/js/spice/nutrition/banana',
-        call_type => 'include',
-        caller => 'DDG::Spice::Nutrition',
-    ),
-    'total calcium in glass of milk' => test_spice(
-        '/js/spice/nutrition/glass%20of%20milk',
-        call_type => 'include',
-        caller => 'DDG::Spice::Nutrition',
-    ),
-    'are there carbs in mashed potatoes?' => test_spice(
-        '/js/spice/nutrition/mashed%20potatoes',
-        call_type => 'include',
-        caller => 'DDG::Spice::Nutrition',
-    ),
-    'how much sugar is in blueberries?' => test_spice(
-        '/js/spice/nutrition/blueberries',
-        call_type => 'include',
-        caller => 'DDG::Spice::Nutrition',
-    ),
-    'saturated fat in spam' => test_spice(
-        '/js/spice/nutrition/spam',
         call_type => 'include',
         caller => 'DDG::Spice::Nutrition',
     ),
@@ -66,12 +26,7 @@ ddg_spice_test(
         '/js/spice/nutrition/tofu',
         call_type => 'include',
         caller => 'DDG::Spice::Nutrition',
-    ),
-    'tofu how much protein' => test_spice(
-        '/js/spice/nutrition/tofu',
-        call_type => 'include',
-        caller => 'DDG::Spice::Nutrition',
-    ),
+    )
 );
 
 done_testing;


### PR DESCRIPTION
Removed some of the ambiguous trigger words so things like `carbon fiber wrap` don't trigger.
Internal pr will take care of the rest of the relevancy. 
fixes #1616