### PR TITLE
#1927 Incorrect dates shown in southern hemisphere

### DIFF
--- a/lib/DDG/Spice/Seasons.pm
+++ b/lib/DDG/Spice/Seasons.pm
@@ -9,8 +9,8 @@ my $seasons_qr = join "|", @seasons;
 
 triggers any => @seasons;
 
-spice from => "(.+)/(.+)/.*";
-spice to => 'https://api.xmltime.com/holidays?accesskey={{ENV{DDG_SPICE_TIME_AND_DATE_ACCESSKEY}}}&secretkey={{ENV{DDG_SPICE_TIME_AND_DATE_SECRETKEY}}}&callback={{callback}}&country=$2&year=$1&types=seasons&version=1';
+spice from => "(.+)/(.+)/.+/.*";
+spice to => 'https://api.xmltime.com/holidays?accesskey={{ENV{DDG_SPICE_TIME_AND_DATE_ACCESSKEY}}}&secretkey={{ENV{DDG_SPICE_TIME_AND_DATE_SECRETKEY}}}&callback={{callback}}&country=$2&year=$1&types=seasons';
 
 spice proxy_cache_valid => "200 30d";
 spice is_cached => 1;
@@ -48,6 +48,10 @@ handle query_lc => sub {
         $country = lc $loc->country_code;
     }
 
+    # Get hemisphere
+    my $hemisphere = ($loc->latitude > 0) ? 'north' : 'south';
+
+
     # Detect year
     my $current_year = (localtime(time))[5] + 1900;
     my $year = $+{year} // $current_year;
@@ -66,7 +70,7 @@ handle query_lc => sub {
     }
 
     # Season is not required for the API call, but used in the frontend
-    return $year, $country, $season, {is_cached => $caching};
+    return $year, $country, $season, $hemisphere, {is_cached => $caching};
 
 };
 

--- a/share/spice/seasons/seasons.js
+++ b/share/spice/seasons/seasons.js
@@ -12,8 +12,17 @@
         // Grab the matching search terms and figure out the season
         var script = $('[src*="/js/spice/seasons/"]')[0];
         var source = $(script).attr("src");
