### PR TITLE
CourseBuffet: Adding more triggers

### DIFF
--- a/lib/DDG/Spice/Coursebuffet.pm
+++ b/lib/DDG/Spice/Coursebuffet.pm
@@ -39,7 +39,7 @@ my @providers = (
 );
 my $providers_str = join('|', @providers);
 
-triggers query_lc => qr/(online|$providers_str)?(?:\s+)?(.*)(?:\s+)(courses? online|courses?|classe?s?|moocs?|$providers_str)$/;
+triggers query_lc => qr/(online|$providers_str)?(?:\s+)?(.*)(?:\s+)(courses? online|courses?|class(?:es)?|moocs?|$providers_str)$/;
 
 handle query_lc => sub {
     
@@ -54,7 +54,7 @@ handle query_lc => sub {
         return "provider", $remainder, $subject;
     }
     
-    if(defined($remainder) && $remainder =~ /(courses?|classe?s?)/ && $remainder !~ /(courses? online)/ && $subject !~ /online/) {
+    if(defined($remainder) && $remainder =~ /(courses?|class(es)?)/ && $remainder !~ /(courses? online)/ && $subject !~ /online/) {
         return if !defined($pre) || $pre !~ /online/;
     }
     if($subject) {

--- a/lib/DDG/Spice/Coursebuffet.pm
+++ b/lib/DDG/Spice/Coursebuffet.pm
@@ -39,7 +39,7 @@ my @providers = (
 );
 my $providers_str = join('|', @providers);
 
-triggers query_lc => qr/(online|$providers_str)?(?:\s+)?(.*)(?:\s+)(courses? online|courses?|class(?:es)?|moocs?|$providers_str)$/;
+triggers query_lc => qr/(online|$providers_str)?(?:\s+)?(.*)(?:\s+)(courses? online|class(?:es)? online|courses?|class(?:es)?|moocs?|$providers_str)$/;
 
 handle query_lc => sub {
     
@@ -54,7 +54,7 @@ handle query_lc => sub {
         return "provider", $remainder, $subject;
     }
     
-    if(defined($remainder) && $remainder =~ /(courses?|class(es)?)/ && $remainder !~ /(courses? online)/ && $subject !~ /online/) {
+    if(defined($remainder) && $remainder =~ /(courses?|class(es)?)/ && $remainder !~ /(courses? online|class(?:es)? online)/ && $subject !~ /online/) {
         return if !defined($pre) || $pre !~ /online/;
     }
     if($subject) {

--- a/lib/DDG/Spice/Coursebuffet.pm
+++ b/lib/DDG/Spice/Coursebuffet.pm
@@ -39,27 +39,13 @@ my @providers = (
 );
 my $providers_str = join('|', @providers);
 
-# triggers any => 'online course', 'online courses', 'course online', 'courses online', @providers;
 triggers query_lc => qr/(online|$providers_str)?(?:\s+)?(.*)(?:\s+)(courses? online|courses?|classe?s?|moocs?|$providers_str)$/;
 
 handle query_lc => sub {
-    # MOOC provider specific search returns courses for the specified provider
-
-    # Generic course search
-#     if (/\bonline courses?\b/ || /\bcourses? online\b/) {
-#         return "standard", "courses", trim("$` $'");
-#     }
-#     print $_;
-#     my $subject = null;
-#     if($3 == /moocs?/) {
-#         $subject = $2;
-#     }
     
     my $pre = $1;
     my $subject = $2;
     my $remainder = $3;
-    
-#     return "provider", $remainder, $subject;
     
     if (defined($pre) && $pre =~ /($providers_str)/) {
         return "provider", $pre, $subject;

--- a/lib/DDG/Spice/Coursebuffet.pm
+++ b/lib/DDG/Spice/Coursebuffet.pm
@@ -39,17 +39,40 @@ my @providers = (
 );
 my $providers_str = join('|', @providers);
 
-triggers any => 'online course', 'online courses', 'course online', 'courses online', @providers;
+# triggers any => 'online course', 'online courses', 'course online', 'courses online', @providers;
+triggers query_lc => qr/(online|$providers_str)?(?:\s+)?(.*)(?:\s+)(courses? online|courses?|classe?s?|moocs?|$providers_str)$/;
 
 handle query_lc => sub {
     # MOOC provider specific search returns courses for the specified provider
-    if (/($providers_str)/) {
-        return "provider", $1, trim("$` $'");
-    }
 
     # Generic course search
-    if (/\bonline courses?\b/ || /\bcourses? online\b/) {
-        return "standard", "courses", trim("$` $'");
+#     if (/\bonline courses?\b/ || /\bcourses? online\b/) {
+#         return "standard", "courses", trim("$` $'");
+#     }
+#     print $_;
+#     my $subject = null;
+#     if($3 == /moocs?/) {
+#         $subject = $2;
+#     }
+    
+    my $pre = $1;
+    my $subject = $2;
+    my $remainder = $3;
+    
+#     return "provider", $remainder, $subject;
+    
+    if (defined($pre) && $pre =~ /($providers_str)/) {
+        return "provider", $pre, $subject;
+    }
+    if (defined($remainder) && $remainder =~ /($providers_str)/) {
+        return "provider", $remainder, $subject;
+    }
+    
+    if(defined($remainder) && $remainder =~ /(courses?|classe?s?)/ && $remainder !~ /(courses? online)/ && $subject !~ /online/) {
+        return if !defined($pre) || $pre !~ /online/;
+    }
+    if($subject) {
+        return "standard", "courses", $subject;
     }
 
     return;

--- a/t/Coursebuffet.t
+++ b/t/Coursebuffet.t
@@ -47,6 +47,21 @@ ddg_spice_test(
         call_type => 'include',
         caller => 'DDG::Spice::Coursebuffet'
     ),
+    'computer science classes online' => test_spice(
+        '/js/spice/coursebuffet/standard/courses/computer%20science',
+        call_type => 'include',
+        caller => 'DDG::Spice::Coursebuffet'
+    ),
+    'computer science class online' => test_spice(
+        '/js/spice/coursebuffet/standard/courses/computer%20science',
+        call_type => 'include',
+        caller => 'DDG::Spice::Coursebuffet'
+    ),
+    'computer science online classes' => test_spice(
+        '/js/spice/coursebuffet/standard/courses/computer%20science%20online',
+        call_type => 'include',
+        caller => 'DDG::Spice::Coursebuffet'
+    ),
     'online computer science class' => test_spice(
         '/js/spice/coursebuffet/standard/courses/computer%20science',
         call_type => 'include',

--- a/t/Coursebuffet.t
+++ b/t/Coursebuffet.t
@@ -62,7 +62,11 @@ ddg_spice_test(
         call_type => 'include',
         caller => 'DDG::Spice::Coursebuffet'
     ),
-    'computer science class' => undef
+    'computer science class' => undef,
+    'computer science courses' => undef,
+    'harvard courses' => undef,
+    'main course' => undef,
+    'online computer science' => undef
 );
 
 done_testing;

--- a/t/Coursebuffet.t
+++ b/t/Coursebuffet.t
@@ -7,16 +7,6 @@ use DDG::Test::Spice;
 
 ddg_spice_test(
     [qw( DDG::Spice::Coursebuffet )],
-    'computer science online course' => test_spice(
-        '/js/spice/coursebuffet/standard/courses/computer%20science',
-        call_type => 'include',
-        caller => 'DDG::Spice::Coursebuffet'
-    ),
-    'computer science online courses' => test_spice(
-        '/js/spice/coursebuffet/standard/courses/computer%20science',
-        call_type => 'include',
-        caller => 'DDG::Spice::Coursebuffet'
-    ),
     'computer science course online' => test_spice(
         '/js/spice/coursebuffet/standard/courses/computer%20science',
         call_type => 'include',
@@ -27,13 +17,52 @@ ddg_spice_test(
         call_type => 'include',
         caller => 'DDG::Spice::Coursebuffet'
     ),
-    'udacity computer science' => test_spice(
+    'computer science online course' => test_spice(
+        '/js/spice/coursebuffet/standard/courses/computer%20science%20online',
+        call_type => 'include',
+        caller => 'DDG::Spice::Coursebuffet'
+    ),
+    'computer science online courses' => test_spice(
+        '/js/spice/coursebuffet/standard/courses/computer%20science%20online',
+        call_type => 'include',
+        caller => 'DDG::Spice::Coursebuffet'
+    ),
+    'online computer science course' => test_spice(
+        '/js/spice/coursebuffet/standard/courses/computer%20science',
+        call_type => 'include',
+        caller => 'DDG::Spice::Coursebuffet'
+    ),
+    'online computer science courses' => test_spice(
+        '/js/spice/coursebuffet/standard/courses/computer%20science',
+        call_type => 'include',
+        caller => 'DDG::Spice::Coursebuffet'
+    ),
+    'computer science moocs' => test_spice(
+        '/js/spice/coursebuffet/standard/courses/computer%20science',
+        call_type => 'include',
+        caller => 'DDG::Spice::Coursebuffet'
+    ),
+    'online computer science classes' => test_spice(
+        '/js/spice/coursebuffet/standard/courses/computer%20science',
+        call_type => 'include',
+        caller => 'DDG::Spice::Coursebuffet'
+    ),
+    'online computer science class' => test_spice(
+        '/js/spice/coursebuffet/standard/courses/computer%20science',
+        call_type => 'include',
+        caller => 'DDG::Spice::Coursebuffet'
+    ),
+    'computer science coursera' => test_spice(
+        '/js/spice/coursebuffet/provider/coursera/computer%20science',
+        call_type => 'include',
+        caller => 'DDG::Spice::Coursebuffet'
+    ),
+    'udacity computer science courses' => test_spice(
         '/js/spice/coursebuffet/provider/udacity/computer%20science',
         call_type => 'include',
         caller => 'DDG::Spice::Coursebuffet'
     ),
-    'computer science harvard course' => undef,
-    'main course' => undef
+    'computer science class' => undef
 );
 
 done_testing;

--- a/t/Coursebuffet.t
+++ b/t/Coursebuffet.t
@@ -66,6 +66,7 @@ ddg_spice_test(
     'computer science courses' => undef,
     'harvard courses' => undef,
     'main course' => undef,
+    'online computer science classe' => undef,
     'online computer science' => undef
 );
 


### PR DESCRIPTION
These were the old triggers:
* (subject) courses online
* online course (subject)
* (subject) (provider_name)

I have updated it to more useful and user friendly(grammatically) triggers:

* online (subject) course/s
* online (subject) class/es
* (subject) online course/s
* (subject) online class/es
* (subject) course/s online
* (subject) class/es online
* (subject) MOOC/s
* (subject) (provider_name)
* (provider_name) (subject) courses