### PR TITLE
Update to newest Spice API, ensure Spice.failed() call

### DIFF
--- a/share/spice/editor/editor.js
+++ b/share/spice/editor/editor.js
@@ -1,4 +1,9 @@
-function ddg_spice_editor() {
+(function(env){
+    "use strict";
+
+    if (is_mobile) {
+        return Spice.failed('editor');
+    }
 
     // Get the language from the query.
     var language = DDG.get_query().match(/javascript|python/i)[0].toLowerCase();
@@ -8,73 +13,76 @@ function ddg_spice_editor() {
             "javascript": "JavaScript",
             "python": "Python"
         };
-        
+
         return languageNames[language.toLowerCase()];
     }
-       
-    Spice.add({
-        id: 'editor',
-        name: 'Editor',
-        data: {
-            title: formatLanguageName(language) + " Editor"
-        },
-        meta: {
-            sourceName: "Ace",
-            sourceUrl: "http://ace.c9.io/"
-        },
-        templates: {
-            // group: 'base',
-            detail: Spice.editor.editor,
-            options: {
-                // content: Spice.editor.editor
-            }
-        },
-        // The `ace` object looks for an element that has ID of `ace-editor`.
-        // The `onShow` function triggers when the element is already on the page.
-        onShow: function() {
-            var editor_id = "ace-editor";
-            var editor = ace.edit(editor_id);
 
-            // Remove margin.
-            editor.setShowPrintMargin(false);
+    env.ddg_spice_editor = function() {
 
-            // Tell Ace where the themes and modes are.
-            ace.config.set("basePath", "/js/ace/");
+        DDG.require("/js/ace/ace.js", function() {
+            console.log("AJAX Fired!");
+            Spice.add({
+                id: 'editor',
+                name: 'Editor',
+                data: {
+                    title: formatLanguageName(language) + " Editor"
+                },
+                meta: {
+                    sourceName: "Ace",
+                    sourceUrl: "http://ace.c9.io/"
+                },
+                templates: {
+                    // group: 'base',
+                    detail: Spice.editor.editor,
+                    options: {
+                        // content: Spice.editor.editor
+                    }
+                },
+                // The `ace` object looks for an element that has ID of `ace-editor`.
+                // The `onShow` function triggers when the element is already on the page.
+                onShow: function() {
 
-            // Set theme based on DDG theme
-            if ($(".dark-header").length) {
-                editor.setTheme("ace/theme/monokai");
-            } else {
-                editor.setTheme("ace/theme/eclipse");
-            }
+                    console.log("OnShow Fired!");
 
-            // Listen for clicks on the default theme button and change editor theme accordingly
-            $(".nav-menu__theme--default").click(function(e) {
-                editor.setTheme("ace/theme/eclipse");
-                e.stopPropagation();
+                    var editor_id = "ace-editor";
+                    var editor = ace.edit(editor_id);
+
+                    // Remove margin.
+                    editor.setShowPrintMargin(false);
+
+                    // Tell Ace where the themes and modes are.
+                    ace.config.set("basePath", "/js/ace/");
+
+                    // Set theme based on DDG theme
+                    if ($(".dark-header").length) {
+                        editor.setTheme("ace/theme/monokai");
+                    } else {
+                        editor.setTheme("ace/theme/eclipse");
+                    }
+
+                    // Listen for clicks on the default theme button and change editor theme accordingly
+                    $(".nav-menu__theme--default").click(function(e) {
+                        editor.setTheme("ace/theme/eclipse");
+                        e.stopPropagation();
+                    });
+
+                    // Listen for clicks on the dark theme button and change editor theme accordingly
+                    $(".nav-menu__theme--d").click(function(e) {
+                        editor.setTheme("ace/theme/monokai");
+                        e.stopPropagation();
+                    });
+
+                    editor.getSession().setMode("ace/mode/" + language);
+
+                    // Stop DDG keybindings, when editor has focus
+                    $("#" + editor_id).keydown(function(e) {
+                        e.stopPropagation();
+                    });
+                }
             });
+        });
+    };
 
-            // Listen for clicks on the dark theme button and change editor theme accordingly
-            $(".nav-menu__theme--d").click(function(e) {
-                editor.setTheme("ace/theme/monokai");
-                e.stopPropagation();
-            });
-
-            editor.getSession().setMode("ace/mode/" + language);
-
-            // Stop DDG keybindings, when editor has focus
-            $("#" + editor_id).keydown(function(e) {
-                e.stopPropagation();
-            });
-        }
-    });
-};
-
-// Load ace.js
-// Ace is a bit buggy on mobile at the moment, so we don't want to display it there.
-if(!is_mobile) {
-    // Make sure to call ddg_spice_editor when ace.js loads.
-    $.getScript("/js/ace/ace.js", function() {
-        ddg_spice_editor(); 
-    });
-}
+    // manually fire the callback
+    ddg_spice_editor();
+}(this));

--- a/share/spice/editor/editor.js
+++ b/share/spice/editor/editor.js
@@ -20,7 +20,6 @@
     env.ddg_spice_editor = function() {
 
         DDG.require("/js/ace/ace.js", function() {
-            console.log("AJAX Fired!");
             Spice.add({
                 id: 'editor',
                 name: 'Editor',
@@ -41,8 +40,6 @@
                 // The `ace` object looks for an element that has ID of `ace-editor`.
                 // The `onShow` function triggers when the element is already on the page.
                 onShow: function() {
-
-                    console.log("OnShow Fired!");
 
                     var editor_id = "ace-editor";
                     var editor = ace.edit(editor_id);


### PR DESCRIPTION
Wrap everything in a closure (as we do for all Spice IA's) and ensure we call `Spice.failed()` for mobile devices because it shouldn't show.

/cc @nilnilnil @jagtalon 