### PR TITLE
Dictionary: Only add subtitle if word is plural

### DIFF
--- a/share/spice/dictionary/definition/content.handlebars
+++ b/share/spice/dictionary/definition/content.handlebars
@@ -1,14 +1,16 @@
 <h3>
-    {{#if plural_form}}
-        <span class="zci__def__word text--primary">{{plural_form}}</span>
-    {{else}}
-        <span class="zci__def__word text--primary">{{word}}</span>
-    {{/if}}
+{{#if plural_form}}
+    <span class="zci__def__word text--primary">{{plural_form}}</span>
     <span class="zci__def__pronunciation"></span>
 </h3>
 <div class="zci__subheader">
     Plural form of {{word}}
 </div>
+{{else}}
+    <span class="zci__def__word text--primary">{{word}}</span>
+</h3>
+{{/if}}
+
 <ul>
 {{#definitions}}
     <li>
@@ -18,8 +20,7 @@
 {{/definitions}}
 </ul>
 <div class="zci__def__links">
-	{{{moreAt meta.sourceUrl meta.sourceName}}}
-	<span class="zcm__sep"></span>
-	<span class="zci__def__attribution  tx-clr--lt2  t-s">{{meta.attributionText}}</span>
+    {{{moreAt meta.sourceUrl meta.sourceName}}}
+    <span class="zcm__sep"></span>
+    <span class="zci__def__attribution  tx-clr--lt2  t-s">{{meta.attributionText}}</span>
 </div>
-

--- a/share/spice/dictionary/definition/content.handlebars
+++ b/share/spice/dictionary/definition/content.handlebars
@@ -3,7 +3,7 @@
     <span class="zci__def__word text--primary">{{plural_form}}</span>
 </h3>
 <div class="zci__subheader">
-    Plural form of {{word}}
+    Plural form of {{word}}, <span class="zci__def__pronunciation"></span>
 </div>
 {{else}}
     <span class="zci__def__word text--primary">{{word}}</span>

--- a/share/spice/dictionary/definition/content.handlebars
+++ b/share/spice/dictionary/definition/content.handlebars
@@ -1,13 +1,13 @@
 <h3>
 {{#if plural_form}}
     <span class="zci__def__word text--primary">{{plural_form}}</span>
-    <span class="zci__def__pronunciation"></span>
 </h3>
 <div class="zci__subheader">
     Plural form of {{word}}
 </div>
 {{else}}
     <span class="zci__def__word text--primary">{{word}}</span>
+    <span class="zci__def__pronunciation"></span>
 </h3>
 {{/if}}
 

--- a/share/spice/dictionary/definition/dictionary_definition.js
+++ b/share/spice/dictionary/definition/dictionary_definition.js
@@ -116,7 +116,7 @@ var ddg_spice_dictionary = {
 
         // If the word is plural, then we should load the definition of the word
         // in singular form. The definition of the singular word is usually more helpful.
-        if(api_result.length === 1 && singular) {
+        if(singular) {
             this.plural_form = api_result[0].word;
             $.getScript(this.path + "/reference/" + singular[1]);
         } else {


### PR DESCRIPTION
Fixes small bug introduced in https://github.com/duckduckgo/zeroclickinfo-spice/pull/1682#issuecomment-85680571

/cc @jagtalon @chrismorast 

![2015-03-25_21h03_42](https://cloud.githubusercontent.com/assets/873785/6838593/701f8a72-d332-11e4-8bf2-43ac7e05d631.png)

![2015-03-25_21h02_04](https://cloud.githubusercontent.com/assets/873785/6838585/372d4894-d332-11e4-9bb2-d966818c9770.png)