-        var query = source.match(/seasons\/[0-9]{4}\/[a-zA-Z]{2}\/([a-z]+)/)[1];
-        var season = $.inArray(query, [ "spring", "summer", "autumn", "winter" ]);
+        var query = source.match(/seasons\/[0-9]{4}\/[a-zA-Z]{2}\/([a-z]+)\/([a-z]+)/);
+
+        var season_q = query[1];
+        var hemisphere_q = query[2];
+
+        var seasons = [ "spring", "summer", "autumn", "winter" ];
+        if (hemisphere_q == 'south') {
+          seasons = [ "autumn", "winter", "spring", "summer" ];
+        }
+
+        var season = $.inArray(season_q, seasons);
 
         // Somehow we got an unknown season, bail out
         if (season < 0) {
@@ -27,7 +36,7 @@
         var result = {
           date: date,
           location: event.country.name,
-          season: DDG.capitalize(query)
+          season: DDG.capitalize(season_q)
         };
 
         DDG.require("moment.js", function() {

--- a/t/Seasons.t
+++ b/t/Seasons.t
@@ -23,7 +23,7 @@ ddg_spice_test(
         query_raw => "vernal equinox 2016",
         location => test_location("de")
     ) => test_spice(
-        '/js/spice/seasons/2016/de/spring',
+        '/js/spice/seasons/2016/de/spring/north',
         call_type => 'include',
         caller => 'DDG::Spice::Seasons',
     ),
@@ -32,26 +32,26 @@ ddg_spice_test(
         query_raw => "vernal solstice 2011",
         location => test_location("us")
     ) => test_spice(
-        '/js/spice/seasons/2011/us/spring',
+        '/js/spice/seasons/2011/us/spring/north',
         call_type => 'include',
         caller => 'DDG::Spice::Seasons',
     ),
 
     "summer solstice in canada" => test_spice(
-        '/js/spice/seasons/' . $year . '/ca/summer',
+        '/js/spice/seasons/' . $year . '/ca/summer/north',
         call_type => 'include',
         caller => 'DDG::Spice::Seasons',
     ),
 
     "summer solstice in canada 2020" => test_spice(
-        '/js/spice/seasons/2020/ca/summer',
+        '/js/spice/seasons/2020/ca/summer/north',
         call_type => 'include',
         caller => 'DDG::Spice::Seasons',
         is_cached => 1
     ),
 
     "summer solstice in united kingdom" => test_spice(
-        '/js/spice/seasons/' . $year . '/gb/summer',
+        '/js/spice/seasons/' . $year . '/gb/summer/north',
         call_type => 'include',
         caller => 'DDG::Spice::Seasons',
     ),
@@ -60,7 +60,7 @@ ddg_spice_test(
         query_raw => "vernal solstice 2011 in sweden",
         location => test_location("us")
     ) => test_spice(
-        '/js/spice/seasons/2011/se/spring',
+        '/js/spice/seasons/2011/se/spring/north',
         call_type => 'include',
         caller => 'DDG::Spice::Seasons',
         is_cached => 1
@@ -70,7 +70,7 @@ ddg_spice_test(
         query_raw => "first day of spring 2011 in sweden",
         location => test_location("us")
     ) => test_spice(
-        '/js/spice/seasons/2011/se/spring',
+        '/js/spice/seasons/2011/se/spring/north',
         call_type => 'include',
         caller => 'DDG::Spice::Seasons',
         is_cached => 1
@@ -80,7 +80,7 @@ ddg_spice_test(
         query_raw => "first day of spring in sweden 2011",
         location => test_location("us")
     ) => test_spice(
-        '/js/spice/seasons/2011/se/spring',
+        '/js/spice/seasons/2011/se/spring/north',
         call_type => 'include',
         caller => 'DDG::Spice::Seasons',
         is_cached => 1
@@ -96,7 +96,7 @@ ddg_spice_test(
         query_raw => "first day of fall",
         location => test_location("us")
     ) => test_spice(
-        '/js/spice/seasons/' . $year . '/us/autumn',
+        '/js/spice/seasons/' . $year . '/us/autumn/north',
         call_type => 'include',
         caller => 'DDG::Spice::Seasons',
     ),
@@ -104,13 +104,13 @@ ddg_spice_test(
     # Different query styles
 
     "summer solstice" => test_spice(
-        '/js/spice/seasons/' . $year . '/us/summer',
+        '/js/spice/seasons/' . $year . '/us/summer/north',
         call_type => 'include',
         caller => 'DDG::Spice::Seasons',
     ),
 
     "2017 summer solstice" => test_spice(
-        '/js/spice/seasons/2017/us/summer',
+        '/js/spice/seasons/2017/us/summer/north',
         call_type => 'include',
         caller => 'DDG::Spice::Seasons',
     ),
@@ -118,13 +118,13 @@ ddg_spice_test(
     # Query case
 
     "summer equinox" => test_spice(
-        '/js/spice/seasons/' . $year . '/us/summer',
+        '/js/spice/seasons/' . $year . '/us/summer/north',
         call_type => 'include',
         caller => 'DDG::Spice::Seasons',
     ),
 
     "Summer equinox" => test_spice(
-        '/js/spice/seasons/' . $year . '/us/summer',
+        '/js/spice/seasons/' . $year . '/us/summer/north',
         call_type => 'include',
         caller => 'DDG::Spice::Seasons',
     ),
@@ -134,18 +134,39 @@ ddg_spice_test(
     ($min_year - 1) . " summer solstice" => undef,
 
     $min_year . " summer solstice" => test_spice(
-        '/js/spice/seasons/' . $min_year . '/us/summer',
+        '/js/spice/seasons/' . $min_year . '/us/summer/north',
         call_type => 'include',
         caller => 'DDG::Spice::Seasons',
     ),
 
     $max_year . " summer solstice" => test_spice(
-        '/js/spice/seasons/' . $max_year . '/us/summer',
+        '/js/spice/seasons/' . $max_year . '/us/summer/north',
         call_type => 'include',
         caller => 'DDG::Spice::Seasons',
     ),
 
     ($max_year + 1) . " summer solstice" => undef,
+
+    # Northerh/Southern hemisphere
+
+    DDG::Request->new(
+        query_raw => "first day of summer 2011",
+        location => test_location("us")
+    ) => test_spice(
+        '/js/spice/seasons/2011/us/summer/north',
+        call_type => 'include',
+        caller => 'DDG::Spice::Seasons',
+    ),
+
+
+    DDG::Request->new(
+        query_raw => "first day of summer 2011",
+        location => test_location("au")
+    ) => test_spice(
+        '/js/spice/seasons/2011/au/summer/south',
+        call_type => 'include',
+        caller => 'DDG::Spice::Seasons',
+    ),
 
     # Non-matching terms
 


### PR DESCRIPTION
Incorrect dates were shown to users in southern hemisphere.

Timeanddate API always returns results in array indexed 0-3 (spring, summer, fall, winter as viewed from northern hemisphere). This means that in southern hemisphere, one has to look at index 3 ("winter") to get the summer dates down south.
