### PR TITLE
Sharedir

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -38,6 +38,7 @@ run = curl https://duck.co/ia/repo/spice/json -o "share/spice/meta/metadata.json
 [ManifestSkip]
 [ExtraTests]
 [ExecDir]
+[ShareDir]
 [MakeMaker]
 [Manifest]
 [TestRelease]
@@ -46,7 +47,7 @@ run = curl https://duck.co/ia/repo/spice/json -o "share/spice/meta/metadata.json
 [MetaJSON]
 
 [AutoModuleShareDirs]
-scan_namespaces = DDG::Goodie,DDG::Spice
+scan_namespaces = DDG::Goodie,DDG::Spice,DDG::Longtail,DDG::Fathead
 sharedir_method = module_share_dir
 
 [Git::NextVersion]

--- a/dist.ini
+++ b/dist.ini
@@ -47,7 +47,7 @@ run = curl https://duck.co/ia/repo/spice/json -o "share/spice/meta/metadata.json
 [MetaJSON]
 
 [AutoModuleShareDirs]
-scan_namespaces = DDG::Goodie,DDG::Spice,DDG::Longtail,DDG::Fathead
+scan_namespaces = DDG::Goodie,DDG::Spice
 sharedir_method = module_share_dir
 
 [Git::NextVersion]


### PR DESCRIPTION
Adds sharedir to dist.ini so we build the `share/dist/` directory. 
@moollaza want to do a new release after this is merged?