### PR TITLE
Seasons: improve logic and triggering

### DIFF
--- a/lib/DDG/Spice/Seasons.pm
+++ b/lib/DDG/Spice/Seasons.pm
@@ -87,7 +87,7 @@ my %aliases = (
 # Handle statement
 handle query_lc => sub {
 
-    return unless /^(?:(?<year>\d{4}) )?(?:(?:when is the )?(?:(?:first day|start|beginning)) of )?(?<season>$seasons_qr)(?: equinox| solstice)?(?: (?<year>\d{4}))?(?: in (?<country>[\D]+))?(?: (?<year>\d{4}))?$/;
+    return unless /^(?:(?<year>\d{4}) )?(?:(?:when is the ))?(?:(?:first day|start|beginning) of )?(?<season>$seasons_qr)(?: equinox| solstice)?(?: (?<year>\d{4}))?(?: in (?<country>[\D]+))?(?: (?<year>\d{4}))?$/;
 
     # Get season
     my $season = $aliases{$+{season}} // $+{season};

--- a/t/Seasons.t
+++ b/t/Seasons.t
@@ -2,15 +2,14 @@
 
 use strict;
 use warnings;
-
-# These modules are necessary for the functions we'll be running.
 use Test::More;
 use DDG::Test::Spice;
 use DDG::Test::Location;
 use DDG::Request;
 
-use DDG::Spice::Seasons;
+spice is_cached => 0;
 
+use DDG::Spice::Seasons;
 my $year = (localtime(time))[5] + 1900;
 my $min_year = DDG::Spice::Seasons::API_EPOCH;
 my $max_year = $year + DDG::Spice::Seasons::YEARS_INTO_FUTURE;
@@ -27,7 +26,6 @@ ddg_spice_test(
         '/js/spice/seasons/2016/de/spring',
         call_type => 'include',
         caller => 'DDG::Spice::Seasons',
-        is_cached => 0
     ),
 
     DDG::Request->new(
@@ -37,21 +35,18 @@ ddg_spice_test(
         '/js/spice/seasons/2011/us/spring',
         call_type => 'include',
         caller => 'DDG::Spice::Seasons',
-        is_cached => 0
     ),
 
     "summer solstice in canada" => test_spice(
         '/js/spice/seasons/' . $year . '/ca/summer',
         call_type => 'include',
         caller => 'DDG::Spice::Seasons',
-        is_cached => 0
     ),
 
     "summer solstice in united kingdom" => test_spice(
         '/js/spice/seasons/' . $year . '/gb/summer',
         call_type => 'include',
         caller => 'DDG::Spice::Seasons',
-        is_cached => 0
     ),
 
     DDG::Request->new(
@@ -61,7 +56,7 @@ ddg_spice_test(
         '/js/spice/seasons/2011/se/spring',
         call_type => 'include',
         caller => 'DDG::Spice::Seasons',
-        is_cached => 0
+        is_cached => 1
     ),
 
 
@@ -78,7 +73,6 @@ ddg_spice_test(
         '/js/spice/seasons/' . $year . '/us/autumn',
         call_type => 'include',
         caller => 'DDG::Spice::Seasons',
-        is_cached => 0
     ),
 
     # Different query styles
@@ -87,14 +81,12 @@ ddg_spice_test(
         '/js/spice/seasons/' . $year . '/us/summer',
         call_type => 'include',
         caller => 'DDG::Spice::Seasons',
-        is_cached => 0
     ),
 
     "2017 summer solstice" => test_spice(
         '/js/spice/seasons/2017/us/summer',
         call_type => 'include',
         caller => 'DDG::Spice::Seasons',
-        is_cached => 0
     ),
 
     # Query case
@@ -103,14 +95,12 @@ ddg_spice_test(
         '/js/spice/seasons/' . $year . '/us/summer',
         call_type => 'include',
         caller => 'DDG::Spice::Seasons',
-        is_cached => 0
     ),
 
     "Summer equinox" => test_spice(
         '/js/spice/seasons/' . $year . '/us/summer',
         call_type => 'include',
         caller => 'DDG::Spice::Seasons',
-        is_cached => 0
     ),
 
     # Limits
@@ -121,14 +111,12 @@ ddg_spice_test(
         '/js/spice/seasons/' . $min_year . '/us/summer',
         call_type => 'include',
         caller => 'DDG::Spice::Seasons',
-        is_cached => 0
     ),
 
     $max_year . " summer solstice" => test_spice(
         '/js/spice/seasons/' . $max_year . '/us/summer',
         call_type => 'include',
         caller => 'DDG::Spice::Seasons',
-        is_cached => 0
     ),
 
     ($max_year + 1) . " summer solstice" => undef,

--- a/t/Seasons.t
+++ b/t/Seasons.t
@@ -43,6 +43,13 @@ ddg_spice_test(
         caller => 'DDG::Spice::Seasons',
     ),
 
+    "summer solstice in canada 2020" => test_spice(
+        '/js/spice/seasons/2020/ca/summer',
+        call_type => 'include',
+        caller => 'DDG::Spice::Seasons',
+        is_cached => 1
+    ),
+
     "summer solstice in united kingdom" => test_spice(
         '/js/spice/seasons/' . $year . '/gb/summer',
         call_type => 'include',
@@ -59,6 +66,25 @@ ddg_spice_test(
         is_cached => 1
     ),
 
+    DDG::Request->new(
+        query_raw => "first day of spring 2011 in sweden",
+        location => test_location("us")
+    ) => test_spice(
+        '/js/spice/seasons/2011/se/spring',
+        call_type => 'include',
+        caller => 'DDG::Spice::Seasons',
+        is_cached => 1
+    ),
+
+    DDG::Request->new(
+        query_raw => "first day of spring in sweden 2011",
+        location => test_location("us")
+    ) => test_spice(
+        '/js/spice/seasons/2011/se/spring',
+        call_type => 'include',
+        caller => 'DDG::Spice::Seasons',
+        is_cached => 1
+    ),
 
     "summer solstice in " => undef,
 
@@ -124,10 +150,9 @@ ddg_spice_test(
     # Non-matching terms
 
     "first day" => undef,
-
     "solstice and equinox" => undef,
-
     "start solstice" => undef,
+    "summer solistice in canada blah" => undef
 
 );
 


### PR DESCRIPTION
Simplified the code, improved triggering and added more tests.

Using a larger regex to ensure queries match the required form. This fixes the problem of triggering on queries that have trailing words. e.g. "summer solstice tomorrow"

/cc @jagtalon @mayo
