### PR TITLE
Switch String::Trim to Text::Trim (#1638)

### DIFF
--- a/lib/DDG/Spice/Images.pm
+++ b/lib/DDG/Spice/Images.pm
@@ -2,8 +2,7 @@ package DDG::Spice::Images;
 
 use strict;
 use DDG::Spice;
-
-use String::Trim;
+use Text::Trim;
 
 primary_example_queries "tilt shift images";
 secondary_example_queries "thailand beach images";

--- a/lib/DDG/Spice/Quixey.pm
+++ b/lib/DDG/Spice/Quixey.pm
@@ -3,7 +3,7 @@ package DDG::Spice::Quixey;
 use strict;
 use DDG::Spice;
 use JSON;
-use String::Trim;
+use Text::Trim;
 use List::Uniq ':all';
 
 primary_example_queries "flight tracking app", "quixey angry birds";


### PR DESCRIPTION
Switched ```String::Trim``` to ```Text::Trim``` as agreed in #1638.

```
$ ack -l Text::Trim
lib/DDG/Spice/Coursebuffet.pm
lib/DDG/Spice/Currency.pm
lib/DDG/Spice/Forecast.pm
lib/DDG/Spice/GithubStatus.pm
lib/DDG/Spice/GoWatchIt.pm
lib/DDG/Spice/Images.pm
lib/DDG/Spice/Parking.pm
lib/DDG/Spice/Quandl/Fundamentals.pm
lib/DDG/Spice/Quandl/HomeValues.pm
lib/DDG/Spice/Quixey.pm
lib/DDG/Spice/RandPOS.pm
lib/DDG/Spice/Recipes.pm
lib/DDG/Spice/SeatGeek/EventsByArtist.pm
lib/DDG/Spice/TravisStatus.pm
lib/DDG/Spice/Whois.pm
```