### PR TITLE
[Pokedex IA] Amended the IA trigger and the link to next evolution

### DIFF
--- a/lib/DDG/Spice/Pokemon/Data.pm
+++ b/lib/DDG/Spice/Pokemon/Data.pm
@@ -24,7 +24,7 @@ spice wrap_jsonp_callback => 1;
 
 # Handle statement
 handle remainder => sub {
-    return lc $_ if $_;
+    return lc $_ unless !$_ or $_ =~ /\s/;
     return;
 };
 

--- a/share/spice/pokemon/data/pokemon_data.js
+++ b/share/spice/pokemon/data/pokemon_data.js
@@ -30,7 +30,7 @@
                     infoboxData: getInfoboxData.call(item),
                     subtitle: (function(evolutions) {
                         if( evolutions.length > 0 ) {
-                            var html = 'Evolves into: <a href="?q={name}+pokemon">{name}</a>';
+                            var html = 'Evolves into: <a href="?q={name}+pokemon&ia=pokedex">{name}</a>';
 
                             return new Handlebars.SafeString(html.replace(/{name}/g, evolutions[0].to));
                         }

--- a/t/Pokemon.t
+++ b/t/Pokemon.t
@@ -19,7 +19,14 @@ ddg_spice_test(
         call_type => 'include',
         caller => 'DDG::Spice::Pokemon::Data'
     ),
+    'bulbasaur pokemon' => test_spice(
+        '/js/spice/pokemon/data/bulbasaur',
+        call_type => 'include',
+        caller => 'DDG::Spice::Pokemon::Data'
+    ),
     'bulbasaur pokemon stats' => undef,
+    'pokemon movie release date' => undef,
+    'how to catch every pokemon', => undef
 );
 
 done_testing;


### PR DESCRIPTION
Original IA PR: #1536 

* The IA is now triggered only by a one-word remainders, such as "pokemon pikachu". If the user searches for "how to train my pokemon", the IA is not triggered
* The IA provides a link to the next evolution of the pokemon, but it wasn't specifically redirecting to the IA tab