### PR TITLE
Adding group: videos as per request

### DIFF
--- a/share/spice/twitch/featured/twitch_featured.js
+++ b/share/spice/twitch/featured/twitch_featured.js
@@ -17,10 +17,9 @@
                 itemType: "Featured Streams"
             },
             templates: {
-                group: 'base',
+                group: 'videos',
                 detail: false,
                 item_detail: false,
-                item: 'videos_item',
                 moreAt: true,
             },
             normalize: function(item) {

--- a/share/spice/twitch/streams/twitch_streams.js
+++ b/share/spice/twitch/streams/twitch_streams.js
@@ -24,10 +24,9 @@
                 itemType: "Twitch Streams"
             },
             templates: {
-                group: 'base',
+                group: 'videos',
                 detail: false,
                 item_detail: false,
-                item: 'videos_item',
                 moreAt: true,
             },
             normalize: function(item) {


### PR DESCRIPTION
Changing group template to use videos for Twitch Spice IA as per @moollaza's request in #1871.