### PR TITLE
Currency: Fix #1844 - Check api_result.conversion as object

### DIFF
--- a/share/spice/currency/currency.js
+++ b/share/spice/currency/currency.js
@@ -51,9 +51,9 @@
 
         // Check if there are any errors in the response.
         if(!api_result || !api_result.conversion || !api_result.topConversions || 
-           !api_result.conversion.length || api_result.conversion.length === 0 || 
+           !api_result.conversion || Object.keys(api_result.conversion).length === 0 || 
            !api_result.topConversions.length || api_result.topConversions.length === 0) {
-            Spice.failed('currency');
+            return Spice.failed('currency');
         }
         
         var results = [];


### PR DESCRIPTION
`conversions` is an object not an array. 

Don't worry about < IE 9 support, duckduckgo has a polyfill for the `Object.keys` method :smile:  

// @jagtalon 