### PR TITLE
Remove horizontal separator b/w time and date

### DIFF
--- a/share/spice/time/content.handlebars
+++ b/share/spice/time/content.handlebars
@@ -1,6 +1,6 @@
 <div class="location">Time in <b>{{placeName}}, {{country}}</b></div>
 <div class="time tx-clr--slate">{{time.hours}}:{{time.minutes}} {{time.amPM}}</div>
 <div class="time__date tx-clr--grey-dark">
-    <div>{{dayName}}</div>
-    <div>{{monthName}} {{day}}, {{year}}</div>
+    <div class="tx--19">{{dayName}}</div>
+    <div class="tx--19">{{monthName}} {{day}}, {{year}}</div>
 </div>

--- a/share/spice/time/content.handlebars
+++ b/share/spice/time/content.handlebars
@@ -1,6 +1,6 @@
-<p class="text-secondary">Time in <b>{{placeName}}, {{country}}</b></p>
-<div class="time">{{time.hours}}:{{time.minutes}} {{time.amPM}}</div>
-<div class="time_date">
-    <div id="time_date_weekday">{{dayName}}</div>
-    <div id="time_date_full">{{monthName}} {{day}}, {{year}}</div>
+<div class="location">Time in <b>{{placeName}}, {{country}}</b></div>
+<div class="time tx-clr--slate">{{time.hours}}:{{time.minutes}} {{time.amPM}}</div>
+<div class="time__date tx-clr--grey-dark">
+    <div>{{dayName}}</div>
+    <div>{{monthName}} {{day}}, {{year}}</div>
 </div>

--- a/share/spice/time/time.css
+++ b/share/spice/time/time.css
@@ -11,6 +11,14 @@
     font-weight: 300;
 }
 
+.zci--time .c-base__links {
+    margin-top: 0.25em;
+}
+
+.is-mobile .zci--time .c-base__links {
+    margin-top: 0.75em;
+}
+
 @media (max-width: 244px) {
     .zci--time .time {
         font-size: 2.75em;

--- a/share/spice/time/time.css
+++ b/share/spice/time/time.css
@@ -1,7 +1,8 @@
 .zci--time .time {
     display: inline-block;
     font-size: 3.75em;
-    padding-right: 0.4em;
+    line-height: 1;
+    padding:.2em 0.4em 0.2em 0;
     font-weight: 300;
 }
 
@@ -15,8 +16,10 @@
     margin-top: 0.25em;
 }
 
-.is-mobile .zci--time .c-base__links {
-    margin-top: 0.75em;
+@media (max-width: 345px) {
+    .is-mobile .zci--time .c-base__links {
+        margin-top: 0.75em;
+    }
 }
 
 @media (max-width: 244px) {

--- a/share/spice/time/time.css
+++ b/share/spice/time/time.css
@@ -1,53 +1,20 @@
-.zci--time p {
-    margin-top: 0;
-    padding-top: 0;
-}
-
 .zci--time .time {
-    font-size: 54px;
-    color: #333;
+    display: inline-block;
+    font-size: 3.75em;
     padding-right: 10px;
-    float: left;
-    padding-right: 0.5em;
+    padding-right: 0.4em;
     font-weight: 300;
 }
 
-.zci--time .time_date {
-    margin-top: 8px;
-    color: #888;
-    border-left: solid 1px #d0d0d0;
-    float: left;
+.zci--time .time__date {
+    display: inline-block;
+    line-height: 1.25;
     font-weight: 300;
     font-size: 1.25em;
-    margin-top: 0.85em;
-    padding-left: 1.4em;
-    height: 2.2em;
-    line-height: 1.25;
-}
-
-.dark-header .zci--time .time {
-    color: #e6e6e6;
-}
-
-@media (max-width: 406px) {
-    .zci--time .time_date {
-        border-left: none;
-        padding-left: 0;
-        margin-top: 0;
-        margin-bottom: 1em;
-    }
-    .zci--time .time {
-        float: none;
-    }
-}
-
-.is-mobile .zci--time .time_date {
-    border-left: none;
-    padding-left: 0;
 }
 
 @media (max-width: 244px) {
     .zci--time .time {
-       font-size: 50px;
+        font-size: 2.75em;
     }
 }

--- a/share/spice/time/time.css
+++ b/share/spice/time/time.css
@@ -1,7 +1,6 @@
 .zci--time .time {
     display: inline-block;
     font-size: 3.75em;
-    padding-right: 10px;
     padding-right: 0.4em;
     font-weight: 300;
 }
@@ -10,7 +9,6 @@
     display: inline-block;
     line-height: 1.25;
     font-weight: 300;
-    font-size: 1.25em;
 }
 
 @media (max-width: 244px) {

--- a/share/spice/time/time.js
+++ b/share/spice/time/time.js
@@ -36,12 +36,12 @@
         //Convert 24 hour time to 12 hour time
         function toPrettyTime(date) {
             var hours = date.getHours(),
-                minutes = date.getMinutes()
+                minutes = date.getMinutes();
             return {
                 hours: (hours % 12) || 12,
                 minutes: minutes < 10 ? '0' + minutes : minutes,
                 amPM: hours >= 12 ? "PM" : "AM"
-            }
+            };
         }
 
         var dateTime = {
@@ -54,7 +54,7 @@
             offset: chosen.time.timezone.offset.replace(/0|:/g, ""),
             zone: chosen.time.timezone.zonename,
             country: chosen.geo.country.name
-        }
+        };
 
         Spice.add({
             id: "time",


### PR DESCRIPTION
In response to a tweet, we realized the floated text was causing problems.

This simplifies and cleans up the CSS. Opting for `inline-block` elements over floats.

/cc @chrismorast 