### PR TITLE
npm - checking dependency length before showing, added trigger "npm install"

### DIFF
--- a/lib/DDG/Spice/Npm.pm
+++ b/lib/DDG/Spice/Npm.pm
@@ -15,6 +15,7 @@ attribution github  => ['https://github.com/remixz', 'zachbruggeman'],
             twitter => ['https://twitter.com/zachbruggeman', 'zachbruggeman'];
 
 triggers startend => 'npm';
+triggers start => 'npm install';
 
 spice to => 'http://registry.npmjs.org/$1/latest';
 spice wrap_jsonp_callback => 1;

--- a/share/spice/npm/npm.js
+++ b/share/spice/npm/npm.js
@@ -61,15 +61,17 @@
                     });
                 }
 
-                var dependencies = $.map(item.dependencies, function(val, key) {
-                    return key + " (" + val + ")";
-                }).join(", ");
-
-                if (dependencies !== "") {
-                    boxData.push({
-                        label: "Dependencies",
-                        value: dependencies
+                if (item.dependencies) {
+                    var dependencies = $.map(item.dependencies, function(val, key) {
+                        return key + " (" + val + ")";
                     });
+
+                    if (dependencies.length + 0) {
+                        boxData.push({
+                            label: "Dependencies",
+                            value: dependencies.join(", ")
+                        });
+                    }
                 }
 
                 return {

--- a/share/spice/npm/npm.js
+++ b/share/spice/npm/npm.js
@@ -61,11 +61,11 @@
                     });
                 }
 
-                if (Object.keys(item.dependencies).length > 0) {
-                    var dependencies = $.map(item.dependencies, function(val, key) {
-                        return key + " (" + val + ")";
-                    }).join(", ");
+                var dependencies = $.map(item.dependencies, function(val, key) {
+                    return key + " (" + val + ")";
+                }).join(", ");
 
+                if (dependencies !== "") {
                     boxData.push({
                         label: "Dependencies",
                         value: dependencies

--- a/share/spice/npm/npm.js
+++ b/share/spice/npm/npm.js
@@ -16,7 +16,7 @@
             },
             normalize: function(item) {
                 var boxData = [{heading: 'Package Information:'}];
-                
+
                 if (item.author) {
                     boxData.push({
                         label: "Author",
@@ -27,10 +27,11 @@
                 if (item.homepage) {
                     boxData.push({
                         label: "Project Homepage",
-                        value: item.homepage
+                        value: item.homepage,
+                        url: item.homepage
                     });
                 }
-                
+
                 if (item.license) {
                     boxData.push({
                         label: "License",
@@ -44,22 +45,23 @@
                         value: item.repository.url
                     });
                 }
-                
+
                 if (item.engines) {
                     boxData.push({
                         label: "Engines",
                         value: item.engines.node
                     });
                 }
-                
+
                 if (item.dist) {
                     boxData.push({
                         label: "Source",
-                        value: item.dist.tarball
+                        value: item.dist.tarball,
+                        url: item.dist.tarball
                     });
                 }
 
-                if (item.dependencies) {      
+                if (Object.keys(item.dependencies).length > 0) {
                     var dependencies = $.map(item.dependencies, function(val, key) {
                         return key + " (" + val + ")";
                     }).join(", ");
@@ -69,12 +71,12 @@
                         value: dependencies
                     });
                 }
- 
+
                 return {
                     title: item.name + " " + item.version,
                     subtitle: item.description,
                     infoboxData: boxData,
-                }  
+                }
             },
 
             templates: {

--- a/share/spice/npm/npm.js
+++ b/share/spice/npm/npm.js
@@ -66,7 +66,7 @@
                         return key + " (" + val + ")";
                     });
 
-                    if (dependencies.length + 0) {
+                    if (dependencies.length > 0) {
                         boxData.push({
                             label: "Dependencies",
                             value: dependencies.join(", ")


### PR DESCRIPTION
Fixes #1881.

 - Checking if there is any dependency before showing it in infobox.
 - I sometimes end up searching for `npm install foo`, thought it might be helpful to support it as trigger.
 - Added project homepage and repo url as `url` in infobox

![selection_045](https://cloud.githubusercontent.com/assets/357253/8145292/d3203816-121f-11e5-9f68-c0217793447f.jpg)
