### PR TITLE
Fix Fandango description line in GoWatchIt IA

### DIFF
--- a/share/spice/go_watch_it/go_watch_it.js
+++ b/share/spice/go_watch_it/go_watch_it.js
@@ -189,7 +189,12 @@
                     item.buy_line = "Available for Purchase";
                     item.rent_line = "";
                 }
-                
+
+                // Fandango has its own suggested line
+                if(item.provider_name === "Fandango") {
+                    item.buy_line = item.suggested_line;
+                }
+
                 // If the provider is "Netflix Mail" Change buy_line and format_line
                 if(item.provider_format_name === "Netflix Mail" && item.category !== "online") {
                     item.buy_line = "Available for Rent";


### PR DESCRIPTION
The Fandango description line was being replaced by a cut-off one

![fandango](https://cloud.githubusercontent.com/assets/104916/8397827/05b6aa84-1da7-11e5-83af-23586dafc413.png)

this should fix #1544 