### PR TITLE
Added trigger words for Japanese, Chinese and Korean

### DIFF
--- a/lib/DDG/Spice/Forecast.pm
+++ b/lib/DDG/Spice/Forecast.pm
@@ -3,6 +3,7 @@ package DDG::Spice::Forecast;
 use strict;
 use DDG::Spice;
 use Text::Trim;
+use utf8;
 
 name "Forecast";
 description "Weather forecast";
@@ -15,7 +16,7 @@ code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/
 # my @forecast_words = qw(weather);
 # my @triggers = (@forecast_words);
 # triggers startend => @triggers;
-triggers startend => "weather";
+triggers startend => "weather", "天気", "天气", "날씨";
 
 spice from => '([^/]*)/?([^/]*)';
 spice to => 'http://forecast.io/ddg?apikey={{ENV{DDG_SPICE_FORECAST_APIKEY}}}&q=$1&callback={{callback}}';

--- a/t/Forecast.t
+++ b/t/Forecast.t
@@ -7,6 +7,7 @@ use URI::Escape;
 use DDG::Test::Location;
 use DDG::Test::Spice;
 use DDG::Request;
+use utf8;
 
 my $loc = test_location('de');
 
@@ -14,6 +15,33 @@ ddg_spice_test(
     ['DDG::Spice::Forecast'],
     DDG::Request->new(
         query_raw => 'weather',
+        location => $loc
+    ) => test_spice(
+        "/js/spice/forecast/" . uri_escape_utf8(${\$loc->loc_str}) . "/current",
+        call_type => 'include',
+        caller => 'DDG::Spice::Forecast',
+        is_cached => 0
+    ),
+    DDG::Request->new(
+        query_raw => '天気',
+        location => $loc
+    ) => test_spice(
+        "/js/spice/forecast/" . uri_escape_utf8(${\$loc->loc_str}) . "/current",
+        call_type => 'include',
+        caller => 'DDG::Spice::Forecast',
+        is_cached => 0
+    ),
+    DDG::Request->new(
+        query_raw => '天气',
+        location => $loc
+    ) => test_spice(
+        "/js/spice/forecast/" . uri_escape_utf8(${\$loc->loc_str}) . "/current",
+        call_type => 'include',
+        caller => 'DDG::Spice::Forecast',
+        is_cached => 0
+    ),
+    DDG::Request->new(
+        query_raw => '날씨',
         location => $loc
     ) => test_spice(
         "/js/spice/forecast/" . uri_escape_utf8(${\$loc->loc_str}) . "/current",


### PR DESCRIPTION
It's just the translation of "weather":
天気 => Japanese, Traditional Chinese
天气 => Simplified Chinese
날씨 => Korean

The IA result itself is not localized but the symbols and temperatures are easily understandable.