### PR TITLE
Modify maps workflow to resemble other IAs

### DIFF
--- a/share/spice/maps/maps/maps_maps.js
+++ b/share/spice/maps/maps/maps_maps.js
@@ -1,5 +1,23 @@
 DDG.require('maps',function(){
-    ddg_spice_maps_maps = function(place) {
-        DDG.duckbar.add_map(place);
+    ddg_spice_maps_maps = function(d) {
+        
+        if (!d || !d.length) { return Spice.failed('maps'); }
+
+        console.log("RAW MAP OBJECT %o", d);
+
+        d = [d[0]]; // OSM sends back a bunch of places, just want the first one for now
+                                
+        if (!DDG.isRelevant(d[0].display_name.toLowerCase())) { 
+            console.log("Maps failed relevancy", { log: "duckbar" });
+            return Spice.failed('maps'); 
+        } 
+        
+        Spice.add({
+            data: d,
+            id: "maps",
+            name: "maps",
+            model: "Place"
+        });
+
     };
 });

--- a/share/spice/maps/maps/maps_maps.js
+++ b/share/spice/maps/maps/maps_maps.js
@@ -1,19 +1,17 @@
 DDG.require('maps',function(){
-    ddg_spice_maps_maps = function(d) {
+    ddg_spice_maps_maps = function(response) {
         
-        if (!d || !d.length) { return Spice.failed('maps'); }
+        if (!response || !response.length) { return Spice.failed('maps'); }
 
-        console.log("RAW MAP OBJECT %o", d);
-
-        d = [d[0]]; // OSM sends back a bunch of places, just want the first one for now
+        // OSM sends back a bunch of places, just want the first one for now
+        response = [response[0]]; 
                                 
-        if (!DDG.isRelevant(d[0].display_name.toLowerCase())) { 
-            console.log("Maps failed relevancy", { log: "duckbar" });
+        if (!DDG.isRelevant(response[0].display_name.toLowerCase())) { 
             return Spice.failed('maps'); 
         } 
         
         Spice.add({
-            data: d,
+            data: response,
             id: "maps",
             name: "maps",
             model: "Place"


### PR DESCRIPTION
This pull request has a matching PR internally, and both need to be merged/released at the same time. The general idea is to make our maps calls act more like other IAs by directly calling `Spice.add()` from the callback, instead of relying on an internal function in the frontend code.

@b2ddg @nilnilnil 
