### PR TITLE
Time: force return if capital doesn't exist

### DIFF
--- a/lib/DDG/Spice/Time.pm
+++ b/lib/DDG/Spice/Time.pm
@@ -2,6 +2,7 @@ package DDG::Spice::Time;
 use DDG::Spice;
 
 use strict;
+use Text::Trim;
 use YAML::XS qw( Load );
 
 primary_example_queries "time in Melbourne", "time for Australia";
@@ -28,15 +29,14 @@ handle query_lc => sub {
 
     return unless $q =~ m/^(what'?s?|is|the|current|local|\s)*time(?:is|it|\s)*(?:\b$place_connector\b)\s+(?<loc>[^\?]+)[\?]?$/;
     $q = $+{loc};
-    $q =~ s/(^\s+|\s+$)//g;
+    trim($q);
     $q =~ s/,//g;
-    return unless $q;
 
-    if (my $caps = $capitals->{$q}) {
-        # These are internally sorted by population, so assume they want the big one for now.
-        $q = string_for_search($caps->[0]);
-        return $q;
-    }
+    return unless (my $caps = $capitals->{$q});
+
+    # These are internally sorted by population, so assume they want the big one for now.
+    $q = string_for_search($caps->[0]);
+    return $q;
 };
 
 sub string_for_search {

--- a/t/Time.t
+++ b/t/Time.t
@@ -50,6 +50,7 @@ ddg_spice_test(
     'time and space museum'    => undef,
     'time complexity of qsort' => undef,
     'running time of titanic'  => undef,
+    'time in Toronto'          => undef, # This will still show a result in production, but the triggering is handled internally
 );
 
 done_testing;


### PR DESCRIPTION
Right now the code falls through if the capitals lookup fails which still causes the IA to `return ""` creating an API call with no param.

This fixes that and cleans up the code a bit.

/cc @jagtalon @tommytommytommy 
