### PR TITLE
GoWatchIt: Fix buy_line for "Netflix Mail" result

### DIFF
--- a/share/spice/go_watch_it/go_watch_it.js
+++ b/share/spice/go_watch_it/go_watch_it.js
@@ -190,6 +190,12 @@
                     item.rent_line = "";
                 }
                 
+                // If the provider is "Netflix Mail" Change buy_line and format_line
+                if(item.provider_format_name === "Netflix Mail" && item.category !== "online") {
+                    item.buy_line = "Available for Rent";
+                    item.format_line = "Available on Blu-ray / DVD";
+                }
+                
                 // Change the format line to match the other tiles.
                 if(item.format_line === "DVD & Blu-ray") {
                     item.format_line = "DVD / Blu-ray";


### PR DESCRIPTION
Fixing - #1813

![selection_392](https://cloud.githubusercontent.com/assets/5282264/7391426/c99daf06-eeb3-11e4-8dbe-cf0d6e06d206.png)

//CC @jagtalon @abeyang 

I'd rather implement this by adding the provider to an array like you have with `purchase_providers` etc, however this seems to be the quickest way to deal with it. 
