### PR TITLE
ensure codeshares property exists before iterating

### DIFF
--- a/share/spice/airlines/airlines.js
+++ b/share/spice/airlines/airlines.js
@@ -102,7 +102,7 @@
 
             // If this is a code-shared flight, we may not have the right
             // airline name/code information...try to find a better match
-            if (airlineCode !== queryCarrier) {
+            if (airlineCode !== queryCarrier && flight[i].codeshares) {
 
                 for (var j = 0; j < flight[i].codeshares.length; j++) {
 


### PR DESCRIPTION
Fixes the missing result on "[SY 394](https://duckduckgo.com/?q=SY+394)". Also for "[Sun Country Flight 394](https://duckduckgo.com/?q=Sun+country+flight+394)"

- https://moollaza.duckduckgo.com/?q=SY+394&ia=airlines
- https://moollaza.duckduckgo.com/?q=Sun+country+flight+394&ia=airlines

/cc @tommytommytommy 