### PR TITLE
Update Forecast variableTileWidth => itemsWidthVaries

### DIFF
--- a/share/spice/forecast/forecast.js
+++ b/share/spice/forecast/forecast.js
@@ -262,7 +262,8 @@ function ddg_spice_forecast(r) {
             sourceName: 'Forecast.io',
             primaryText: weatherData.header,
             secondaryText: altMeta,
-            variableTileWidth: true
+
+            itemsWidthVaries: true
         },
 
         templates: {


### PR DESCRIPTION
I've been trying to namespace all the item-specific meta options with `items` at the beginning. This depends on an internal change.

@sdougbrown 