### PR TITLE
Dogo: Switch Movies & Books to movies template group

### DIFF
--- a/share/spice/dogo_books/dogo_books.js
+++ b/share/spice/dogo_books/dogo_books.js
@@ -17,11 +17,11 @@
             data: api_result.results,
             meta: {
                 sourceName: 'DOGObooks',
-                sourceUrl: 'http://www.dogobooks.com/search?query=' + encodeURIComponent(query) + '&ref=ddg',
+                sourceUrl: 'http://www.dogobooks.com/search?query=' + encodeURIComponent(query),
                 itemType: 'kids books'
             },
             normalize: function(item) {
-                var thumb = item.hi_res_thumb || item.thumb;                
+                var thumb = item.hi_res_thumb || item.thumb;
                 return {
                     title: item.name,
                     image: thumb,
@@ -36,13 +36,10 @@
                 };
             },
             templates: {
-                group: 'media',
+                group: 'movies',
                 options: {
                     buy: Spice.dogo_books.buy,
                     rating: true
-                },
-                variants: {
-                    tile: 'poster'
                 }
             }
         });

--- a/share/spice/dogo_movies/dogo_movies.js
+++ b/share/spice/dogo_movies/dogo_movies.js
@@ -20,14 +20,14 @@
             }
             return hours + (minutes > 0 ? minutes + ' min.' : '');
         }
-        
+
         Spice.add({
             id: 'dogo_movies',
             name: 'Kids Movies',
             data: api_result.results,
             meta: {
                 sourceName: 'DOGOmovies',
-                sourceUrl: 'http://www.dogomovies.com/search?query=' + encodeURIComponent(query) + '&ref=ddg',
+                sourceUrl: 'http://www.dogomovies.com/search?query=' + encodeURIComponent(query),
                 itemType: 'kids movies'
             },
             normalize: function(item) {
@@ -47,15 +47,12 @@
                 };
             },
             templates: {
-                group: 'media',
+                group: 'movies',
                 options: {
                     buy: Spice.dogo_movies.buy,
                     subtitle_content: Spice.dogo_movies.subtitle_content,
                     rating: true
                 },
-                variants: {
-                    tile: 'poster'
-                }
             }
         });
     };

--- a/share/spice/dogo_news/dogo_news.js
+++ b/share/spice/dogo_news/dogo_news.js
@@ -10,7 +10,7 @@
         var script = $('[src*="/js/spice/dogo_news/"]')[0],
             source = $(script).attr("src"),
             query = decodeURIComponent(source.match(/dogo_news\/([^\/]+)/)[1]);
-    
+
         DDG.require('moment.js', function(){
             Spice.add({
                 id: 'dogo_news',
@@ -18,7 +18,7 @@
                 data: api_result.results,
                 meta: {
                     sourceName: 'DOGOnews',
-                    sourceUrl: 'http://www.dogonews.com/search?query=' + encodeURIComponent(query) + '&ref=ddg',
+                    sourceUrl: 'http://www.dogonews.com/search?query=' + encodeURIComponent(query),
                     itemType: 'kids news articles'
                 },
                 normalize: function(item) {


### PR DESCRIPTION
Need to switch these over to the new 'movies' template group, now that it's released.

Also removed `ref=` param from `sourceUrl` links -- that's not allowed ;)

/cc @jagtalon