### PR TITLE
Add zci__header, zci__subheader and text-primary classes for better colours

### DIFF
--- a/share/spice/quandl/fundamentals/content.handlebars
+++ b/share/spice/quandl/fundamentals/content.handlebars
@@ -1,18 +1,16 @@
-
 <div id="quandl">
-    <h1 class="quandl-header">
+    <h1 class="quandl-header zci__header">
         <a href="{{url}}" title="{{urlTitle}}">
             {{header}}
         </a>
     </h1>
-    <div class="quandl-date">
+    <div class="quandl-date zci__subheader">
         <span>{{subheader}} as of {{to_date}}</span>
     </div>
     <div>
         <div class="quandl-values  quandl-change-{{changeDirection}}">
-            <span class="quandl-value">{{value}}</span>
-            <span class="quandl-percent">{{change_percent}}%</span> 
+            <span class="quandl-value text--primary">{{value}}</span>
+            <span class="quandl-percent">{{change_percent}}%</span>
         </div>
     </div>
 </div>
-

--- a/share/spice/quandl/home_values/content.handlebars
+++ b/share/spice/quandl/home_values/content.handlebars
@@ -1,18 +1,16 @@
-
 <div id="quandl">
-    <h1 class="quandl-header">
+    <h1 class="quandl-header zci__header">
         <a href="{{url}}" title="{{urlTitle}}">
             {{header}}
         </a>
     </h1>
-    <div class="quandl-date">
+    <div class="quandl-date zci__subheader">
         <span>{{subheader}} as of {{to_date}}</span>
     </div>
     <div>
         <div class="quandl-values  quandl-change-{{changeDirection}}">
-            <span class="quandl-value">{{value}}</span>
-            <span class="quandl-percent">{{change_percent}}%</span> 
+            <span class="quandl-value text--primary">{{value}}</span>
+            <span class="quandl-percent">{{change_percent}}%</span>
         </div>
     </div>
 </div>
-


### PR DESCRIPTION
Added in our DDG text classes. Darkens header and subheader colours slightly:

![2015-03-11_19h49_34](https://cloud.githubusercontent.com/assets/873785/6609430/c20ad7bc-c827-11e4-9e2a-f42cec73dced.png)

- https://ddh7.duckduckgo.com/?q=aapl+revenue&ia=fundamentals
- https://ddh7.duckduckgo.com/?q=19087+3+bedroom+home&ia=homevalues

//cc @brianrisk @abeyang