### PR TITLE
Removed old meta text attribute

### DIFF
--- a/share/spice/transit/njt/transit_njt.js
+++ b/share/spice/transit/njt/transit_njt.js
@@ -13,6 +13,7 @@
             signal: 'high',
             data: api_result.routes,
             meta: {
+                primaryText: api_result.origin + " to " + api_result.destination,
                 sourceUrl: api_result.url,
                 sourceName: "NJ Transit"
             },

--- a/share/spice/transit/njt/transit_njt.js
+++ b/share/spice/transit/njt/transit_njt.js
@@ -13,7 +13,6 @@
             signal: 'high',
             data: api_result.routes,
             meta: {
-                heading: api_result.origin + " to " + api_result.destination,
                 sourceUrl: api_result.url,
                 sourceName: "NJ Transit"
             },

--- a/share/spice/transit/path/transit_path.js
+++ b/share/spice/transit/path/transit_path.js
@@ -11,7 +11,6 @@
             signal: 'high',
             data: api_result.routes,
             meta: {
-                heading: api_result.origin + " to " + api_result.destination,
                 sourceUrl: "http://www.panynj.gov/path/",
                 sourceName: "PATH"
             },

--- a/share/spice/transit/path/transit_path.js
+++ b/share/spice/transit/path/transit_path.js
@@ -11,6 +11,7 @@
             signal: 'high',
             data: api_result.routes,
             meta: {
+                primaryText: api_result.origin + " to " + api_result.destination,
                 sourceUrl: "http://www.panynj.gov/path/",
                 sourceName: "PATH"
             },

--- a/share/spice/transit/septa/transit_septa.js
+++ b/share/spice/transit/septa/transit_septa.js
@@ -23,7 +23,6 @@
             data: api_result,
             signal: 'high',
             meta: {
-                heading: from + " to " + to,
                 sourceName: 'SEPTA',
                 sourceUrl: 'http://www.septa.org/schedules/rail/index.html',
                 sourceIconUrl: 'http://septa.org/site/images/favicon.ico'

--- a/share/spice/transit/septa/transit_septa.js
+++ b/share/spice/transit/septa/transit_septa.js
@@ -23,6 +23,7 @@
             data: api_result,
             signal: 'high',
             meta: {
+                primaryText: from + " to " + to,
                 sourceName: 'SEPTA',
                 sourceUrl: 'http://www.septa.org/schedules/rail/index.html',
                 sourceIconUrl: 'http://septa.org/site/images/favicon.ico'

--- a/share/spice/transit/switzerland/transit_switzerland.js
+++ b/share/spice/transit/switzerland/transit_switzerland.js
@@ -14,7 +14,6 @@
             name: "Swiss Trains",
             data: api_result.connections,
             meta: {
-                heading: from + " to " + to,
                 sourceName: "transport.opendata.ch",
                 sourceUrl: 'http://transport.opendata.ch/examples/connections.php?from=' + from + '&to=' + to
             },

--- a/share/spice/transit/switzerland/transit_switzerland.js
+++ b/share/spice/transit/switzerland/transit_switzerland.js
@@ -14,6 +14,7 @@
             name: "Swiss Trains",
             data: api_result.connections,
             meta: {
+                primaryText: from + " to " + to,
                 sourceName: "transport.opendata.ch",
                 sourceUrl: 'http://transport.opendata.ch/examples/connections.php?from=' + from + '&to=' + to
             },


### PR DESCRIPTION
Removed some old meta text attributes from Transit. Fixes #1794 