### PR TITLE
Set title to 4line, change fontsize to 17px

### DIFF
--- a/share/spice/wikinews/wikinews.js
+++ b/share/spice/wikinews/wikinews.js
@@ -35,7 +35,10 @@
                     detail: false,
                     item_detail: false,
                     variants: {
-                        tileTitle: "3line-small",
+                        tileTitle: "4line",
+                    },
+                    elClass: {
+                        tileTitle: 'tx--17'
                     }
                 }
             });

--- a/share/spice/wikinews/wikinews.js
+++ b/share/spice/wikinews/wikinews.js
@@ -13,7 +13,7 @@
                 data: api_result.query.categorymembers,
                 meta: {
                     total: api_result.query.categorymembers.length,
-                    sourceName: 'Wikinews articles',
+                    sourceName: 'Wikinews',
                     sourceUrl: "https://en.wikinews.org/wiki/Main_Page",
                     itemType: "Latest Wikinews articles"
                 },


### PR DESCRIPTION
Updated text size to 17em, changed title length to 4 lines, and updated the source name to "Wikinews"

![1____projects__ssh__and_wikinews_at_duckduckgo](https://cloud.githubusercontent.com/assets/873785/8041757/87f47b8a-0de8-11e5-9f9c-0a987ea053c5.png)

/cc @iambibhas @abeyang 