### PR TITLE
spice/timer - added new trigger 'timer for'

### DIFF
--- a/lib/DDG/Spice/Timer.pm
+++ b/lib/DDG/Spice/Timer.pm
@@ -13,7 +13,7 @@ attribution twitter => 'mattr555',
             github => ['https://github.com/mattr555/', 'Matt Ramina'];
 
 triggers startend => ['timer', 'countdown', 'alarm'];
-triggers start => ['time'];
+triggers start => ['time', 'timer for'];
 
 spice call_type => 'self';
 

--- a/t/Timer.t
+++ b/t/Timer.t
@@ -7,7 +7,7 @@ use Test::More;
 use DDG::Test::Spice;
 
 my @test_args = (
-    '', 
+    '',
     call_type => 'self',
     caller => 'DDG::Spice::Timer'
 );
@@ -28,6 +28,8 @@ ddg_spice_test(
     'time 2 minutes' => test_spice(@test_args),
     '3.5 minute timer' => test_spice(@test_args),
     'alarm 30 minutes' => test_spice(@test_args),
+    'timer for 15 mins' => test_spice(@test_args),
+    'timer for 77 mins 13 secs' => test_spice(@test_args),
     'blahblah timer' => undef,
     'wwdc 2015 countdown' => undef,
     'timer 5 hellos' => undef


### PR DESCRIPTION
Fixes #1607. Queries like `timer for 15 mins` will show timer.

![](http://imgur.com/ZMRdvji.png)