### PR TITLE
Start to deprecate models in Spice.add()

### DIFF
--- a/share/spice/amazon/amazon.js
+++ b/share/spice/amazon/amazon.js
@@ -12,7 +12,6 @@
             name: 'Products',
             data: api_result.results,
             allowMultipleCalls: true,
-            model: 'Product',
             meta: {
                 itemType: 'Products',
                 sourceName: 'Amazon',
@@ -25,6 +24,9 @@
                 options: {
                     buy: 'products_amazon_buy'
                 }
+            },
+            relevancy: {
+                dup: ['ASIN','img_m','img']
             },
             onItemShown: function(item) {
                 if (item.loadedRatings) { return; }

--- a/share/spice/astrobin/subject/astrobin_subject.js
+++ b/share/spice/astrobin/subject/astrobin_subject.js
@@ -29,7 +29,11 @@
                     title: item.title
                 };
             },
-            view: 'Images'
+            view: 'Images',
+            templates: {
+                item: 'images_item',
+                detail: 'images_detail'
+            }
         });
     };
 }(this));

--- a/share/spice/envato/envato.js
+++ b/share/spice/envato/envato.js
@@ -79,7 +79,7 @@
                 }
             }
 
-            spice.view = spice.model = 'Audio'
+            spice.view = 'Audio'
         }
 
         Handlebars.registerHelper('formatSales', function(sales){

--- a/share/spice/gifs/gifs.js
+++ b/share/spice/gifs/gifs.js
@@ -26,6 +26,12 @@ function ddg_spice_gifs(res) {
             itemType: 'Gifs'
         },
 
-        view: 'Images'
+        view: 'Images',
+
+        templates: {
+            item: 'images_item',
+            detail: 'images_detail'
+        }
+
     });
 } 

--- a/share/spice/images/images.js
+++ b/share/spice/images/images.js
@@ -12,16 +12,20 @@ function ddg_spice_images(apiResult) {
 
         data: apiResult.results,
 
-        model: 'Image',
-
         meta: {
             next: apiResult.next,
             searchTerm: apiResult.query
         },
 
+        templates: {
+            item: 'images_item',
+            detail: 'images_detail'
+        },
+
         relevancy: {
             dup: 'image'
         }
+
     });
 
 }

--- a/share/spice/isbn/isbn.js
+++ b/share/spice/isbn/isbn.js
@@ -14,7 +14,6 @@
             name: 'Books',
             data: items[0],
             allowMultipleCalls: true,
-            model: 'Product',
             meta: {
                 itemType: 'Products',
                 sourceName: 'Amazon',
@@ -27,6 +26,9 @@
                 options: {
                     buy: 'products_amazon_buy'
                 }
+            },
+            relevancy: {
+                dup: ['ASIN','img_m','img']
             },
             onItemShown: function(item) {
                 if (item.loadedRatings) { return; }

--- a/share/spice/sound_cloud/sound_cloud.js
+++ b/share/spice/sound_cloud/sound_cloud.js
@@ -36,7 +36,9 @@
                 }
             },
             view: 'Audio',
-            model: 'Audio',
+            relevancy: {
+                dup: 'url'
+            },
             normalize: function(o) {
 
                 var image = o.artwork_url || o.user.avatar_url;

--- a/share/spice/videos/videos.js
+++ b/share/spice/videos/videos.js
@@ -19,6 +19,11 @@ function ddg_spice_videos(apiResult) {
             searchTerm: apiResult.query
         },
 
+        templates: {
+            item: 'videos_item',
+            detail: 'videos_detail'
+        },
+
         relevancy: {
             dup: 'id'
         }


### PR DESCRIPTION
I'd like to move towards deprecating the need to specify a `model` from Spice.add(). This removes it for Audio/Product/Image and replaces it with `relevancy.dup` attribute, which is essentially the only thing those models are actually doing right now anyway.

The only models remaining are Places and Videos. I'd like to replace them with some kind of shared normalize() function or something since that's essentially all those models are doing. They take in data and transform it into standard objects for the templates. I think this logic needs to be open source so developers understand what's happening to the data between when it's passed into Spice.add() and when it shows up in the templates.

This PR also specifies the templates for Images/Videos spices instead of us magically adding them internally. Trying to get everything to follow the same pattern.

@moollaza @jagtalon @sdougbrown