### PR TITLE
Quandl: http to https

### DIFF
--- a/lib/DDG/Spice/Quandl/Fundamentals.pm
+++ b/lib/DDG/Spice/Quandl/Fundamentals.pm
@@ -34,7 +34,7 @@ triggers startend => @trigger_keys;
 # duckpan env set <name> <value>
 
 # set spice parameters
-spice to => 'http://quandl.com/api/v1/datasets/SF1/$1_MRQ.json?auth_token={{ENV{DDG_SPICE_QUANDL_APIKEY}}}&rows=2';
+spice to => 'https://quandl.com/api/v1/datasets/SF1/$1_MRQ.json?auth_token={{ENV{DDG_SPICE_QUANDL_APIKEY}}}&rows=2';
 spice wrap_jsonp_callback => 1;
 spice proxy_cache_valid => "418 1d";
 

--- a/lib/DDG/Spice/Quandl/HomeValues.pm
+++ b/lib/DDG/Spice/Quandl/HomeValues.pm
@@ -42,7 +42,7 @@ triggers any => @trigger_keys;
 # duckpan env set <name> <value>
 
 # set spice parameters
-spice to => 'http://quandl.com/api/v1/datasets/ZILLOW/$1.json?auth_token={{ENV{DDG_SPICE_QUANDL_APIKEY}}}&rows=2';
+spice to => 'https://quandl.com/api/v1/datasets/ZILLOW/$1.json?auth_token={{ENV{DDG_SPICE_QUANDL_APIKEY}}}&rows=2';
 spice wrap_jsonp_callback => 1;
 spice proxy_cache_valid => "418 1d";
 

--- a/lib/DDG/Spice/Quandl/WorldBank.pm
+++ b/lib/DDG/Spice/Quandl/WorldBank.pm
@@ -37,7 +37,7 @@ triggers any => @primary_keys;
 # duckpan env set <name> <value>
 
 # set spice parameters
-spice to => 'http://quandl.com/api/v1/datasets/WORLDBANK/$1.json?auth_token={{ENV{DDG_SPICE_QUANDL_APIKEY}}}&rows=2';
+spice to => 'https://quandl.com/api/v1/datasets/WORLDBANK/$1.json?auth_token={{ENV{DDG_SPICE_QUANDL_APIKEY}}}&rows=2';
 spice wrap_jsonp_callback => 1;
 spice proxy_cache_valid => "418 1d";
 


### PR DESCRIPTION
Hi @moollaza, Quandl has deprecated the http access for API calls and will be shutting it down completely on May 15.  I've made the necessary changes to the code here (which amounted to adding an 's' to three files.)