### PR TITLE
Changed congress template to media

### DIFF
--- a/share/spice/congress/congress.css
+++ b/share/spice/congress/congress.css
@@ -12,7 +12,10 @@
 }
 
 .tile--congress .tile__media {
-    height: 13em;
+    margin-top: 1.4em;
+    height: 110px;
+    width: 110px;
+    border-radius: 100%;
 }
 
 .tile--congress .tile__title {
@@ -21,10 +24,4 @@
     display: table-cell;
     width: 150px;
     text-align: center;
-}
-.tile--congress .tile__media__img {
-    margin-top: 1.4em;
-    max-width: 100%;
-    height: 140px;
-    border-radius: 100%;
 }

--- a/share/spice/congress/congress.css
+++ b/share/spice/congress/congress.css
@@ -12,5 +12,19 @@
 }
 
 .tile--congress .tile__media {
-    height:13em;
+    height: 13em;
+}
+
+.tile--congress .tile__title {
+    vertical-align: middle;
+    font-weight: 400;
+    display: table-cell;
+    width: 150px;
+    text-align: center;
+}
+.tile--congress .tile__media__img {
+    margin-top: 1.4em;
+    width: 130px;
+    height: 130px;
+    border-radius: 100%;
 }

--- a/share/spice/congress/congress.css
+++ b/share/spice/congress/congress.css
@@ -10,3 +10,7 @@
 .tile--congress .tile__body {
 	height:5em;
 }
+
+.tile--congress .tile__media {
+    height:13em;
+}

--- a/share/spice/congress/congress.css
+++ b/share/spice/congress/congress.css
@@ -24,7 +24,7 @@
 }
 .tile--congress .tile__media__img {
     margin-top: 1.4em;
-    width: 130px;
-    height: 130px;
+    max-width: 100%;
+    height: 140px;
     border-radius: 100%;
 }

--- a/share/spice/congress/congress.js
+++ b/share/spice/congress/congress.js
@@ -70,7 +70,7 @@
             },
             sort_default: 'district',
             templates: {
-                group: 'products',
+                group: 'media',
                 options: {
                     buy: Spice.congress.buy,
                     rating: false,
@@ -78,7 +78,11 @@
                     brand: false
                 },
                 variants: {
-                    tile: 'narrow'
+                    tile: 'narrow',
+                    tileTitle: '1line'
+                },
+                elClass: {
+                    tileTitle: 'tx--15'
                 }
             }
         });

--- a/share/spice/congress/congress.js
+++ b/share/spice/congress/congress.js
@@ -79,7 +79,6 @@
                 },
                 variants: {
                     tile: 'narrow',
-                    tileTitle: '1line'
                 },
                 elClass: {
                     tileTitle: 'tx--15'

--- a/share/spice/congress/congress.js
+++ b/share/spice/congress/congress.js
@@ -71,12 +71,8 @@
             sort_default: 'district',
             templates: {
                 group: 'media',
-                options: {
-                    buy: Spice.congress.buy,
-                    rating: false,
-                    price: false,
-                    brand: false
-                },
+                item_detail: false,
+                detail: false,
                 variants: {
                     tile: 'narrow',
                 },


### PR DESCRIPTION
This currently looks like this, What do you think we should do about the names?
This will fix #836 
![congress](https://cloud.githubusercontent.com/assets/6311809/8553895/22c9ddda-2504-11e5-9b11-cf2d28fc06d7.png)
