### PR TITLE
SimilarSites: + and - buttons are now consistent

### DIFF
--- a/share/spice/similar_sites/similar_sites.css
+++ b/share/spice/similar_sites/similar_sites.css
@@ -37,5 +37,9 @@
 }
 
 .zci--similar_sites .chomp--link__icn:after {
-    content: attr(data-content);
+    content: "\2295";
+}
+
+.zci--similar_sites .expand.chomp--link__icn:after {
+    content: "\229d";
 }

--- a/share/spice/similar_sites/similar_sites.js
+++ b/share/spice/similar_sites/similar_sites.js
@@ -63,20 +63,13 @@
                     $icon = $zci.find(".chomp--link__icn"),
                     $more = $zci.find(".chomp--link__mr"),
                     $less = $zci.find(".chomp--link__ls");
-                $icon.attr('data-content', "+");
 
                 $("#show_more").click(function() {
                     $more.toggle();
                     $less.toggle();
                     $("#hidden").toggle();
 
-                    if(toggle) {
-                        $icon.attr('data-content', "+");
-                        toggle = false;
-                    } else {
-                        $icon.attr('data-content', "-");
-                        toggle = true;
-                    }
+                    $icon.toggleClass("expand");
                 });
             }
         });

--- a/share/spice/similar_sites/similar_sites.js
+++ b/share/spice/similar_sites/similar_sites.js
@@ -58,7 +58,6 @@
             },
 
             onShow: function() {
-                var toggle = false;
                 var $zci = $(".zci--similar_sites"),
                     $icon = $zci.find(".chomp--link__icn"),
                     $more = $zci.find(".chomp--link__mr"),


### PR DESCRIPTION
It should look consistent with the Wikipedia buttons:

![screen shot 2015-03-26 at 11 07 57 am](https://cloud.githubusercontent.com/assets/81969/6849241/68ea5d42-d3a8-11e4-8d7a-e238542076d6.png)

Screencast:
https://gfycat.com/AlienatedShamefulButterfly