### PR TITLE
People in Space: Update for IE8

### DIFF
--- a/share/spice/people_in_space/people_in_space.css
+++ b/share/spice/people_in_space/people_in_space.css
@@ -20,7 +20,7 @@
 }
 
 .zci--people_in_space .info {
-	text-align: center;
+    text-align: center;
     position: inherit;
     display:table-cell;
     vertical-align: middle;
@@ -37,8 +37,8 @@
 }
 
 .zci--people_in_space .tile__body {
-	padding: 0;
-	padding-top: 0;
+    padding: 0;
+    padding-top: 0;
 }
 
 .zci--people_in_space .image-under img {
@@ -53,6 +53,7 @@
     width: 100%;
     height: 100%;
 }
+
 
 .zci--people_in_space .image-under {
     position: absolute;

--- a/share/spice/people_in_space/people_in_space.css
+++ b/share/spice/people_in_space/people_in_space.css
@@ -42,25 +42,29 @@
 }
 
 .zci--people_in_space .image-under img {
-   	height: 130px;
-    width: 100px;
+    width: 100%;
+    height: 100%;
 }
 
 .zci--people_in_space .image-over img {
     border: 3px solid #fff;
-    height: 32px;
-    width: 32px;
-	border-radius: 100%;
+    border-radius: 100%;
     background-color: #fff;
+    width: 100%;
+    height: 100%;
 }
 
 .zci--people_in_space .image-under {
     position: absolute;
+    height: 130px;
+    width: 100px;
 }
 
 .zci--people_in_space .image-over {
     position: absolute;
-    z-index: 5;
+    height: 32px;
+    width: 32px;
+    z-index: 1000;
     top: 86px;
     left: 95px;
 }


### PR DESCRIPTION
Adjust img and container sizing CSS for IE8 Support.

Images need a background color otherwise they look a little odd because we don't have border-radius available to use:

![dashboard](https://cloud.githubusercontent.com/assets/873785/8555891/0c2278f0-24c1-11e5-804b-286c4cf83f68.png)

Merging as a hotfix because right now its completely broken in IE8.

Result: https://www.browserstack.com/screenshots/6e3cb4c05b6462a582a395819cc4590c8b6c5ca1

/cc @abeyang @MrChrisW 