### PR TITLE
Parse Amazon Review Count

### DIFF
--- a/share/spice/amazon/amazon.js
+++ b/share/spice/amazon/amazon.js
@@ -47,7 +47,7 @@
                     if (item.$html) {
                         var $ratingsWrapper = item.$html.find('.tile__rating,.detail__rating');
                         if ($ratingsWrapper && $ratingsWrapper.length) {
-                            $ratingsWrapper.html(Handlebars.helpers.starsAndReviews(item.rating, item.reviewCount, item.url_review, true));
+                            $ratingsWrapper.html(Handlebars.helpers.starsAndReviews(item.rating, parseInt(item.reviewCount, 10), item.url_review, true));
                         }
                     }
                 });


### PR DESCRIPTION
Currently being passed to the template as a formatted string, this should remove commas and allow the template to abbreviate the review counts for extremely high numbers.

to @bsstoner 