### PR TITLE
Custom Item Detail Wrappers

### DIFF
--- a/share/spice/recipes/recipes_item_detail.handlebars
+++ b/share/spice/recipes/recipes_item_detail.handlebars
@@ -1,18 +1,20 @@
-<div class="detail__media  detail__media--recipe">
-    <img src="{{imageProxy image}}" alt="{{recipeName}}" class="detail__media__img" />
-</div>
-<div class="detail__body  detail__body--recipe">
-    <div class="detail__body__content  recipe">
-        <h5 class="detail__title  recipe__title"><a href='{{url}}' title="{{title}}">{{recipeName}}</a></h5>
-        <div class="detail__desc">
-            <p class="detail__source  recipe__subtitle">
-                {{{include 'DDH.recipes.recipes_subtitle'}}}
-            </p>
-            <div class="recipe__content">
-                {{{include 'DDH.recipes.recipes_ingredients'}}}
-                {{{include 'DDH.recipes.recipes_flavors'}}}
+<div class="detail__inner">
+    <div class="detail__media  detail__media--recipe">
+        <img src="{{imageProxy image}}" alt="{{recipeName}}" class="detail__media__img" />
+    </div>
+    <div class="detail__body  detail__body--recipe">
+        <div class="detail__body__content  recipe">
+            <h5 class="detail__title  recipe__title"><a href='{{url}}' title="{{title}}">{{recipeName}}</a></h5>
+            <div class="detail__desc">
+                <p class="detail__source  recipe__subtitle">
+                    {{{include 'DDH.recipes.recipes_subtitle'}}}
+                </p>
+                <div class="recipe__content">
+                    {{{include 'DDH.recipes.recipes_ingredients'}}}
+                    {{{include 'DDH.recipes.recipes_flavors'}}}
+                </div>
+                {{{include 'DDH.recipes.recipes_view_full'}}}
             </div>
-            {{{include 'DDH.recipes.recipes_view_full'}}}
         </div>
     </div>
 </div>

