### PR TITLE
Update PromptIfStale to use index_base_url

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -7,7 +7,7 @@ copyright_year   = 2013
 main_module = lib/DDG/SpiceBundle/OpenSourceDuckDuckGo.pm
 
 [PromptIfStale]
-index = http://duckpan.org
+index_base_url = http://duckpan.org
 module = Dist::Zilla::Plugin::UploadToDuckPAN
 module = Dist::Zilla::Plugin::BuildShareAssets
 


### PR DESCRIPTION
Required update, you can no longer specify `index`

/cc @zachthompson 