### PR TITLE
require a space between flight and  flight number

### DIFF
--- a/lib/DDG/Spice/Airlines.pm
+++ b/lib/DDG/Spice/Airlines.pm
@@ -19,7 +19,7 @@ attribution web => [ 'https://www.duckduckgo.com', 'DuckDuckGo' ],
 spice to => 'https://duckduckgo.com/flights.js?airline=$1&flightno=$2&callback={{callback}}';
 spice from => '(.*?)/(.*)';
 
-triggers query_lc => qr/^(\d+)\s*(.*?)(?:[ ]air.*?)?$|^(.*?)(?:[ ]air.*?)?\s*(\d+)$/;
+triggers query_lc => qr/^(\d+)\s+(.*?)(?:[ ]air.*?)?$|^(.*?)(?:[ ]air.*?)?\s+(\d+)$/;
 
 # Get the list of airlines and strip out the words.
 my %airlines = ();


### PR DESCRIPTION
Check for a space in between the flight and flight number.  Otherwise queries like "sha512" will trigger airlines.
@moollaza @russellholt 