### PR TITLE
Revert "Guard against trailing whitespaces in Perl files when building"

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -57,6 +57,7 @@ version_regexp = ^(.+)$
 [PodSyntaxTests]
 [GithubMeta]
 [Test::EOL]
+trailing_whitespace = 0
 [@Git]
 tag_format = %v
 [Git::Push]


### PR DESCRIPTION
Being overly strict with trailing whitespaces was confusing for devs
according to

  https://github.com/duckduckgo/zeroclickinfo-spice/commit/5980b02618d1f96e0d9e43af1b4ad788d392447e#commitcomment-10675310

. Hence, reverting.

This reverts commit 5980b02618d1f96e0d9e43af1b4ad788d392447e.