### PR TITLE
Add support for German queries to the "what's the current time in" instant answer

### DIFF
--- a/lib/DDG/Spice/Time.pm
+++ b/lib/DDG/Spice/Time.pm
@@ -1,5 +1,5 @@
 package DDG::Spice::Time;
-# ABSTRACT: Time zone converter
+# ABSTRACT: Shows the current time for cities, states and countries
 
 use strict;
 use DDG::Spice;
@@ -32,7 +32,7 @@ handle query_lc => sub {
           | (?:what'?s?|is|the|current|local|\s)*time(?:is|it|in|of|for|at|\s)*  # english
         )(?<loc>[^\?]*)[\?]*$
     }x;
-    #return unless $q =~ m/^(?:what'?s?|is|the|current|local|\s)*time(?:is|it|in|of|for|at|\s)*(?<loc>[^\?]*)[\?]*$/;
+    
     my $q_loc = trim $+{loc};
 
     # if no location is given, current user location is returned

--- a/lib/DDG/Spice/Time.pm
+++ b/lib/DDG/Spice/Time.pm
@@ -28,7 +28,7 @@ handle query_lc => sub {
 
     return unless $q =~ m{
         ^(?:
-            (?:was|ist|die|aktuelle|wieviel|welche|wie|\s)*(?:spät|uhrzeit|uhr|zeit)(?:hat|ist|es|in|auf|hier|gerade|\s)*  # german
+            (?:was|ist|die|aktuelle|wieviel|welche|wie|\s)*(?:spät|uhrzeit|uhr|zeit)(?:hat|ist|es|in|auf|hier|jetzt|gerade|aktuell|momentan|\s)*  # german
           | (?:what'?s?|is|the|current|local|\s)*time(?:is|it|in|of|for|at|\s)*  # english
         )(?<loc>[^\?]*)[\?]*$
     }x;

--- a/lib/DDG/Spice/Time.pm
+++ b/lib/DDG/Spice/Time.pm
@@ -19,15 +19,20 @@ attribution github  => ['https://github.com/MrChrisW', 'Chris Wilson'];
 spice proxy_cache_valid => "418 1d";
 spice to => 'http://api.xmltime.com/timeservice?accesskey={{ENV{DDG_SPICE_TIME_AND_DATE_ACCESSKEY}}}&secretkey={{ENV{DDG_SPICE_TIME_AND_DATE_SECRETKEY}}}&out=js&callback={{callback}}&query=$1&time=1&tz=1&verbosetime=1';
 
-triggers any => "time";
+triggers any => ["time", "uhr", "zeit", "uhrzeit", "spät"];
 
 my $capitals = LoadFile(share('capitals.yml'));
 
 handle query_lc => sub {
     my $q = shift;
 
-    return unless $q =~ m/^(?<rest>what'?s?|is|the|current|local|\s)*time(?:is|it|in|of|for|at|\s)*(?<loc>[^\?]*)[\?]*$/;
-    my $rest = trim $+{rest};
+    return unless $q =~ m{
+        ^(?:
+            (?:was|ist|die|aktuelle|wieviel|welche|wie|\s)*(?:spät|uhrzeit|uhr|zeit)(?:hat|ist|es|in|auf|hier|gerade|\s)*  # german
+          | (?:what'?s?|is|the|current|local|\s)*time(?:is|it|in|of|for|at|\s)*  # english
+        )(?<loc>[^\?]*)[\?]*$
+    }x;
+    #return unless $q =~ m/^(?:what'?s?|is|the|current|local|\s)*time(?:is|it|in|of|for|at|\s)*(?<loc>[^\?]*)[\?]*$/;
     my $q_loc = trim $+{loc};
 
     # if no location is given, current user location is returned

--- a/t/Time.t
+++ b/t/Time.t
@@ -64,6 +64,7 @@ ddg_spice_test(
     'was ist die aktuelle zeit in kingston??'  => test_spice(@kingston_town),
     'welche uhrzeit hat es in kingston'        => test_spice(@kingston_town),
     'wie spät ist es gerade in kingston'       => test_spice(@kingston_town),
+    'wieviel uhr ist es momentan in kingston'  => test_spice(@kingston_town),
     
     # Intentionally ignored
     'pdt time'                 => undef,

--- a/t/Time.t
+++ b/t/Time.t
@@ -54,6 +54,17 @@ ddg_spice_test(
     'time'                                     => test_spice(@phoenixville),
     'current time'                             => test_spice(@phoenixville),
     'current local time'                       => test_spice(@phoenixville),
+    
+    # German queries
+    'uhrzeit in kingston'                      => test_spice(@kingston_town),
+    'aktuelle uhrzeit in kingston'             => test_spice(@kingston_town),
+    'wieviel uhr ist es in kingston?'          => test_spice(@kingston_town),
+    'wieviel uhr in kingston'                  => test_spice(@kingston_town),
+    'aktuelle zeit in kingston'                => test_spice(@kingston_town),
+    'was ist die aktuelle zeit in kingston??'  => test_spice(@kingston_town),
+    'welche uhrzeit hat es in kingston'        => test_spice(@kingston_town),
+    'wie spät ist es gerade in kingston'       => test_spice(@kingston_town),
+    
     # Intentionally ignored
     'pdt time'                 => undef,
     'testing time'             => undef,


### PR DESCRIPTION
This is a change to the Time.pm "what's the current time" instant answer. It adds support for german queries.

**What are some example queries that trigger this Instant Answer?**

* was ist die aktuelle zeit in kingston
* wieviel uhr ist es jetzt in kingston
* wie spät ist es gerade?

## Checklist
[x] added test cases for the German queries
[x] only modified the backend .pm file, so no changes to the design
[x] Verified that instant answer adheres to code styleguide (https://duck.co/duckduckhack/code_styleguide)
