### PR TITLE
Removed ambiguous tickers and triggers

### DIFF
--- a/share/spice/quandl/fundamentals/fundamentals_triggers.yml
+++ b/share/spice/quandl/fundamentals/fundamentals_triggers.yml
@@ -26,7 +26,6 @@ ebt:	EBT
 eps:	EPS
 equity ratio:	DE
 equity:	EQUITY
-events:	EVENTS
 exchange:	NCFX
 fcf:	FCF
 fcfps:	FCFPS

--- a/share/spice/quandl/fundamentals/fundamentals_triggers.yml
+++ b/share/spice/quandl/fundamentals/fundamentals_triggers.yml
@@ -26,7 +26,6 @@ ebt:	EBT
 eps:	EPS
 equity ratio:	DE
 equity:	EQUITY
-exchange:	NCFX
 fcf:	FCF
 fcfps:	FCFPS
 flow:	NCF

--- a/share/spice/quandl/fundamentals/fundamentals_triggers.yml
+++ b/share/spice/quandl/fundamentals/fundamentals_triggers.yml
@@ -41,7 +41,6 @@ non-current assets:	ASSETSNC
 noncurrent assets:	ASSETSNC
 preferred dividends:	PREFDIVIS
 price to book:	PB
-price:	PRICE
 revenue:	REVENUE
 revenues:	REVENUE
 sales:	REVENUE

--- a/share/spice/quandl/fundamentals/tickers.txt
+++ b/share/spice/quandl/fundamentals/tickers.txt
@@ -101,7 +101,6 @@ aht
 aig
 aimc
 aiq
-air
 airi
 airm
 airt
@@ -122,7 +121,6 @@ algt
 alim
 alj
 alk
-all
 allb
 alog
 alot
@@ -641,7 +639,6 @@ colb
 colm
 comm
 coo
-cool
 cop
 copy
 cosi
@@ -826,7 +823,6 @@ dnbf
 dndn
 dnkn
 dnr
-do
 door
 dorm
 dov
@@ -1336,7 +1332,6 @@ hnt
 hog
 holx
 homb
-home
 hon
 hos
 hot
@@ -1397,7 +1392,6 @@ ibm
 ibtx
 icad
 iccc
-ice
 icel
 icfi
 icon
@@ -1637,7 +1631,6 @@ linc
 line
 lion
 liox
-live
 lkq
 ll
 lll
@@ -1706,7 +1699,6 @@ lyv
 lzb
 m
 ma
-mac
 mack
 main
 mako
@@ -1844,7 +1836,6 @@ morn
 mos
 mosy
 mov
-move
 mpaa
 mpc
 mpet
@@ -2048,7 +2039,6 @@ omex
 omg
 omi
 onb
-one
 onfc
 onnn
 onp
@@ -2056,7 +2046,6 @@ ontx
 onty
 onvi
 onxx
-open
 ophc
 oplk
 optr
@@ -2175,7 +2164,6 @@ plow
 plpc
 plpm
 plt
-plus
 plxs
 plxt
 pm
@@ -2666,7 +2654,6 @@ taln
 tap
 tasr
 tast
-tax
 tayc
 tayd
 tbac

--- a/share/spice/quandl/fundamentals/tickers.txt
+++ b/share/spice/quandl/fundamentals/tickers.txt
@@ -377,7 +377,6 @@ bll
 blmn
 blmt
 blt
-blue
 bmc
 bmi
 bmr


### PR DESCRIPTION
@moollaza After seeing which API requests were called over the past few days, I have noticed that certain ticker symbols and certain trigger phrases were being called in combinations that implied the users did not truly desire fundamentals data with those queries.

A removed trigger is "price".  While "AAPL price" strongly implies a fundamentals response, "FORD price" does not.  In the end, I decided that "price" as an indicator would produce more inappropriate queries than not.

I also removed many ticker symbols that had common meanings when paired with indicators.  For example those submitting "HOME income" and "HOME revenue" queries are most likely interested in making money at home.

Note that many tickers are English words, and I did not remove those that, when paired with indicator triggers, are not typical English phrases.  However, I will continue to monitor requests to see if any do not make sense.

