### PR TITLE
Add check for closed market, add to frontend

### DIFF
--- a/share/spice/stocks/content.handlebars
+++ b/share/spice/stocks/content.handlebars
@@ -7,6 +7,10 @@
     <span class="stocks__symbol">{{Security.Symbol}}</span>
     <span>as of {{date}} {{time}}</span>
     <span title="Eastern Time Zone"> ET</span>
+    {{#if marketClosed}}
+        <span class="zcm__sep"></span>
+        <span>Markets are closed</span>
+    {{/if}}
 </div>
 <div class="stocks__quotes  stocks__quote-{{quoteChangeDir}}">
     <span class="stocks__quote text--primary">{{quote}}</span>

--- a/share/spice/stocks/stocks.js
+++ b/share/spice/stocks/stocks.js
@@ -21,6 +21,7 @@
                 normalize: function(data){
                     var change = data.ChangeFromPreviousClose,
                         changeDir;
+
                     moment().utcOffset(data.UTCOffset);
 
                     // remove +/- from change attributes and add up/down class:
@@ -40,7 +41,10 @@
                         change: change.toFixed(2),
                         change_percent: data.PercentChangeFromPreviousClose.toFixed(2),
                         date: moment(data.Date).format("MMM DD"),
-                        time: moment(data.Time, "hh:mm:ss A").format("h:mm A")
+                        time: moment(data.Time, "hh:mm:ss A").format("h:mm A"),
+                        // if last close date is today, or time is 4:00 PM then markets are closed
+                        // Note: API reports time is 4PM until 9AM following day
+                        marketClosed: (data.Date === data.PreviousCloseDate || data.Time === "4:00:00 PM")
                     };
                 },
                 templates: {

--- a/share/spice/stocks/stocks.js
+++ b/share/spice/stocks/stocks.js
@@ -20,6 +20,7 @@
                 },
                 normalize: function(data){
                     var change = data.ChangeFromPreviousClose,
+                        dateObj = new Date(data.Date), // use Date constructor to handle non-standard date format: mm/dd/yy
                         changeDir;
 
                     moment().utcOffset(data.UTCOffset);
@@ -40,7 +41,7 @@
                         quoteChangeDir: changeDir,
                         change: change.toFixed(2),
                         change_percent: data.PercentChangeFromPreviousClose.toFixed(2),
-                        date: moment(data.Date).format("MMM DD"),
+                        date: moment(dateObj).format("MMM DD"),
                         time: moment(data.Time, "hh:mm:ss A").format("h:mm A"),
                         // if last close date is today, or time is 4:00 PM then markets are closed
                         // Note: API reports time is 4PM until 9AM following day


### PR DESCRIPTION
Check if markets are closed, if so, add notice to display. Fixes #1854

New design: 

After 4PM

![stock_quote_for_aapl_at_duckduckgo](https://cloud.githubusercontent.com/assets/873785/7895489/209b10f6-065f-11e5-9ebc-10612cbbfb7a.png)

Following morning, before next opening:
![aapl_stock_at_duckduckgo](https://cloud.githubusercontent.com/assets/873785/7936970/09ed534c-090b-11e5-99f7-9b5611202664.png)


/cc @abeyang @jagtalon 