### PR TITLE
Stocks: Use template.options.moreText property for attribution 

### DIFF
--- a/share/spice/stocks/content.handlebars
+++ b/share/spice/stocks/content.handlebars
@@ -18,11 +18,3 @@
     <span class="stocks__change-sep  detail__sep"></span>
     <span class="stocks__change-pct">{{change_percent}}%</span>
 </div>
-
-<div class="c-base__links">
-    {{{moreAt meta.sourceUrl meta.sourceName}}}
-    <span class="zcm__sep"></span>
-    <span class="zci__def__attribution  tx-clr--grey-dark  t-s">
-        Data by <a href="https://xignite.com" class="tx-clr--grey-dark">{{meta.attributionText}}</a>
-    </span>
-</div>

--- a/share/spice/stocks/stocks.js
+++ b/share/spice/stocks/stocks.js
@@ -16,7 +16,12 @@
                 meta: {
                     sourceName: 'NASDAQ',
                     sourceUrl: url,
-                    attributionText: "Xignite"
+                    options: {
+                        moreText: { 
+                            href: 'https://xignite.com', 
+                            text: 'Xignite' 
+                        }
+                    }
                 },
                 normalize: function(data){
                     var change = data.ChangeFromPreviousClose,
@@ -52,7 +57,7 @@
                     group: 'base',
                     options: {
                         content: Spice.stocks.content,
-                        moreAt: false
+                        moreAt: true,
                     }
                 }
             });

--- a/share/spice/stocks/stocks.js
+++ b/share/spice/stocks/stocks.js
@@ -15,13 +15,7 @@
                 data: api_result,
                 meta: {
                     sourceName: 'NASDAQ',
-                    sourceUrl: url,
-                    options: {
-                        moreText: { 
-                            href: 'https://xignite.com', 
-                            text: 'Data by Xignite' 
-                        }
-                    }
+                    sourceUrl: url
                 },
                 normalize: function(data){
                     var change = data.ChangeFromPreviousClose,
@@ -58,6 +52,10 @@
                     options: {
                         content: Spice.stocks.content,
                         moreAt: true,
+                        moreText: { 
+                            href: 'https://xignite.com', 
+                            text: 'Data by Xignite' 
+                        }
                     }
                 }
             });

--- a/share/spice/stocks/stocks.js
+++ b/share/spice/stocks/stocks.js
@@ -19,7 +19,7 @@
                     options: {
                         moreText: { 
                             href: 'https://xignite.com', 
-                            text: 'Xignite' 
+                            text: 'Data by Xignite' 
                         }
                     }
                 },


### PR DESCRIPTION
Fixing: #1946 

@moollaza Can you clarify if the moreText hyperlink key is `url` or `href` ? also this doesn't seem to work yet. 

Currently the spices uses `Data by Xignite`, are we able to add "Data by" or is it not needed?

````perl
meta: {
    sourceName: 'NASDAQ',
    sourceUrl: url,
    options: {
        moreText: {
            href: 'https://xignite.com',
            text: 'Xignite'
        }
    }
}
```
![selection_447](https://cloud.githubusercontent.com/assets/5282264/8305677/1b73069a-19e4-11e5-8ec0-b0a5223e033a.png)
