### PR TITLE
simplify CSS, set tile-width to prevent 0 width tile display

### DIFF
--- a/share/spice/playing_cards/playing_cards.css
+++ b/share/spice/playing_cards/playing_cards.css
@@ -1,5 +1,5 @@
 .zci--playing_cards .tile--playing_cards {
-    width: auto;
+    width: 9em;
     background-color: transparent;
     outline-color: transparent;
     border: transparent;
@@ -7,17 +7,4 @@
 
 .zci--playing_cards .tile {
     outline: none;
-}
-
-.tile--playing_cards .tile__media {
-    height: 12em;
-}
-
-.tile--playing_cards .tile__media__img {
-    height: 12em;
-}
-
-.tile--playing_cards .tile__body {
-    padding: 0;
-    height: 0;
 }

--- a/share/spice/playing_cards/playing_cards.js
+++ b/share/spice/playing_cards/playing_cards.js
@@ -4,7 +4,7 @@
         if(api_result.error || !api_result.cards) {
             return Spice.failed('playing_cards');
         }
-        
+
         Spice.add({
             id: "playing_cards",
             name: "Deck of Cards",
@@ -21,7 +21,7 @@
                 };
             },
             templates: {
-                group: 'media',
+                group: 'movies',
                 detail: false,
                 item_detail: false
             }


### PR DESCRIPTION
- Switched to Movie template (automates hiding the tile body)
- Set width on tile (prevents calculating tile width at 0px when image hasn't loaded)

/cc @kbhat95 