### PR TITLE
Add new Instant Answer: Coderwall

### DIFF
--- a/lib/DDG/Spice/Coderwall.pm
+++ b/lib/DDG/Spice/Coderwall.pm
@@ -1,0 +1,26 @@
+package DDG::Spice::Coderwall;
+# ABSTRACT: Shows coderwall user information
+
+use DDG::Spice;
+
+name "Coderwall";
+source "Coderwall";
+icon_url "/i/coderwall.com.ico";
+description "Display information on coderwall user";
+primary_example_queries "coderwall jagtalon";
+secondary_example_queries "motersen coderwall";
+category "ids";
+topics "programming", "social";
+code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/Coderwall.pm";
+attribution github => ["motersen", "Moritz Petersen"];
+
+triggers startend => "coderwall";
+
+spice to => 'https://coderwall.com/$1.json?full=true&callback={{callback}}';
+
+handle remainder => sub {
+    return $_ if $_;
+    return;
+};
+
+1;

--- a/share/spice/coderwall/coderwall.js
+++ b/share/spice/coderwall/coderwall.js
@@ -1,0 +1,62 @@
+(function (env) {
+    "use strict";
+    env.ddg_spice_coderwall = function(api_result){
+
+        // Check if API provided information
+        if ($.isEmptyObject(api_result.data)) {
+            return Spice.failed('coderwall');
+        }
+
+        Spice.add({
+            id: "coderwall",
+            name: "Social",
+            data: api_result.data,
+            meta: {
+                sourceName: "Coderwall",
+                sourceUrl: 'https://coderwall.com/' + api_result.data.username
+            },
+
+            normalize: function(item) {
+                // Profile URL templates: {{}} is replaced with username
+                var account_url = {
+                    github: 'https://github.com/{{}}',
+                    twitter: 'https://twitter.com/{{}}'
+                };
+                // Username display formats
+                var account_name = {
+                    twitter: '@{{}}'
+                };
+                var subtitles = [];
+                $.each(item.accounts, function(service, name) {
+                    // Check that we have a profile url template and
+                    // coderwall actually provided a name instead null
+                    if (account_url[service] && name) {
+                        subtitles.push({
+                            href: account_url[service].replace('{{}}', name),
+                            text: account_name[service]
+                                ? account_name[service].replace('{{}}', name)
+                                : name
+                        });
+                    }
+                });
+                subtitles.push(item.location);
+                return {
+                    // some thumbnail URIs are relative to coderwall.com
+                    image: /^\//.test(item.thumbnail)
+                        ? 'https://coderwall.com/' + item.thumbnail
+                        : item.thumbnail,
+                    title: item.name,
+                    subtitle: subtitles,
+                    description: item.about
+                };
+            },
+
+            templates: {
+                group: 'icon',
+                variants: {
+                    iconImage: 'large'
+                }
+            }
+        });
+    };
+}(this));

--- a/t/Coderwall.t
+++ b/t/Coderwall.t
@@ -1,0 +1,24 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+ddg_spice_test(
+    ['DDG::Spice::Coderwall'],
+    'coderwall jagtalon' => test_spice(
+        '/js/spice/coderwall/jagtalon',
+        call_type => 'include',
+        caller => 'DDG::Spice::Coderwall'
+    ),
+    'motersen coderwall' => test_spice(
+        '/js/spice/coderwall/motersen',
+        call_type => 'include',
+        caller => 'DDG::Spice::Coderwall'
+    ),
+    'jagtalon coderwall motersen' => undef
+);
+
+done_testing;
+


### PR DESCRIPTION
Adds an IA that displays coderwall user profiles
See #1360

------

**What does your Instant Answer do?**
Display information about a coderwall.com user

**What problem does your Instant Answer solve (Why is it better than organic links)?**
It helps to ensure a specific user is found (by displaying location) and provides a direct link to the user's profile

**What is the data source for your Instant Answer? (Provide a link if possible)**
[Coderwall API](https://coderwall.com/api)

**Why did you choose this data source?**
It is the only one that i know of.

**Are there any other alternative (better) data sources?**
No

**What are some example queries that trigger this Instant Answer?**
`coderwall jagtalon`, `motersen coderwall`

**Which communities will this Instant Answer be especially useful for? (gamers, book lovers, etc)**
programmers

**Is this Instant Answer connected to a DuckDuckHack [Instant Answer idea](https://duck.co/ideas)?**
[Yes](https://duck.co/ideas/idea/760/coderwall-instant-answer)

**Which existing Instant Answers will this one supersede/overlap with?**
None that i know of.

**Are you having any problems? Do you need our help with anything?**
I initially wanted to limit the display to three badges by setting `to` in `{{#each}}` to a variable determined in `normalize`. But I could not get it working.

**What are the terms of use for the API? Will DuckDuckGo need specific authorization (e.g. an API key)? Are there any costs associated with API usage?**
No API key needed, no terms of use known. Therefore: no costs.

**Where did you hear about DuckDuckHack? (For first time contributors)**
DuckDuckGo

**What does the Instant Answer look like? (Provide a screenshot for new or updated Instant Answers)**
![jpcamara_desc_nog](https://cloud.githubusercontent.com/assets/6299210/8118898/03f920e0-1092-11e5-8e75-747885962c53.jpg)

## Checklist
Please place an 'X' where appropriate.

```
[X] Added metadata and attribution information
[X] Wrote test file and added to t/ directory
[] Verified that instant answer adheres to design guidelines (https://duck.co/duckduckhack/design_styleguide)
[X] Verified that instant answer adheres to code styleguide (https://duck.co/duckduckhack/code_styleguide)
[] Tested cross-browser compatibility
```
------

https://duck.co/ia/view/coderwall