### PR TITLE
BrainyQuote: Cut at 150 chars (fixes #805)

### DIFF
--- a/share/spice/brainy_quote/content.handlebars
+++ b/share/spice/brainy_quote/content.handlebars
@@ -1,6 +1,6 @@
 <div class="brainy__quote--container">
   <div class="brainy__quote">
-    {{ellipsis q 85}}
+    {{ellipsis q 150}}
   </div>
   <div class="brainy__attribution">
     {{person}}


### PR DESCRIPTION
fixes #805 
Cutting off at 200, was breaking the design, so i set this at 150 chars.