### PR TITLE
limit time to capitals

### DIFF
--- a/lib/DDG/Spice/Time.pm
+++ b/lib/DDG/Spice/Time.pm
@@ -35,9 +35,8 @@ handle query_lc => sub {
     if (my $caps = $capitals->{$q}) {
         # These are internally sorted by population, so assume they want the big one for now.
         $q = string_for_search($caps->[0]);
+        return $q;
     }
-
-    return $q;
 };
 
 sub string_for_search {

--- a/share/spice/time/time.js
+++ b/share/spice/time/time.js
@@ -9,12 +9,16 @@
         var script = $('[src*="/js/spice/time/"]')[0],
             source = $(script).attr("src"),
             // Query is normalized as we'll normalize the generated strings.
-            query = decodeURIComponent(source.match(/time\/([^\/]+)/)[1]).toLowerCase(),
+            // if we have a comma separated query it is in the form:
+            // "town, state, country"  but state is optional
+            query = decodeURIComponent(source.match(/time\/([^\/]+)/)[1]).toLowerCase().split(','),
             chosen;
 
         for(var i = 0; i < api.locations.length; i++) {
-            if(DDG.stringsRelevant(query, api.locations[i].geo.name + " " + api.locations[i].geo.country.name) ||
-               DDG.stringsRelevant(query, api.locations[i].geo.name)) {
+            // query[0] = state
+            // query[len-1] = country
+            if(DDG.stringsRelevant(query[0], api.locations[i].geo.name) &&
+                    DDG.stringsRelevant(query[query.length-1], api.locations[i].geo.country.name)) {
                 chosen = api.locations[i];
                 break;
             }

--- a/t/Time.t
+++ b/t/Time.t
@@ -16,27 +16,12 @@ my @kingston_town = (
 ddg_spice_test(
     [qw( DDG::Spice::Time)],
     # Primary examples
-    'time in Melbourne' => test_spice(
-        '/js/spice/time/melbourne',
-        call_type => 'include',
-        caller    => 'DDG::Spice::Time'
-    ),
     'time for Australia' => test_spice(
         '/js/spice/time/canberra%20australia',
         call_type => 'include',
         caller    => 'DDG::Spice::Time'
     ),
     # Secondary examples
-    'what time is it in Melbourne' => test_spice(
-        '/js/spice/time/melbourne',
-        call_type => 'include',
-        caller    => 'DDG::Spice::Time'
-    ),
-    'what is the time in Birmingham' => test_spice(
-        '/js/spice/time/birmingham',
-        call_type => 'include',
-        caller    => 'DDG::Spice::Time'
-    ),
     # Additional queries
     'time in Canada' => test_spice(
         '/js/spice/time/ottawa%20canada',
@@ -45,11 +30,6 @@ ddg_spice_test(
     ),
     'time in London' => test_spice(
         '/js/spice/time/london%20united%20kingdom',
-        call_type => 'include',
-        caller    => 'DDG::Spice::Time'
-    ),
-    'time at the Vatican' => test_spice(
-        '/js/spice/time/the%20vatican',
         call_type => 'include',
         caller    => 'DDG::Spice::Time'
     ),


### PR DESCRIPTION
Fixes #1657 
This limits the time IA to only return if it finds a known capitol from the capitols.yml file.  There is also an internal pr to go with its one. 
Bolth PRs are installed on ddh4 for testing. https://ddh4.duckduckgo.com/?q=seattle+time&ia=time
@moollaza @russellholt  