### PR TITLE
IndeedJobs: Add relevancy check

### DIFF
--- a/share/spice/indeed_jobs/indeed_jobs.js
+++ b/share/spice/indeed_jobs/indeed_jobs.js
@@ -1,6 +1,6 @@
 (function(env) {
     "use strict";
-    
+
     env.ddg_spice_indeed_jobs = function(api_result) {
         if (api_result.error || !api_result.results.length) {
             return Spice.failed('indeed_jobs');
@@ -11,7 +11,7 @@
             re = /^http:\/\/([a-z.]+)\//,
             rematch = api_result.results[0].url.match(re),
             www_domain = rematch ? rematch[0] : "http://www.indeed.com/";
-        
+
         Spice.add({
             id: "indeed_jobs",
             name: "Jobs",
@@ -21,6 +21,11 @@
                 sourceUrl: www_domain + 'jobs?q=' + encodeURIComponent(q) + '&l=' + encodeURIComponent(loc)
             },
             normalize: function(item) {
+                // ensure job is relevant to query
+                if (q.length && !DDG.stringsRelevant(item.jobtitle, q)){
+                    return null;
+                }
+
                 return {
                     url: item.url,
                     title: item.jobtitle,


### PR DESCRIPTION
/cc @jagtalon @tagawa 

Prevents queries like "steve jobs" from passing -- though technically they do return somewhat relevant results (i.e. "steve" exists in the description) -- we could generalize this to check the description as well if we wanted.

Couldn't use a relevancy block because I want to only compare the search term portion of the query, and ignore the location portion if it exists.

FTR, I can't add a Perl test, because technically this query is valid and will trigger an API call.
