### PR TITLE
Movies + InTheaters: Use an alternate image source.

### DIFF
--- a/lib/DDG/Spice/MovieImage.pm
+++ b/lib/DDG/Spice/MovieImage.pm
@@ -1,0 +1,20 @@
+package DDG::Spice::MovieImage;
+# ABSTRACT: Show movies from Rotten Tomatoes.
+
+use strict;
+use DDG::Spice;
+
+triggers any => '///***never_trigger***///';
+
+spice to => 'https://api.themoviedb.org/3/find/$1?api_key={{ENV{DDG_SPICE_MOVIEDB_APIKEY}}}&external_source=imdb_id';
+
+# Uses $loc so needs to not cache back end.
+spice is_cached => 0;
+
+spice proxy_cache_valid => "200 30d";
+
+handle query_lc => sub {
+    return $_ if $_;
+    return;
+};
+1;

--- a/share/spice/in_theaters/in_theaters.js
+++ b/share/spice/in_theaters/in_theaters.js
@@ -75,12 +75,12 @@
                 var image = toDetail(item.posters.detailed)
                 return {
                     rating: item.ratings.critics_score >= 0 ? item.ratings.critics_score / 20 : 0,
-                    image: image,
+                    //image: image,
                     icon_image: get_image(item.ratings.critics_rating),
                     abstract: Handlebars.helpers.ellipsis(item.synopsis, 200),
                     heading: item.title,
-                    img: image,
-                    img_m: image,
+                    //img: image,
+                    //img_m: image,
                     url: item.links.alternate,
                     is_retina: ((DDG.is3x || DDG.is2x) ? 'is_retina' : 'no_retina')
                 };
@@ -91,6 +91,23 @@
                     subtitle_content: Spice.in_theaters.subtitle_content,
                     rating: false,
                     buy: Spice.in_theaters.buy
+                }
+            },
+            onItemShown: function(item) {
+                $.ajaxSetup({ cache: true });
+                
+                if(item.alternate_ids && item.alternate_ids.imdb) {
+                    $.getJSON("/js/spice/movie_image/tt" + item.alternate_ids.imdb, function(data) {
+                        if(data && data.movie_results && data.movie_results.length > 0) {
+                            var image = "https://image.tmdb.org/t/p/w185" + data.movie_results[0].poster_path;
+                            item.$html.find(".tile__media__img").attr("src", "https://images.duckduckgo.com/iu/?f=1&u=" + encodeURIComponent(image));
+                            $.extend(item, {
+                                image: image,
+                                img: image,
+                                img_m: image
+                            });
+                        }
+                    });
                 }
             }
         });

