### PR TITLE
Quandl: quandl.com redirects to www.quandl.com

### DIFF
--- a/lib/DDG/Spice/Quandl/Fundamentals.pm
+++ b/lib/DDG/Spice/Quandl/Fundamentals.pm
@@ -34,7 +34,7 @@ triggers startend => @trigger_keys;
 # duckpan env set <name> <value>
 
 # set spice parameters
-spice to => 'https://quandl.com/api/v1/datasets/SF1/$1_MRQ.json?auth_token={{ENV{DDG_SPICE_QUANDL_APIKEY}}}&rows=2';
+spice to => 'https://www.quandl.com/api/v1/datasets/SF1/$1_MRQ.json?auth_token={{ENV{DDG_SPICE_QUANDL_APIKEY}}}&rows=2';
 spice wrap_jsonp_callback => 1;
 spice proxy_cache_valid => "418 1d";
 

--- a/lib/DDG/Spice/Quandl/HomeValues.pm
+++ b/lib/DDG/Spice/Quandl/HomeValues.pm
@@ -42,7 +42,7 @@ triggers any => @trigger_keys;
 # duckpan env set <name> <value>
 
 # set spice parameters
-spice to => 'https://quandl.com/api/v1/datasets/ZILL/$1.json?auth_token={{ENV{DDG_SPICE_QUANDL_APIKEY}}}&rows=2';
+spice to => 'https://www.quandl.com/api/v1/datasets/ZILL/$1.json?auth_token={{ENV{DDG_SPICE_QUANDL_APIKEY}}}&rows=2';
 spice wrap_jsonp_callback => 1;
 spice proxy_cache_valid => "418 1d";
 

--- a/lib/DDG/Spice/Quandl/WorldBank.pm
+++ b/lib/DDG/Spice/Quandl/WorldBank.pm
@@ -37,7 +37,7 @@ triggers any => @primary_keys;
 # duckpan env set <name> <value>
 
 # set spice parameters
-spice to => 'https://quandl.com/api/v1/datasets/WORLDBANK/$1.json?auth_token={{ENV{DDG_SPICE_QUANDL_APIKEY}}}&rows=2';
+spice to => 'https://www.quandl.com/api/v1/datasets/WORLDBANK/$1.json?auth_token={{ENV{DDG_SPICE_QUANDL_APIKEY}}}&rows=2';
 spice wrap_jsonp_callback => 1;
 spice proxy_cache_valid => "418 1d";
 


### PR DESCRIPTION
Nginx can't handle redirects, so we modify the Spice endpoint.