### PR TITLE
IndeedJobs.pm: Switch to deep trigger.

### DIFF
--- a/lib/DDG/Spice/IndeedJobs.pm
+++ b/lib/DDG/Spice/IndeedJobs.pm
@@ -18,27 +18,15 @@ attribution github  => ['parker', 'Parker'],
             twitter => ['ourmaninjapan', 'Daniel Davis'],
             web     => ['http://daniemon.com/', 'Daniel Davis'];
 
-triggers any => "job", "jobs";
+triggers any => "///***never trigger***///";
 
 spice to => 'http://api.indeed.com/ads/apisearch?publisher={{ENV{DDG_SPICE_INDEED_APIKEY}}}&v=2&useragent=DuckDuckGo&userip=1.2.3.4&q=$1&l=$2&co=$3&sort=date&format=json&callback={{callback}}';
 spice from => '([^/]+)/(.*?)/([^/]*)';
 spice proxy_cache_valid   => "418 1d";
 
 handle query => sub {
-    my $country = 'US';
-    if($loc->country_code) {
-        $country = $loc->country_code;
-    }
-    my $spice_location = $loc->city . ', ' . $loc->region_name;
-    
-    if (/(?:\s*(?:i\s+|we\s+)?(?:need|want|wanna|deserve|seek|get|find)\s+(?:a\s+|an?\s+)?)?(?:(?<query>.+)\s+)?(?:jobs?|work|employment|internship)(?:\s+(?:in|near|around\s+)?\s*(?<location>.+))?$/i) {
-        if ($1 || $2) {
-            my $query = $+{query} || ' ';
-            my $location = $+{location} || $spice_location || ' ';
-            return $query, $location, $country;
-        }
-    }
-	return;
+    return $_ if $_;
+    return;
 };
 
 1;

--- a/share/spice/indeed_jobs/indeed_jobs.js
+++ b/share/spice/indeed_jobs/indeed_jobs.js
@@ -21,11 +21,6 @@
                 sourceUrl: www_domain + 'jobs?q=' + encodeURIComponent(q) + '&l=' + encodeURIComponent(loc)
             },
             normalize: function(item) {
-                // ensure job is relevant to query
-                if (q.length && !DDG.stringsRelevant(item.jobtitle, q)){
-                    return null;
-                }
-
                 return {
                     url: item.url,
                     title: item.jobtitle,

--- a/t/IndeedJobs.t
+++ b/t/IndeedJobs.t
@@ -5,55 +5,7 @@ use warnings;
 use Test::More;
 use DDG::Test::Spice;
 
-ddg_spice_test(
-    [qw( DDG::Spice::IndeedJobs )],
-    'perl jobs in    Austin, TX' => test_spice(
-        '/js/spice/indeed_jobs/perl/Austin%2C%20TX/US',
-        call_type => 'include',
-        caller => 'DDG::Spice::IndeedJobs'
-    ),
-    'perl job in nyc' => test_spice(
-        '/js/spice/indeed_jobs/perl/nyc/US',
-        call_type => 'include',
-        caller => 'DDG::Spice::IndeedJobs'
-    ),
-    'perl jobs' => test_spice(
-        '/js/spice/indeed_jobs/perl/Phoenixville%2C%20Pennsylvania/US',
-        call_type => 'include',
-        caller => 'DDG::Spice::IndeedJobs'
-    ),
-    'perl job' => test_spice(
-        '/js/spice/indeed_jobs/perl/Phoenixville%2C%20Pennsylvania/US',
-        call_type => 'include',
-        caller => 'DDG::Spice::IndeedJobs'
-    ),
-    'jobs in austin' => test_spice(
-        '/js/spice/indeed_jobs/%20/austin/US',
-        call_type => 'include',
-        caller => 'DDG::Spice::IndeedJobs'
-    ),
-    'jobs near austin' => test_spice(
-        '/js/spice/indeed_jobs/%20/austin/US',
-        call_type => 'include',
-        caller => 'DDG::Spice::IndeedJobs'
-    ),
-    'fitness trainer job around new york' => test_spice(
-        '/js/spice/indeed_jobs/fitness%20trainer/new%20york/US',
-        call_type => 'include',
-        caller => 'DDG::Spice::IndeedJobs'
-    ),
-    'I want java job in Austin' => test_spice(
-        '/js/spice/indeed_jobs/java/Austin/US',
-        call_type => 'include',
-        caller => 'DDG::Spice::IndeedJobs'
-    ),
-    'I want a job in Austin' => test_spice(
-        '/js/spice/indeed_jobs/%20/Austin/US',
-        call_type => 'include',
-        caller => 'DDG::Spice::IndeedJobs'
-    ),
-    'jobs' => undef
-);
+use_ok('DDG::Spice::Amazon');
 
 done_testing;
 

--- a/t/IndeedJobs.t
+++ b/t/IndeedJobs.t
@@ -5,7 +5,7 @@ use warnings;
 use Test::More;
 use DDG::Test::Spice;
 
-use_ok('DDG::Spice::Amazon');
+use_ok('DDG::Spice::IndeedJobs');
 
 done_testing;
 


### PR DESCRIPTION
We're switching to deep triggers because it's difficult to extract the location from a query. We can understand location for some queries such as "javascript jobs in philadelphia" because of the "in" preposition, but we can do nothing for queries such as "javascript nyc jobs" because we don't have the functionality to get the location part of the query. For the mean time, we switch to a Deep trigger so that we can pass the right location to the Indeed API endpoint.

**What is a Deep trigger?**

A Deep trigger is triggering based on the SERP results instead of on the query. This means we can look in the search results, see indeed.com domains (such as indeed.com/q-Javascript-l-San-Francisco,-CA-jobs.html), extract the things that we want using regexp (in this case, "Javascript" and "San Francisco, CA"), and pass that along to the endpoint. Unfortunately, it isn't open source at the moment so it's a bit of a black box at the moment.

![screen shot 2015-04-27 at 9 29 30 pm](https://cloud.githubusercontent.com/assets/81969/7361340/8b743474-ed24-11e4-9db8-d8871d1ad849.png)

Currently depends on an internal PR. Will ping if it's ready.