### PR TITLE
Wikidata spice

### DIFF
--- a/lib/DDG/Spice/Wikidata.pm
+++ b/lib/DDG/Spice/Wikidata.pm
@@ -1,0 +1,32 @@
+package DDG::Spice::Wikidata;
+# ABSTRACT: Uses Wikidata to answer simple questions
+
+use strict;
+use DDG::Spice;
+use Text::Trim;
+
+name "Wikidata";
+source "Wikidata";
+icon_url "https://www.wikidata.org/static/favicon/wikidata.ico";
+description "Answer simple questions for properties on subjects";
+primary_example_queries "population of Germany", "mayor of munich", "president of the United States", "children of Barack Obama", "spouse of Angelina Jolie";
+category "facts";
+topics "everyday";
+code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/Wikidata.pm";
+attribution github => ["Benestar", "Bene*"],
+            twitter => "benestar_wm";
+
+spice to => 'http://tools.wmflabs.org/bene/ddg-backend/?subject=$1&property=$2';
+spice from => '(.*)/(.*)';
+spice wrap_jsonp_callback => 1;
+
+triggers any => "of";
+
+# Handle statement
+handle query_lc => sub {
+    return unless $_ =~ /^(who|what|which)?\s*(is|are|was|were)?\s*(the|a|an)?\s*(?<property>\b.*?)\s+of\s+(the|a|an)?\s*(?<subject>\b.*)$/i;
+    return unless $+{subject} and $+{property};
+    return trim($+{subject}), trim($+{property});
+};
+
+1;

--- a/share/spice/wikidata/wikidata.js
+++ b/share/spice/wikidata/wikidata.js
@@ -1,0 +1,25 @@
+(function (env) {
+    "use strict";
+
+    env.ddg_spice_wikidata = function(api_result){
+
+        if (!api_result || api_result.error) {
+            return Spice.failed('wikidata');
+        }
+
+        Spice.add({
+            id: "wikidata",
+            name: "Answer",
+            data: api_result.result.values,
+            meta: {
+                sourceName: "wikidata.org",
+                sourceUrl: 'https://www.wikidata.org/wiki/' + api_result.result.item
+            },
+            templates: {
+                group: 'media',
+                item_detail: 'basic_info_detail' // group: media doesn't recognize links
+            }
+        });
+    };
+
+}(this));

--- a/t/Wikidata.t
+++ b/t/Wikidata.t
@@ -1,0 +1,38 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+spice is_cached => 1;
+
+ddg_spice_test(
+    [qw( DDG::Spice::Wikidata)],
+    'population of Germany' => test_spice(
+        '/js/spice/wikidata/germany/population',
+        call_type => 'include',
+        caller => 'DDG::Spice::Wikidata'
+    ),
+    'president of the United States' => test_spice(
+        '/js/spice/wikidata/united%20states/president',
+        call_type => 'include',
+        caller => 'DDG::Spice::Wikidata'
+    ),
+    'who is the mayor of London' => test_spice(
+        '/js/spice/wikidata/london/mayor',
+        call_type => 'include',
+        caller => 'DDG::Spice::Wikidata'
+    ),
+    'what are the sister cities of Berlin' => test_spice(
+        '/js/spice/wikidata/berlin/sister%20cities',
+        call_type => 'include',
+        caller => 'DDG::Spice::Wikidata'
+    ),
+    'proffessor' => undef,
+    'who is the mayor in London' => undef,
+    'how is the wather in Germany' => undef
+);
+
+done_testing;
+


### PR DESCRIPTION
This is a first version of a spice to automatically show results based on [Wikidata](https://www.wikidata.org/). More information below or in [the introduction](https://www.wikidata.org/wiki/Wikidata:Introduction).

This proposal currently uses an api wrapper of the [Wikidata api](https://www.wikidata.org/w/api.php) to avoid having several requests. To have a stable api, we can provide this wrapper directly on Wikidata. I will create a patch for such an api module if this is going to be merged.

## What is Wikidata?
Wikidata is a free linked database that can be read and edited by both humans and machines.

Wikidata acts as central storage for the structured data of its Wikimedia sister projects including Wikipedia, Wikivoyage, Wikisource, and others.

Wikidata also provides support to many other sites and services beyond just Wikimedia projects! The content of Wikidata is available under a free license, exported using standard formats, and can be interlinked to other open data sets on the linked data web.

*From the main page (CC-BY-SA 3.0)*

![Wikidata logo](https://upload.wikimedia.org/wikipedia/commons/6/66/Wikidata-logo-en.svg)

Pinging @moollaza as he was interested in this wikidata integration.

# Pull request template

**What does your Instant Answer do?**

Parse simple questions/phrases in the form "foo of bar" and search for values on Wikidata.

**What problem does your Instant Answer solve (Why is it better than organic links)?**

Instead of having to read eg. the Wikipedia article you can directly see the result in a nice format.

**What is the data source for your Instant Answer? (Provide a link if possible)**

[Wikidata](https://www.wikidata.org/)

**Why did you choose this data source?**

It's the new great project for open data, it's free and it's created and maintained by the Wikipedia community

**Are there any other alternative (better) data sources?**

There may be better sources for some specific data, but no sources have such a broad coverage as Wikidata

**What are some example queries that trigger this Instant Answer?**

"president of the United States", "population of Berlin", "what are the children of Barack Obama"

**Which communities will this Instant Answer be especially useful for? (gamers, book lovers, etc)**

very broad topics covered (like Wikipedia and even more)

**Is this Instant Answer connected to a DuckDuckHack [Instant Answer idea](https://duck.co/ideas)?**

something like this was suggested in https://duck.co/ideas/idea/343/improve-0-click-info-with-wikidata-entries

**Which existing Instant Answers will this one supersede/overlap with?**

it may overlap with some IAs about population data

**Are you having any problems? Do you need our help with anything?**

yes, merge this :D

**What are the terms of use for the API? Will DuckDuckGo need specific authorization (e.g. an API key)? Are there any costs associated with API usage?**

Wikidata is licenced under CC0 and no special authorization should be required

**What does the Instant Answer look like? (Provide a screenshot for new or updated Instant Answers)**

![hgzsp](https://cloud.githubusercontent.com/assets/2998254/8501097/9bf542c2-21a2-11e5-9e75-f6ed39e23468.jpg)

## Checklist
Please place an 'X' where appropriate.

```
[x] Added metadata and attribution information
[x] Wrote test file and added to t/ directory
[x] Verified that instant answer adheres to design guidelines (https://duck.co/duckduckhack/design_styleguide)
[x] Verified that instant answer adheres to code styleguide (https://duck.co/duckduckhack/code_styleguide)
[] Tested cross-browser compatibility

    Please let us know which browsers/devices you've tested on:
    - Windows 8
        [x] Google Chrome
        [x] Firefox
        [] Opera
        [] IE 10

    - Windows 7
        [] Google Chrome
        [] Firefox
        [] Opera
        [] IE 8
        [] IE 9
        [] IE 10

    - Windows XP
        [] IE 8

    - Mac OSX
        [] Google Chrome
        [] Firefox
        [] Opera
        [] Safari

    - iOS (iPhone)
        [] Safari Mobile
        [] Google Chrome
        [] Opera

    - iOS (iPad)
        [] Safari Mobile
        [] Google Chrome
        [] Opera

    - Android
        [] Firefox
        [] Native Browser
        [] Google Chrome
        [] Opera
```

IA Page: https://duck.co/ia/view/wikidata