### PR TITLE
RedditSubSearch: Move to record template.

### DIFF
--- a/share/spice/reddit_sub_search/reddit_sub_search.handlebars
+++ b/share/spice/reddit_sub_search/reddit_sub_search.handlebars
@@ -1,5 +1,0 @@
-{{#rt "Title"}} <a href="http://www.reddit.com{{url}}">{{title}}</a>{{/rt}}
-{{#if public_description}}
-{{#rd "Description"}} {{{unescape description_html}}} {{/rd}}
-{{/if}}
-{{#rd "Subscribers"}} {{formatSubscribers subscribers}} {{/rd}}

--- a/share/spice/reddit_sub_search/reddit_sub_search.js
+++ b/share/spice/reddit_sub_search/reddit_sub_search.js
@@ -21,12 +21,23 @@
                 sourceUrl: 'http://www.reddit.com' + api_response.data.url,
                 sourceName: 'Reddit'
             },
+            normalize: function(item) {
+                return {
+                    title: "/r/" + item.title,
+                    subtitle: item.submit_link_label,
+                    record_data: {
+                        "Title": item.title,
+                        "Description": item.public_description,
+                        "Subscribers": item.subscribers.toLocaleString()
+                    }
+                };
+            },
             templates: {
-		group: 'base',
-		options: {
-                    content: Spice.reddit_sub_search.detail,
-		    moreAt: true
-		}
+                group: 'text',
+                options: {
+                    content: 'record',
+                    moreAt: true
+                }
             }   
         });
     }


### PR DESCRIPTION
This PR removes the use of `{{rt}}` and `{{rd}}` template helpers and makes use of the record template instead. CC @moollaza @abeyang @bsstoner 

Old:
![screen shot 2015-04-14 at 2 57 22 pm](https://cloud.githubusercontent.com/assets/81969/7144903/97c9eb4c-e2b6-11e4-91c4-0c992dd59231.png)

New:
![screen shot 2015-04-14 at 2 57 28 pm](https://cloud.githubusercontent.com/assets/81969/7144905/9be0401e-e2b6-11e4-8912-09a001d62d41.png)
