### PR TITLE
Template Group Adjustment - Movies/Media

### DIFF
--- a/share/spice/bbc/bbc.js
+++ b/share/spice/bbc/bbc.js
@@ -93,9 +93,7 @@
                 };
             },
             templates: {
-                group: 'media',
-                detail: 'products_detail',
-                item_detail: 'products_item_detail',
+                group: 'products_simple',
                 options: {
                     buy: Spice.bbc.buy,
                     subtitle_content: Spice.bbc.subtitle_content

--- a/share/spice/coursebuffet/coursebuffet.js
+++ b/share/spice/coursebuffet/coursebuffet.js
@@ -36,7 +36,7 @@
                 };
             },
             templates: {
-                group: "media",
+                group: "products_simple",
                 item_detail: false,
                 detail: false,
                 options: {

--- a/share/spice/guidebox/getid/guidebox_getid.js
+++ b/share/spice/guidebox/getid/guidebox_getid.js
@@ -53,7 +53,7 @@
                     itemType: 'episodes of ' + metadata.res_title
                 },
                 templates: {
-                    group: 'media',
+                    group: 'products_simple',
                     options: {
                         price: true,
                         buy: Spice.guidebox_getid.buy

--- a/share/spice/in_theaters/in_theaters.css
+++ b/share/spice/in_theaters/in_theaters.css
@@ -1,26 +1,3 @@
-.tile--in_theaters {
-    width: 12em;
-}
-
-.tile--in_theaters .tile__media__img {
-    min-width: 100%;
-    height: 100%;
-    margin-top: 0;
-}
-
-.zci--in_theaters .one-line {
-    float: left;
-}
-
-.tile--in_theaters .tile__title {
-    height: 2.5em;
-}
-
-.tile--in_theaters .tile__source,
-.tile--in_theaters.highlight .tile__source {
-    color: #999;
-}
-
 .zci--in_theaters .tomato--icon {
     width: 16px;
     height: 16px;

--- a/share/spice/in_theaters/in_theaters.js
+++ b/share/spice/in_theaters/in_theaters.js
@@ -86,22 +86,14 @@
                 };
             },
             templates: {
-                group: 'media',
+                group: 'movies',
                 options: {
                     subtitle_content: Spice.in_theaters.subtitle_content,
                     rating: false,
                     buy: Spice.in_theaters.buy
-                },
-                variants: {
-                    tile: 'poster'
                 }
             }
         });
-
-        // Hide the bottom text so that the poster occupies the whole tile.
-        if(typeof Spice.getDOM('in_theaters') !== 'undefined') {
-            Spice.getDOM('in_theaters').find('.tile__body').addClass('is-hidden');
-        }
     }
     
     // Convert minutes to hr. min. format.

--- a/share/spice/kwixer/kwixer.css
+++ b/share/spice/kwixer/kwixer.css
@@ -1,9 +1,3 @@
-.tile--kwixer .tile__media__img {
-    min-width: 100%;
-    height: 100%;
-    margin-top: 0;
-}
-
 .zci--kwixer .btn.btn--primary {
     margin-top: 1em;
 }

--- a/share/spice/kwixer/kwixer.js
+++ b/share/spice/kwixer/kwixer.js
@@ -43,22 +43,15 @@
                 };
             },
             templates: {
-                group: 'media',
+                group: 'movies',
                 detail: 'products_item_detail',
                 item: 'basic_image_item',
                 options: {
                     rating: false,
                     buy: Spice.kwixer.buy
-                },
-                variants: {
-                    tile: 'poster'
                 }
             }
         });
-        
-        // We're going to use this to hide the title of the template.
-        // We want the poster to take up the whole tile.
-        Spice.getDOM('kwixer').find('.tile__body').hide();
     };
     
     // The separator that we get from the API is `;`, but it looks better with

--- a/share/spice/movie/movie.css
+++ b/share/spice/movie/movie.css
@@ -1,26 +1,3 @@
-.tile--movie  {
-    width: 12em;
-}
-
-.tile--movie .tile__media__img {
-    min-width: 100%;
-    height: 100%;
-    margin-top: 0;
-}
-
-.zci--movie .one-line {
-    float: left;
-}
-
-.tile--movie .tile__title {
-    height: 2.5em;
-}
-
-.tile--movie .tile__source,
-.tile--movie:hover .tile__source {
-    color: #aaa;
-}
-
 .zci--movie .tomato--icon {
     width: 16px;
     height: 16px;

--- a/share/spice/movie/movie.js
+++ b/share/spice/movie/movie.js
@@ -88,13 +88,10 @@
                 };
             },
             templates: {
-                group: 'media',
+                group: 'movies',
                 options: {
                     subtitle_content: Spice.movie.subtitle_content,
                     buy: Spice.movie.buy
-                },
-                variants: {
-                    tile: 'poster'
                 }
             },
             relevancy: {
@@ -108,13 +105,6 @@
                 }]
             }
         });
-
-        // Make sure we hide the title and ratings.
-        // It looks nice to show only the poster of the movie.
-        var $dom = Spice.getDOM('movie')
-        if ($dom && $dom.length) {
-            $dom.find('.tile__body').hide();
-        }
     };
 
     // Convert minutes to hr. min. format.


### PR DESCRIPTION
A bunch of 'movies' IAs are using some custom styling and scripting that could be standardized.  These have been consolidated into a 'movies' template group.

We're also adjusting the 'media' template group to be more flexible, so we're moving other IAs that were using it to the 'products_simple' group for now.

cc @bsstoner @moollaza @jagtalon @abeyang 
