### PR TITLE
BrainyQuote: Prevent triggering on 'stock quote'

### DIFF
--- a/lib/DDG/Spice/BrainyQuote.pm
+++ b/lib/DDG/Spice/BrainyQuote.pm
@@ -27,9 +27,10 @@ handle remainder => sub {
         s/\./\. /g;
     }
     
-    # Hacky fix to avoid triggering on 'stock quote'
-    # 'stock quote' is handled by the Stocks IA
-    s/stock//g;
+    # Avoid triggering on 'stock' quotes; these are handled by Stocks IA
+    if ($req->query_lc =~ m/stock quote/) {
+       return;
+    }
 
     return $_ if $_;
     return;

--- a/lib/DDG/Spice/BrainyQuote.pm
+++ b/lib/DDG/Spice/BrainyQuote.pm
@@ -26,6 +26,10 @@ handle remainder => sub {
     if(/^\w\.\w/) {
         s/\./\. /g;
     }
+    
+    # Hacky fix to avoid triggering on 'stock quote'
+    # 'stock quote' is handled by the Stocks IA
+    s/stock//g;
 
     return $_ if $_;
     return;

--- a/t/BrainyQuote.t
+++ b/t/BrainyQuote.t
@@ -1,0 +1,30 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use DDG::Test::Spice;
+
+ddg_spice_test(
+    [qw( DDG::Spice::BrainyQuote )],
+
+    'lincoln quote' => test_spice(
+        '/js/spice/brainy_quote/lincoln',
+        call_type => 'include',
+        caller => 'DDG::Spice::BrainyQuote',
+    ),
+    
+    'buddha quote' => test_spice(
+        '/js/spice/brainy_quote/buddha',
+        call_type => 'include',
+        caller => 'DDG::Spice::BrainyQuote',
+    ),
+
+    'stock quote' => undef,
+    'quote' => undef
+);
+
+# This function call is expected by Test::More. It makes sure the program
+# doesn't exit before all the tests have been run.
+done_testing;

--- a/t/BrainyQuote.t
+++ b/t/BrainyQuote.t
@@ -21,7 +21,8 @@ ddg_spice_test(
         caller => 'DDG::Spice::BrainyQuote',
     ),
 
-    'stock quote' => undef,
+    'microsoft stock quote' => undef,
+    'stock quote duckduckgo' => undef,
     'quote' => undef
 );
 


### PR DESCRIPTION
Seems rather inelegant, but it fixes #1952. Is there a better way to do this?

Also, I saw that this Spice was missing a tests file, so I added that in as well.