### PR TITLE
SublimePackages: Remove common words, add filtering options

### DIFF
--- a/lib/DDG/Spice/SublimePackages.pm
+++ b/lib/DDG/Spice/SublimePackages.pm
@@ -24,12 +24,12 @@ my $skip = join "|", share('skipwords.txt')->slurp(chomp => 1);
 handle remainder => sub {
     return unless $_; 
     # OS search filters
-    s/linux/:linux/g; 
-    s/windows/:win/g;
-    s/mac\s?os\s?x|os\s?x/:osx/g;
+    s/\blinux\b/:linux/g; 
+    s/\bwindows\b|\bwin\b/:win/g;
+    s/\bmac\s?os\s?x\b|\bos\s?x\b/:osx/g;
     # Version search filters
-    s/version 2/:st2/g;
-    s/version 3/:st3/g;
+    s/v?(ersion )?2/:st2/g;
+    s/v?(ersion )?3/:st3/g;
     # Do not trigger IA if query matches any words in skipwords.txt file
     return if  m/$skip/i;
     s/\b(for)\s+?\b//g; #skip common words

--- a/lib/DDG/Spice/SublimePackages.pm
+++ b/lib/DDG/Spice/SublimePackages.pm
@@ -14,7 +14,6 @@ topics "programming", "computing";
 code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/SublimePackages.pm";
 attribution github => ["MrChrisW", "Chris Wilson"],
             web => ["http://chrisjwilson.com", "Chris Wilson"];
-
 spice to => 'https://packagecontrol.io/search/$1.json';
 spice wrap_jsonp_callback => 1;
 
@@ -24,6 +23,13 @@ my $skip = join "|", share('skipwords.txt')->slurp(chomp => 1);
 
 handle remainder => sub {
     return unless $_; 
+    # OS search filters
+    s/linux/:linux/g; 
+    s/windows/:win/g;
+    s/mac\s?os\s?x|os\s?x/:osx/g;
+    # Version search filters
+    s/version 2/:st2/g;
+    s/version 3/:st3/g;
     # Do not trigger IA if query matches any words in skipwords.txt file
     return if  m/$skip/i;
     s/\b(for)\s+?\b//g; #skip common words

--- a/lib/DDG/Spice/SublimePackages.pm
+++ b/lib/DDG/Spice/SublimePackages.pm
@@ -25,7 +25,8 @@ my $skip = join "|", share('skipwords.txt')->slurp(chomp => 1);
 handle remainder => sub {
     return unless $_; 
     # Do not trigger IA if query matches any words in skipwords.txt file
-    return if  m/$skip/i;  
+    return if  m/$skip/i;
+     s/\b(for)\s+?\b//g; #skip common words
     return $_;
 };
 

--- a/lib/DDG/Spice/SublimePackages.pm
+++ b/lib/DDG/Spice/SublimePackages.pm
@@ -26,7 +26,7 @@ handle remainder => sub {
     return unless $_; 
     # Do not trigger IA if query matches any words in skipwords.txt file
     return if  m/$skip/i;
-     s/\b(for)\s+?\b//g; #skip common words
+    s/\b(for)\s+?\b//g; #skip common words
     return $_;
 };
 

--- a/t/SublimePackages.t
+++ b/t/SublimePackages.t
@@ -12,8 +12,15 @@ ddg_spice_test(
         call_type => 'include',
         caller => 'DDG::Spice::SublimePackages'
     ),
+    
     'sublime text package php' => test_spice(
         '/js/spice/sublime_packages/php',
+        call_type => 'include',
+        caller => 'DDG::Spice::SublimePackages'
+    ),
+    
+    'sublime text package for json' => test_spice(
+        '/js/spice/sublime_packages/json',
         call_type => 'include',
         caller => 'DDG::Spice::SublimePackages'
     ),

--- a/t/SublimePackages.t
+++ b/t/SublimePackages.t
@@ -7,13 +7,15 @@ use DDG::Test::Spice;
 
 ddg_spice_test(
     [qw( DDG::Spice::SublimePackages )],
+    
+    # Basic tests
     'sublimetext package code' => test_spice(
         '/js/spice/sublime_packages/code',
         call_type => 'include',
         caller => 'DDG::Spice::SublimePackages'
     ),
     
-    'sublime text package php' => test_spice(
+    'sublime text php' => test_spice(
         '/js/spice/sublime_packages/php',
         call_type => 'include',
         caller => 'DDG::Spice::SublimePackages'
@@ -25,6 +27,8 @@ ddg_spice_test(
         caller => 'DDG::Spice::SublimePackages'
     ),
     
+    
+    # Operating system filtering tests
     'sublimetext package html linux' => test_spice(
         '/js/spice/sublime_packages/html%20%3Alinux',
         call_type => 'include',
@@ -37,6 +41,20 @@ ddg_spice_test(
         caller => 'DDG::Spice::SublimePackages'
     ),
     
+    'sublimetext package auto osx' => test_spice(
+        '/js/spice/sublime_packages/auto%20%3Aosx',
+        call_type => 'include',
+        caller => 'DDG::Spice::SublimePackages'
+    ),
+    
+    'sublime text package javascript win' => test_spice(
+        '/js/spice/sublime_packages/javascript%20%3Awin',
+        call_type => 'include',
+        caller => 'DDG::Spice::SublimePackages'
+    ),
+    
+    
+    # Version filtering tests
     'sublimetext package text version 2' => test_spice(
         '/js/spice/sublime_packages/text%20%3Ast2',
         call_type => 'include',
@@ -45,6 +63,18 @@ ddg_spice_test(
     
     'sublimetext package text version 3' => test_spice(
         '/js/spice/sublime_packages/text%20%3Ast3',
+        call_type => 'include',
+        caller => 'DDG::Spice::SublimePackages'
+    ),
+    
+    'sublime text 2 yml' => test_spice(
+        '/js/spice/sublime_packages/%3Ast2%20yml',
+        call_type => 'include',
+        caller => 'DDG::Spice::SublimePackages'
+    ),
+    
+    'sublime text v3 yml' => test_spice(
+        '/js/spice/sublime_packages/%3Ast3%20yml',
         call_type => 'include',
         caller => 'DDG::Spice::SublimePackages'
     ),

--- a/t/SublimePackages.t
+++ b/t/SublimePackages.t
@@ -25,6 +25,30 @@ ddg_spice_test(
         caller => 'DDG::Spice::SublimePackages'
     ),
     
+    'sublimetext package html linux' => test_spice(
+        '/js/spice/sublime_packages/html%20%3Alinux',
+        call_type => 'include',
+        caller => 'DDG::Spice::SublimePackages'
+    ),
+    
+    'sublimetext package javascript mac os x' => test_spice(
+        '/js/spice/sublime_packages/javascript%20%3Aosx',
+        call_type => 'include',
+        caller => 'DDG::Spice::SublimePackages'
+    ),
+    
+    'sublimetext package text version 2' => test_spice(
+        '/js/spice/sublime_packages/text%20%3Ast2',
+        call_type => 'include',
+        caller => 'DDG::Spice::SublimePackages'
+    ),
+    
+    'sublimetext package text version 3' => test_spice(
+        '/js/spice/sublime_packages/text%20%3Ast3',
+        call_type => 'include',
+        caller => 'DDG::Spice::SublimePackages'
+    ),
+    
     'about sublime text' => undef,
     'sublimetext download' => undef,
 


### PR DESCRIPTION
Fixing  #1944

Currently only removing the word `for` 

Filtering by Operating System (windows, mac os x, linux)
Filtering by Sublime version 2/3

//cc @moollaza 