### PR TITLE
Transit::Switzerland - using moment to show 12h time

### DIFF
--- a/share/spice/transit/switzerland/train_item.handlebars
+++ b/share/spice/transit/switzerland/train_item.handlebars
@@ -11,5 +11,7 @@
 </div>
 <div class="switzerland__status">
     <div class="one-line">{{status}}</div>
-    <div class="one-line">Platform {{platform}}</div>
+    {{#if platform}}
+        <div class="one-line">Platform {{platform}}</div>
+    {{/if}}
 </div>

--- a/share/spice/transit/switzerland/transit_switzerland.js
+++ b/share/spice/transit/switzerland/transit_switzerland.js
@@ -31,8 +31,8 @@
                 normalize: function(item){
                     console.log(item);
                     return {
-                        arrival_time: moment(item.to.arrival).zone(item.to.arrival).format('LT'),
-                        departure_time: moment(item.from.departure).zone(item.from.departure).format('LT'),
+                        arrival_time: moment(item.to.arrival).utcOffset(item.to.arrival).format('LT'),
+                        departure_time: moment(item.from.departure).utcOffset(item.from.departure).format('LT'),
                         name: item.sections[0].journey.name,
                         platform: item.from.platform,
                         status: (item.from.delay) ? 'Delayed' : 'On time',

--- a/share/spice/transit/switzerland/transit_switzerland.js
+++ b/share/spice/transit/switzerland/transit_switzerland.js
@@ -5,50 +5,46 @@
         if (!api_result || api_result.error || !api_result.to || !api_result.from || !api_result.connections) {
             return Spice.failed('switzerland');
         }
-        
+
         var to = api_result.to.name || '',
             from = api_result.from.name || '';
-        
-        Spice.add({
-            id: "switzerland",
-            name: "Swiss Trains",
-            data: api_result.connections,
-            meta: {
-                heading: from + " to " + to,
-                sourceName: "transport.opendata.ch",
-                sourceUrl: 'http://transport.opendata.ch/examples/connections.php?from=' + from + '&to=' + to
-            },
-            templates: {
-                group: 'base',
-                detail: false,
-                item_detail: false,
-                options: {
-                    content: Spice.transit_switzerland.train_item,
-                    moreAt: true
+
+        DDG.require('moment.js', function() {
+            Spice.add({
+                id: "switzerland",
+                name: "Swiss Trains",
+                data: api_result.connections,
+                meta: {
+                    heading: from + " to " + to,
+                    sourceName: "transport.opendata.ch",
+                    sourceUrl: 'http://transport.opendata.ch/examples/connections.php?from=' + from + '&to=' + to
+                },
+                templates: {
+                    group: 'base',
+                    detail: false,
+                    item_detail: false,
+                    options: {
+                        content: Spice.transit_switzerland.train_item,
+                        moreAt: true
+                    }
+                },
+                normalize: function(item){
+                    console.log(item);
+                    return {
+                        arrival_time: moment(item.to.arrival).zone(item.to.arrival).format('LT'),
+                        departure_time: moment(item.from.departure).zone(item.from.departure).format('LT'),
+                        name: item.sections[0].journey.name,
+                        platform: item.from.platform,
+                        status: (item.from.delay) ? 'Delayed' : 'On time',
+                        status_class: (item.from.delay) ? 'switzerland__delayed' : '',
+                        transfers: format_transfers(item.transfers),
+                        url: 'http://transport.opendata.ch/examples/connections.php?from=' + from + '&to=' + to
+                    }
                 }
-            },
-            normalize: function(item){
-                return {
-                    arrival_time: format_time(item.to.arrival),
-                    departure_time: format_time(item.from.departure),
-                    name: item.sections[0].journey.name,
-                    platform: item.from.platform,
-                    status: (item.from.delay) ? 'Delayed' : 'On time',
-                    status_class: (item.from.delay) ? 'switzerland__delayed' : '',
-                    transfers: format_transfers(item.transfers),
-                    url: 'http://transport.opendata.ch/examples/connections.php?from=' + from + '&to=' + to
-                }
-            }
-        });
+            });
+        })
     };
-    
-    // Extract time only from datetime, e.g. "2015-03-04T13:32:00+0100"
-    function format_time(departure) {
-        var dep_array = departure.split('T');
-        var time = dep_array[1];
-        return time.substr(0, 5);
-    }
-    
+
     // Make the transfers output format more human-readable
     function format_transfers(transfers) {
         var plural = (transfers === 1) ? '' : 's';


### PR DESCRIPTION
Fixes #1781. 

I'm showing local time of the train, not the local time of the user. Is that fine? Might be easy to, let's say, instruct someone over phone or plan something.

![selection_013](https://cloud.githubusercontent.com/assets/357253/7209270/aa03068a-e564-11e4-978a-1e5de56c3fa0.jpg)
![selection_012](https://cloud.githubusercontent.com/assets/357253/7209269/aa0315ee-e564-11e4-94c6-ccd5a57b0ae4.jpg)
