### PR TITLE
use "tickets" as trigger for EventsByArtist IA

### DIFF
--- a/lib/DDG/Spice/SeatGeek/EventsByArtist.pm
+++ b/lib/DDG/Spice/SeatGeek/EventsByArtist.pm
@@ -22,7 +22,8 @@ triggers startend =>
     'live',
     'live show',
     'live shows',
-    'gigs';
+    'gigs'
+    'tickets';
 
 spice proxy_cache_valid => "200 304 12h";
 

--- a/t/SeatGeek.t
+++ b/t/SeatGeek.t
@@ -59,6 +59,10 @@ ddg_spice_test(
         '/js/spice/seat_geek/events_by_artist/beastie-boys',
         caller => 'DDG::Spice::SeatGeek::EventsByArtist',
     ),
+    'upcoming beastie boys tickets' => test_spice(
+        '/js/spice/seat_geek/events_by_artist/beastie-boys',
+        caller => 'DDG::Spice::SeatGeek::EventsByArtist',
+    ),
 );
 
 ddg_spice_test(


### PR DESCRIPTION
As reported in #1585, "tickets" was not a trigger for concerts