### PR TITLE
ProductHunt: Comment to explain the ProductHunt API we're using

### DIFF
--- a/lib/DDG/Spice/ProductHunt.pm
+++ b/lib/DDG/Spice/ProductHunt.pm
@@ -17,6 +17,7 @@ attribution
 
 triggers startend => 'producthunt', 'product hunt';
 
+# API provided by Algolia for ProductHunt keyword search: https://github.com/producthunt/producthunt-api/wiki/Product-Hunt-APIs#algolia-search-api
 spice to => 'http://0H4SMABBSG.algolia.io/1/indexes/Post_production?query=$1&callback={{callback}}&X-Algolia-Application-Id=0H4SMABBSG&X-Algolia-API-Key=9670d2d619b9d07859448d7628eea5f3';
 
 handle remainder => sub {


### PR DESCRIPTION
Wasn't sure where this API came from or if the keys needed to be hidden.

PH explains that others are free to use this endpoint and should use their given API key.

/cc @jagtalon @zekiel 