--- a/share/spice/in_theaters/in_theaters.js
+++ b/share/spice/in_theaters/in_theaters.js
@@ -101,7 +101,7 @@
                 
                 if(item.alternate_ids && item.alternate_ids.imdb) {
                     $.getJSON("/js/spice/movie_image/tt" + item.alternate_ids.imdb, function(data) {
-                        if(data && data.movie_results && data.movie_results.length > 0) {
+                        if(data && data.movie_results && data.movie_results.length > 0 && data.movie_results[0].poster_path) {
                             var image = "https://image.tmdb.org/t/p/w185" + data.movie_results[0].poster_path;
                             item.$html.find(".tile__media__img").attr("src", "https://images.duckduckgo.com/iu/?f=1&u=" + encodeURIComponent(image));
                             $.extend(item, {

--- a/share/spice/in_theaters/in_theaters.js
+++ b/share/spice/in_theaters/in_theaters.js
@@ -73,17 +73,20 @@
                 
                 // Modify the image from _tmb.jpg to _det.jpg
                 var image = toDetail(item.posters.detailed)
-                return {
-                    rating: item.ratings.critics_score >= 0 ? item.ratings.critics_score / 20 : 0,
-                    //image: image,
-                    icon_image: get_image(item.ratings.critics_rating),
-                    abstract: Handlebars.helpers.ellipsis(item.synopsis, 200),
-                    heading: item.title,
-                    //img: image,
-                    //img_m: image,
-                    url: item.links.alternate,
-                    is_retina: ((DDG.is3x || DDG.is2x) ? 'is_retina' : 'no_retina')
-                };
+                
+                if(item.alternate_ids && item.alternate_ids.imdb) {
+                    return {
+                        rating: item.ratings.critics_score >= 0 ? item.ratings.critics_score / 20 : 0,
+                        //image: image,
+                        icon_image: get_image(item.ratings.critics_rating),
+                        abstract: Handlebars.helpers.ellipsis(item.synopsis, 200),
+                        heading: item.title,
+                        //img: image,
+                        //img_m: image,
+                        url: item.links.alternate,
+                        is_retina: ((DDG.is3x || DDG.is2x) ? 'is_retina' : 'no_retina')
+                    };
+                }
             },
             templates: {
                 group: 'movies',

--- a/share/spice/movie/movie.js
+++ b/share/spice/movie/movie.js
@@ -75,17 +75,20 @@
             normalize: function(item) {
                 // Modify the image from _tmb.jpg to _det.jpg
                 var image = toDetail(item.posters.detailed);
-                return {
-                    rating: Math.max(item.ratings.critics_score / 20, 0),
-                    image: image,
-                    icon_image: get_image(item.ratings.critics_rating),
-                    abstract: Handlebars.helpers.ellipsis(item.synopsis || item.critics_consensus, 200),
-                    heading: item.title,
-                    img: image,
-                    img_m: image,
-                    url: item.links.alternate,
-                    is_retina: (DDG.is3x || DDG.is2x) ? "is_retina" : "no_retina"
-                };
+                
+                if(item.alternate_ids && item.alternate_ids.imdb) {
+                    return {
+                        rating: Math.max(item.ratings.critics_score / 20, 0),
+                        //image: image,
+                        icon_image: get_image(item.ratings.critics_rating),
+                        abstract: Handlebars.helpers.ellipsis(item.synopsis || item.critics_consensus, 200),
+                        heading: item.title,
+                        //img: image,
+                        //img_m: image,
+                        url: item.links.alternate,
+                        is_retina: (DDG.is3x || DDG.is2x) ? "is_retina" : "no_retina"
+                    };
+                }
             },
             templates: {
                 group: 'movies',
@@ -103,6 +106,23 @@
                     match: /\.jpg$/,
                     strict: false
                 }]
+            },
+            onItemShown: function(item) {
+                $.ajaxSetup({ cache: true });
+                
+                if(item.alternate_ids && item.alternate_ids.imdb) {
+                    $.getJSON("/js/spice/movie_image/tt" + item.alternate_ids.imdb, function(data) {
+                        if(data && data.movie_results && data.movie_results.length > 0) {
+                            var image = "https://image.tmdb.org/t/p/w185" + data.movie_results[0].poster_path;
+                            item.$html.find(".tile__media__img").attr("src", "https://images.duckduckgo.com/iu/?f=1&u=" + encodeURIComponent(image));
+                            $.extend(item, {
+                                image: image,
+                                img: image,
+                                img_m: image
+                            });
+                        }
+                    });
+                }
             }
         });
     };

--- a/share/spice/movie/movie.js
+++ b/share/spice/movie/movie.js
@@ -112,7 +112,7 @@
                 
                 if(item.alternate_ids && item.alternate_ids.imdb) {
                     $.getJSON("/js/spice/movie_image/tt" + item.alternate_ids.imdb, function(data) {
-                        if(data && data.movie_results && data.movie_results.length > 0) {
+                        if(data && data.movie_results && data.movie_results.length > 0 && data.movie_results[0].poster_path) {
                             var image = "https://image.tmdb.org/t/p/w185" + data.movie_results[0].poster_path;
                             item.$html.find(".tile__media__img").attr("src", "https://images.duckduckgo.com/iu/?f=1&u=" + encodeURIComponent(image));
                             $.extend(item, {


### PR DESCRIPTION
Currently using TMDb just to get the images working in the mean time. It makes a call to the MovieImage.pm endpoint for every item in the list. Fixes #1647.