### PR TITLE
spice/deb_version - added the spice on top of master

### DIFF
--- a/lib/DDG/Spice/DebVersion.pm
+++ b/lib/DDG/Spice/DebVersion.pm
@@ -1,0 +1,26 @@
+# Get the version of a package in various debian repositories
+package DDG::Spice::DebVersion;
+
+use Text::Trim;
+use DDG::Spice;
+
+attribution github => ['https://github.com/iambibhas', 'Bibhas'],
+            twitter => ['https://twitter.com/bibhasdn', 'Bibhas D'];
+
+triggers startend => "debian version", "debian versions", "deb ver", "debian ver";
+
+spice to => 'https://sources.debian.net/api/src/$1/';
+
+spice wrap_jsonp_callback => 1;
+
+handle remainder_lc => sub {
+    my $query = $_;
+    $query =~ s/\b(for|in|at|on|all|latest|stable)\b//g;
+    $query =~ s/\b(squeeze|wheezy|jessie|sid|experimental|\s)+\b//g;
+    $query =~ /^(?:\s)*(?<package>[a-z0-9\-]+).*$/i;
+
+    my $package = trim $+{package};
+    return $package;
+};
+
+1;

--- a/share/spice/deb_version/deb_version.css
+++ b/share/spice/deb_version/deb_version.css
@@ -1,0 +1,9 @@
+.record__row {
+    line-height: 25px;
+}
+.record__cell__key {
+    padding-left: 5px;
+}
+.record__cell__value {
+    padding-right: 5px;
+}

--- a/share/spice/deb_version/deb_version.css
+++ b/share/spice/deb_version/deb_version.css
@@ -1,9 +1,0 @@
-.record__row {
-    line-height: 25px;
-}
-.record__cell__key {
-    padding-left: 5px;
-}
-.record__cell__value {
-    padding-right: 5px;
-}

--- a/share/spice/deb_version/deb_version.css
+++ b/share/spice/deb_version/deb_version.css
@@ -1,0 +1,4 @@
+.zci--deb_version .record__cell--key {
+  /* separate the columns a bit more */
+  padding-right: 2.5em;
+}

--- a/share/spice/deb_version/deb_version.js
+++ b/share/spice/deb_version/deb_version.js
@@ -1,0 +1,47 @@
+(function (env) {
+    "use strict";
+    env.ddg_spice_deb_version = function(api_result){
+        if (!api_result || api_result.error) {
+            return Spice.failed('deb_version');
+        }
+
+        Spice.add({
+            id: "deb_version",
+            name: "Software",
+            data: api_result,
+            meta: {
+                sourceName: "packages.debian.org",
+                sourceUrl: 'https://packages.debian.org/search?searchon=names&keywords=' + api_result.package
+            },
+            normalize: function(result) {
+                var data = {
+                    title: result.package,
+                    subtitle: "Debian Package Versions",
+                    record_data: {},
+                };
+
+                for (var i = result.versions.length - 1; i >= 0; i--) {
+                    var version = result.versions[i];
+
+                    for (var j = version.suites.length - 1; j >= 0; j--) {
+                        data.record_data[version.suites[j]] = version.version;
+                    };
+                };
+
+                if (Object.keys(data.record_data).length === 0) {
+                    return Spice.failed('deb_version');
+                }
+
+                return data;
+            },
+            templates: {
+                group: 'text',
+                options: {
+                    content: 'record',
+                    rowHighlight: true,
+                    moreAt: true,
+                }
+            }
+        });
+    };
+}(this));

--- a/share/spice/deb_version/deb_version.js
+++ b/share/spice/deb_version/deb_version.js
@@ -38,7 +38,6 @@
                 group: 'text',
                 options: {
                     content: 'record',
-                    rowHighlight: true,
                     moreAt: true,
                 }
             }

--- a/t/DebVersion.t
+++ b/t/DebVersion.t
@@ -1,0 +1,30 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use DDG::Test::Spice;
+
+my @emacs24 = (
+    '/js/spice/deb_version/emacs24',
+    call_type => 'include',
+    caller    => 'DDG::Spice::DebVersion'
+);
+
+ddg_spice_test(
+    [ qw(DDG::Spice::DebVersion) ],
+    'debian version emacs24' => test_spice(@emacs24),
+    'deb ver emacs24' => test_spice(@emacs24),
+    'emacs24 debian version' => test_spice(@emacs24),
+    'emacs24 latest debian version' => test_spice(@emacs24),
+    'debian version for emacs24' => test_spice(@emacs24),
+    'debian versions for emacs24' => test_spice(@emacs24),
+    'debian versions for latest emacs24' => test_spice(@emacs24),
+    'debian versions on wheezy for latest emacs24' => test_spice(@emacs24),
+
+    'what debian version is this' => undef,
+    'emacs is the best' => undef,
+);
+
+done_testing;


### PR DESCRIPTION
Reviving old stale branch `ideas/deb`. Added on top of master, as mentioned in #1667. Should close that other PR.

![](http://imgur.com/mmLZKTq.png)