### PR TITLE
Currency - use of k and cardinals instead of zeros

### DIFF
--- a/lib/DDG/Spice/Currency.pm
+++ b/lib/DDG/Spice/Currency.pm
@@ -128,6 +128,7 @@ handle query_lc => sub {
         }
 
         if ($cardinal ne '') {
+            $amount =~ s/\,//g;
             switch($cardinal) {
                 case 'hundred'  { $amount *= 100 }
                 case 'thousand' { $amount *= 1000 }

--- a/lib/DDG/Spice/Currency.pm
+++ b/lib/DDG/Spice/Currency.pm
@@ -38,9 +38,10 @@ my $into_qr = qr/\s(?:en|in|to|in ?to|to)\s/i;
 my $vs_qr = qr/\sv(?:ersu|)s\.?\s/i;
 my $question_prefix = qr/(?:convert|what (?:is|are|does)|how (?:much|many) (?:is|are))?\s?/;
 my $number_re = number_style_regex();
+my $cardinal_re = join('|', qw(hundred thousand k million m billion b trillion));
 
 # This regexp is responsible for actually processing the query and capturing the important parts.
-my $guard = qr/^$question_prefix($number_re*)\s?(hundred|thousand|k|million|m|billion|b|trillion)?\s?($currency_qr)(?:s)?(?:$into_qr|$vs_qr|\s)?($number_re*)\s?($currency_qr)?(?:s)?\??$/i;
+my $guard = qr/^$question_prefix($number_re*)\s?($cardinal_re)?\s?($currency_qr)(?:s)?(?:$into_qr|$vs_qr|\s)?($number_re*)\s?($currency_qr)?(?:s)?\??$/i;
 
 triggers query_lc => qr/$currency_qr/;
 

--- a/lib/DDG/Spice/Currency.pm
+++ b/lib/DDG/Spice/Currency.pm
@@ -6,7 +6,6 @@ use DDG::Spice;
 with 'DDG::SpiceRole::NumberStyler';
 
 use Text::Trim;
-use Switch;
 
 primary_example_queries "convert 499 usd to cad";
 secondary_example_queries "cad to usd", "cny?";
@@ -129,13 +128,12 @@ handle query_lc => sub {
 
         if ($cardinal ne '') {
             $amount =~ s/\,//g;
-            switch($cardinal) {
-                case 'hundred'  { $amount *= 100 }
-                case 'thousand' { $amount *= 1000 }
-                case 'million'  { $amount *= 1000000 }
-                case 'billion'  { $amount *= 1000000000 }
-                case 'trillion' { $amount *= 1000000000000 }
-            }
+
+            if ($cardinal eq 'hundred')  { $amount *= 100 }
+            elsif ($cardinal eq 'thousand') { $amount *= 1000 }
+            elsif ($cardinal eq 'million')  { $amount *= 1000000 }
+            elsif ($cardinal eq 'billion')  { $amount *= 1000000000 }
+            elsif ($cardinal eq 'trillion') { $amount *= 1000000000000 }
         }
 
         # If two amounts are available, exit early. It's ambiguous.

--- a/t/Currency.t
+++ b/t/Currency.t
@@ -28,6 +28,12 @@ ddg_spice_test(
         caller => 'DDG::Spice::Currency',
         is_cached => 0
     ),
+    'convert 4.000.000k euro to usd' => test_spice(
+        '/js/spice/currency/4000000000/eur/usd',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
     'euro cny' => test_spice(
         '/js/spice/currency/1/eur/cny',
         call_type => 'include',

--- a/t/Currency.t
+++ b/t/Currency.t
@@ -21,6 +21,13 @@ ddg_spice_test(
         caller => 'DDG::Spice::Currency',
         is_cached => 0
     ),
+    # using k for thousand
+    '4k euro' => test_spice(
+        '/js/spice/currency/4000/eur/usd',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
     'euro cny' => test_spice(
         '/js/spice/currency/1/eur/cny',
         call_type => 'include',
@@ -41,6 +48,13 @@ ddg_spice_test(
     ),
     '499 us dollar to euro' => test_spice(
         '/js/spice/currency/499/usd/eur',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
+    # using cardinals instead of zeros
+    '4.5 billion us dollar to euro' => test_spice(
+        '/js/spice/currency/4500000000/usd/eur',
         call_type => 'include',
         caller => 'DDG::Spice::Currency',
         is_cached => 0
@@ -72,6 +86,13 @@ ddg_spice_test(
         caller => 'DDG::Spice::Currency',
         is_cached => 0
     ),
+    # Query with everything smushed together, with k for thousand.
+    '2kcadusd' => test_spice(
+        '/js/spice/currency/2000/cad/usd',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
     # Queries that have "convert" in them.
     'convert 200 cad into usd' => test_spice(
         '/js/spice/currency/200/cad/usd',
@@ -89,6 +110,13 @@ ddg_spice_test(
     # Numbers with commas in them.
     'convert 2,000 cad into usd' => test_spice(
         '/js/spice/currency/2000/cad/usd',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
+    # Numbers with commas in them.
+    'convert 2 million cad into usd' => test_spice(
+        '/js/spice/currency/2000000/cad/usd',
         call_type => 'include',
         caller => 'DDG::Spice::Currency',
         is_cached => 0
@@ -116,6 +144,13 @@ ddg_spice_test(
     # Using plural forms of currency
     'what is 19 hk dollars in thai bahts?' => test_spice(
         '/js/spice/currency/19/hkd/thb',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
+    # Using plural forms of currency with cardinal
+    'what is 19 thousand hk dollars in thai bahts?' => test_spice(
+        '/js/spice/currency/19000/hkd/thb',
         call_type => 'include',
         caller => 'DDG::Spice::Currency',
         is_cached => 0

--- a/t/Currency.t
+++ b/t/Currency.t
@@ -126,7 +126,6 @@ ddg_spice_test(
         caller => 'DDG::Spice::Currency',
         is_cached => 0
     ),
-    # Numbers with commas in them.
     'convert 2 million cad into usd' => test_spice(
         '/js/spice/currency/2000000/cad/usd',
         call_type => 'include',

--- a/t/Currency.t
+++ b/t/Currency.t
@@ -65,6 +65,12 @@ ddg_spice_test(
         caller => 'DDG::Spice::Currency',
         is_cached => 0
     ),
+    'convert 1,021 hundred gbp to cny' => test_spice(
+        '/js/spice/currency/102100/gbp/cny',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
     # Queries with no space between the number and the currency.
     '100cad' => test_spice(
         '/js/spice/currency/100/cad/usd',


### PR DESCRIPTION
Fixes #1563. Now supporting queries like `convert 4k euro to usd`.

![](http://imgur.com/R4vvfce.png)