--- a/share/spice/rx_info/rx_info.handlebars
+++ b/share/spice/rx_info/rx_info.handlebars
@@ -1,42 +1,5 @@
-<div class="detail__inner">
-    <div class="detail__media  detail__media--rx_info">
-        <img src="{{proxyImageUrl}}" alt="Image for NDC: {{{ndc11}}}" class="detail__media__img"/>
-    </div>
-    <div class="detail__body  detail__body--rx_info">
-        <div class="detail__body__content">
-            <h5 class="detail__title detail__title--rx_info">
-                {{#if splSetId}}
-                    <a href="https://dailymed.nlm.nih.gov/dailymed/lookup.cfm?setid={{{splSetId}}}" target="_blank">
-                {{/if}}
-                {{heading}}
-                {{#if splSetId}}
-                    </a>
-                {{/if}}
-            </h5>
-
-            <div class="detail__labeler--rx_info">{{labeler}}</div>
-
-            <div class="detail__desc">
-                {{#if active}}
-                    <h5 class="detail__ingredients__title--rx_info">Active Ingredients</h5>
-
-                    <div class="detail__ingredients__snippet--rx_info">
-                        {{active}}
-                    </div>
-                {{/if}}
-
-                {{#if inactive}}
-                    <h5 class="detail__ingredients__title--rx_info">Inactive Ingredients</h5>
-
-                    <div class="detail__ingredients__snippet--rx_info">
-                        {{inactive}}
-                    </div>
-                {{/if}}
-
-                <h6 class="detail__desc__attribution--rx_info">
-                    Image Source: <a href="http://rximage.nlm.nih.gov/" target="_blank">National Library of Medicine Office of High Performance Computing and Communications</a>
-                </h6>
-            </div>
-        </div>
-    </div>
+{{{formatTitle heading el="h5" className="detail__title" classNameSec="detail__title--rx_info" noSub="true" href=url}}}
+<div class="detail__labeler--rx_info">{{labeler}}</div>
+<div class="detail__desc">
+    {{{include 'DDH.rx_info.rx_info_description'}}}
 </div>

--- a/share/spice/rx_info/rx_info.handlebars
+++ b/share/spice/rx_info/rx_info.handlebars
@@ -1,40 +1,42 @@
-<div class="detail__media  detail__media--rx_info">
-    <img src="{{proxyImageUrl}}" alt="Image for NDC: {{{ndc11}}}" class="detail__media__img"/>
-</div>
-<div class="detail__body  detail__body--rx_info">
-    <div class="detail__body__content">
-        <h5 class="detail__title detail__title--rx_info">
-            {{#if splSetId}}
-                <a href="https://dailymed.nlm.nih.gov/dailymed/lookup.cfm?setid={{{splSetId}}}" target="_blank">
-            {{/if}}
-            {{heading}}
-            {{#if splSetId}}
-                </a>
-            {{/if}}
-        </h5>
+<div class="detail__inner">
+    <div class="detail__media  detail__media--rx_info">
+        <img src="{{proxyImageUrl}}" alt="Image for NDC: {{{ndc11}}}" class="detail__media__img"/>
+    </div>
+    <div class="detail__body  detail__body--rx_info">
+        <div class="detail__body__content">
+            <h5 class="detail__title detail__title--rx_info">
+                {{#if splSetId}}
+                    <a href="https://dailymed.nlm.nih.gov/dailymed/lookup.cfm?setid={{{splSetId}}}" target="_blank">
+                {{/if}}
+                {{heading}}
+                {{#if splSetId}}
+                    </a>
+                {{/if}}
+            </h5>
 
-        <div class="detail__labeler--rx_info">{{labeler}}</div>
+            <div class="detail__labeler--rx_info">{{labeler}}</div>
 
-        <div class="detail__desc">
-            {{#if active}}
-                <h5 class="detail__ingredients__title--rx_info">Active Ingredients</h5>
+            <div class="detail__desc">
+                {{#if active}}
+                    <h5 class="detail__ingredients__title--rx_info">Active Ingredients</h5>
 
-                <div class="detail__ingredients__snippet--rx_info">
-                    {{active}}
-                </div>
-            {{/if}}
+                    <div class="detail__ingredients__snippet--rx_info">
+                        {{active}}
+                    </div>
+                {{/if}}
 
-            {{#if inactive}}
-                <h5 class="detail__ingredients__title--rx_info">Inactive Ingredients</h5>
+                {{#if inactive}}
+                    <h5 class="detail__ingredients__title--rx_info">Inactive Ingredients</h5>
 
-                <div class="detail__ingredients__snippet--rx_info">
-                    {{inactive}}
-                </div>
-            {{/if}}
+                    <div class="detail__ingredients__snippet--rx_info">
+                        {{inactive}}
+                    </div>
+                {{/if}}
 
-            <h6 class="detail__desc__attribution--rx_info">
-                Image Source: <a href="http://rximage.nlm.nih.gov/" target="_blank">National Library of Medicine Office of High Performance Computing and Communications</a>
-            </h6>
+                <h6 class="detail__desc__attribution--rx_info">
+                    Image Source: <a href="http://rximage.nlm.nih.gov/" target="_blank">National Library of Medicine Office of High Performance Computing and Communications</a>
+                </h6>
+            </div>
         </div>
     </div>
 </div>

--- a/share/spice/rx_info/rx_info.js
+++ b/share/spice/rx_info/rx_info.js
@@ -56,9 +56,10 @@
             },
             templates: {
                 group: 'products_simple',
-                detail: Spice.rx_info.rx_info,
-                item_detail: Spice.rx_info.rx_info,
+                item_detail: 'base_item_detail',
                 options: {
+                    content: Spice.rx_info.rx_info,
+                    description_content: Spice.rx_info.rx_info_description,
                     brand: false,
                     rating: false
                 }
@@ -77,13 +78,15 @@
 
                 return {
                     image: item.imageUrl,
+                    imageAlt: "Image for NDC: " + item.ndc11,
                     abstract: item.ndc11,
                     heading: heading,
                     title: heading,
+                    subtitle: item.labeler,
                     ratingText: item.ndc11,
                     active: active,
                     inactive: inactive,
-                    proxyImageUrl: "https://images.duckduckgo.com/iu/?u=" + encodeURIComponent(item.imageUrl) + "&f=1"
+                    url: item.splSetId ? 'https://dailymed.nlm.nih.gov/dailymed/lookup.cfm?setid=' + item.splSetId : ''
                 }
             },
             relevancy: relCheck,

--- a/share/spice/rx_info/rx_info_description.handlebars
+++ b/share/spice/rx_info/rx_info_description.handlebars
@@ -1,0 +1,19 @@
+{{#if active}}
+    <h5 class="detail__ingredients__title--rx_info">Active Ingredients</h5>
+
+    <div class="detail__ingredients__snippet--rx_info">
+        {{active}}
+    </div>
+{{/if}}
+
+{{#if inactive}}
+    <h5 class="detail__ingredients__title--rx_info">Inactive Ingredients</h5>
+
+    <div class="detail__ingredients__snippet--rx_info">
+        {{inactive}}
+    </div>
+{{/if}}
+
+<h6 class="detail__desc__attribution--rx_info">
+    Image Source: <a href="http://rximage.nlm.nih.gov/" target="_blank">National Library of Medicine Office of High Performance Computing and Communications</a>
+</h6>


### PR DESCRIPTION
Item detail templates are now going to require an extra wrapping div.  This makes handling the templates internally a lot easier.  This shouldn't be a problem going forward since it's generally easier to use the `base_item_detail` template rather than crafting a custom one. :smile: 

to @bsstoner 