### PR TITLE
Disable airlines trigger

### DIFF
--- a/lib/DDG/Spice/Airlines.pm
+++ b/lib/DDG/Spice/Airlines.pm
@@ -21,7 +21,8 @@ spice to => 'https://api.flightstats.com/flex/flightstatus/rest/v2/jsonp/flight/
 spice from => '(.*)/(.*)/(.*)/(.*)/(.*)/(.*)';
 spice proxy_cache_valid => '418 1d';
 
-triggers query_lc => qr/^(\d+)\s+(.*?)(?:[ ]air.*?)?$|^(.*?)(?:[ ]air.*?)?\s+(\d+)$/;
+triggers query_lc => '///***never trigger***///';
+# triggers query_lc => qr/^(\d+)\s+(.*?)(?:[ ]air.*?)?$|^(.*?)(?:[ ]air.*?)?\s+(\d+)$/;
 
 # Get the list of airlines and strip out the words.
 my %airlines = ();

--- a/lib/DDG/Spice/Airlines.pm
+++ b/lib/DDG/Spice/Airlines.pm
@@ -21,7 +21,7 @@ spice to => 'https://api.flightstats.com/flex/flightstatus/rest/v2/jsonp/flight/
 spice from => '(.*)/(.*)/(.*)/(.*)/(.*)/(.*)';
 spice proxy_cache_valid => '418 1d';
 
-triggers query_lc => '///***never trigger***///';
+triggers any => '///***never trigger***///';
 # triggers query_lc => qr/^(\d+)\s+(.*?)(?:[ ]air.*?)?$|^(.*?)(?:[ ]air.*?)?\s+(\d+)$/;
 
 # Get the list of airlines and strip out the words.

--- a/t/Airlines.t
+++ b/t/Airlines.t
@@ -5,6 +5,9 @@ use warnings;
 use Test::More;
 use DDG::Test::Spice;
 
+use_ok('DDG::Spice::Airlines');
+
+if (0) {
 ddg_spice_test(
     [qw( DDG::Spice::Airlines )],
     'aa 102' => test_spice(
@@ -26,6 +29,7 @@ ddg_spice_test(
         caller    => 'DDG::Spice::Airlines',
     ),
 );
+}
 
 done_testing;
 


### PR DESCRIPTION
We are reaching our API limits and need to reign in this trigger. In the interim, let's disable the word-based trigger and rely on our internal trigger until we can find a more general solution.
