### PR TITLE
Quixey: Additional Relevancy Checking - #1793

### DIFF
--- a/share/spice/quixey/quixey.js
+++ b/share/spice/quixey/quixey.js
@@ -90,8 +90,20 @@
                     return null;
                 }
 
-                // ignoring the case where rating_count is null
+                // relevancy pre-filter: remove GoogleTV Android packages 
+                // API doesn't differentiate between GoogleTV Android and Android packages
+                var reFilter = /Google\s?TV/i;
 
+                for (var i in item.editions) {
+                    var packageAppName = [DDG.getProperty(item, "editions." + [i] + ".custom.features.package_name"),              
+                                          DDG.getProperty(item, "editions." + [i] + ".name")].join(" ");
+
+                    if (packageAppName.match(reFilter)) {
+                        item.editions.splice(i,1);
+                   }
+                }
+
+                // ignoring the case where rating_count is null
                 var icon_url = make_icon_url(item), screenshot; 
 
                 if (!icon_url)


### PR DESCRIPTION
Fixing #1793 - Remove Google TV editions of Android apps based on regexp for ` /Google\s?TV/i` on `package_name` or `name`