### PR TITLE
(Forecast) Alert Styling Update

### DIFF
--- a/share/spice/forecast/forecast.css
+++ b/share/spice/forecast/forecast.css
@@ -25,6 +25,14 @@
 	opacity: 0.81;
 }
 	.dark-header .fe_icon--alt { display: block; }
+	
+.fe_icon--alert {
+	font-size: 16px;
+	margin-top: -1px;
+	margin-right: 0.5em;
+	display: inline-block;
+	vertical-align: middle;
+}
 
 /* Other Styling */
 .fe_currently,

--- a/share/spice/forecast/forecast.js
+++ b/share/spice/forecast/forecast.js
@@ -227,7 +227,7 @@ function ddg_spice_forecast(r) {
     }
 
     if(alert_message)
-      return '<a href="'+alert_message.uri+'" class="fe_alert" target="_blank"><span class="fe_icon--flag">&#9873;</span> '+alert_message.title+'</a>';
+      return '<a href="'+alert_message.uri+'" class="fe_alert  tx-clr--red" target="_blank"><span class="ddgsi fe_icon--alert">!</span>'+alert_message.title+'</a>';
   }
   
   // Go!


### PR DESCRIPTION
Removing the blank square of doom for Windows users finally... :smile: 

![forecast-alert-update](https://cloud.githubusercontent.com/assets/2266707/7028459/f3460430-dd23-11e4-908a-57b041779bd9.png)

cc @jagtalon @chrismorast @bsstoner 