### PR TITLE
Hide flag icon in IE8

### DIFF
--- a/share/spice/people_in_space/people_in_space.css
+++ b/share/spice/people_in_space/people_in_space.css
@@ -69,3 +69,8 @@
     top: 86px;
     left: 95px;
 }
+
+
+.ie8 .zci--people_in_space .image-over {
+    display: none;
+}


### PR DESCRIPTION
We've decided that it's best to just hide the flag in IE8. 

This accomplishes that with some CSS:

![dashboard](https://cloud.githubusercontent.com/assets/873785/8556574/f1ecc9fe-24c5-11e5-8259-ed2ce968409c.png)

/cc @abeyang @MrChrisW 