### PR TITLE
Call Spice.failed if response fails relevancy

### DIFF
--- a/share/spice/time/time.js
+++ b/share/spice/time/time.js
@@ -26,7 +26,7 @@
 
         // If there isn't a place, return immediately.
         if(!chosen) {
-            return;
+            return Spice.failed('time');
         }
 
         var dateObj = DDG.getDateFromString(chosen.time.iso),


### PR DESCRIPTION
While debugging issues with queries such as "time london" and "time in mauritania", I noticed that we don't always call Spice.failed() after making an API call and failing relevancy. I don't think that this is what is causing the problem with those queries, but just wanted to fix it for good measure...