### PR TITLE
Time - changed regex handling to trigger on time, current time etc

### DIFF
--- a/lib/DDG/Spice/Time.pm
+++ b/lib/DDG/Spice/Time.pm
@@ -22,21 +22,23 @@ triggers any => "time";
 
 my $capitals = Load(scalar share("capitals.yml")->slurp);
 
-my $place_connector = join '|', qw(in of for at);
-
 handle query_lc => sub {
     my $q = shift;
 
-    return unless $q =~ m/^(what'?s?|is|the|current|local|\s)*time(?:is|it|\s)*(?:\b$place_connector\b)\s+(?<loc>[^\?]+)[\?]?$/;
-    $q = $+{loc};
-    trim($q);
-    $q =~ s/,//g;
+    $q =~ m/(?<rest>what'?s?|is|the|current|local|\s)*time(?:is|it|in|of|for|at|\s)*(?<loc>[^\?]*)[\?]*$/;
+    my $rest = trim $+{rest};
+    my $q_loc = trim $+{loc};
 
-    return unless (my $caps = $capitals->{$q});
+    # if no location is given, current user location is returned
+    return join ' ', (lc $loc->city, lc $loc->country_name) unless $q_loc;
+
+    $q_loc =~ s/,//g;
+
+    return unless (my $caps = $capitals->{$q_loc});
 
     # These are internally sorted by population, so assume they want the big one for now.
-    $q = string_for_search($caps->[0]);
-    return $q;
+    $q_loc = string_for_search($caps->[0]);
+    return $q_loc;
 };
 
 sub string_for_search {

--- a/t/Time.t
+++ b/t/Time.t
@@ -13,6 +13,12 @@ my @kingston_town = (
     caller    => 'DDG::Spice::Time'
 );
 
+my @phoenixville = (
+    '/js/spice/time/phoenixville%20united%20states',
+    call_type => 'include',
+    caller    => 'DDG::Spice::Time'
+);
+
 ddg_spice_test(
     [qw( DDG::Spice::Time)],
     # Primary examples
@@ -44,9 +50,11 @@ ddg_spice_test(
     'whats the current local time in kingston' => test_spice(@kingston_town),
     'local time for kingston'                  => test_spice(@kingston_town),
     'local time of kingston'                   => test_spice(@kingston_town),
+
+    'time'                                     => test_spice(@phoenixville),
+    'current time'                             => test_spice(@phoenixville),
+    'current local time'                       => test_spice(@phoenixville),
     # Intentionally ignored
-    'curent time in kingston'  => undef,
-    'current local time'       => undef,
     'time and space museum'    => undef,
     'time complexity of qsort' => undef,
     'running time of titanic'  => undef,


### PR DESCRIPTION
Fixes #1641. time, current time, current local time etc now returns the user's local time(which is phoenixville in the tests).
