### PR TITLE
similar_sites.css: Add additional qualifier to avoid extra spacing.

### DIFF
--- a/share/spice/similar_sites/similar_sites.css
+++ b/share/spice/similar_sites/similar_sites.css
@@ -2,11 +2,11 @@
     vertical-align: middle;
 }
 
-.zci--similar_sites div {
+.zci--similar_sites .zci__body div {
     margin-bottom: 5px;
 }
 
-.zci--similar_sites div > a {
+.zci--similar_sites .zci__body div > a {
     font-size: 1.357em;
     font-weight: 300;
     vertical-align: middle;


### PR DESCRIPTION
Removing the container `div` in #1716 made the CSS selectors too broad which added margins everywhere.

Now:
![screen shot 2015-04-07 at 11 45 10 pm](https://cloud.githubusercontent.com/assets/81969/7038472/5c786d74-dd80-11e4-8200-7da7cf60eaac.png)

Before:
![screen shot 2015-04-07 at 11 44 58 pm](https://cloud.githubusercontent.com/assets/81969/7038469/5716d636-dd80-11e4-9f3d-abda3e6e121a.png)

Notice the increased space at the bottom.