### PR TITLE
codemodedev's GetGPSCoordinates Spice

### DIFF
--- a/lib/DDG/Spice/GetGPSCoordinates.pm
+++ b/lib/DDG/Spice/GetGPSCoordinates.pm
@@ -17,7 +17,8 @@ category "geography";
 # Uncomment and complete: https://duck.co/duckduckhack/metadata#topics
 topics "geography";
 code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/GetGPSCoordinates.pm";
-attribution github => ["codemodedev", "Anthony DiSante"];
+attribution github => ["codemodedev", "Anthony DiSante"],
+            email => ['codes@anthonydisante.com', "Anthony DiSante"];
 
 spice to =>'https://en.wikipedia.org/w/api.php?action=query&titles=$1&prop=revisions&rvprop=content&format=json&callback={{callback}}';
 

--- a/lib/DDG/Spice/GetGPSCoordinates.pm
+++ b/lib/DDG/Spice/GetGPSCoordinates.pm
@@ -1,0 +1,120 @@
+package DDG::Spice::GetGPSCoordinates;
+# ABSTRACT: displays the latitude and longitude for a given city, from the city's Wikipedia page.
+
+use DDG::Spice;
+
+spice is_cached => 1; 
+
+# Metadata.  See https://duck.co/duckduckhack/metadata for help in filling out this section.
+name "GetGPSCoordinates";
+source "Wikipedia";
+#icon_url "";
+description "Displays the GPS coordinates for the requested city, with a link to OpenStreetMap.";
+primary_example_queries "gps for paoli, pa", "gps coordinates for philadelphia";
+secondary_example_queries "denver gps coordinates";
+# Uncomment and complete: https://duck.co/duckduckhack/metadata#category
+category "geography";
+# Uncomment and complete: https://duck.co/duckduckhack/metadata#topics
+topics "geography";
+code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/GetGPSCoordinates.pm";
+attribution github => ["codemodedev", "Anthony DiSante"];
+
+spice to =>'https://en.wikipedia.org/w/api.php?action=query&titles=$1&prop=revisions&rvprop=content&format=json&callback={{callback}}';
+
+triggers start => 'gps coordinates for', 'coordinates for', 'gps for';
+triggers startend => 'gps coordinates';
+
+# Handle statement
+handle remainder => sub {
+
+    # optional - regex guard
+    # return unless qr/^\w+/;
+
+    return unless $_;    # Guard against "no answer"
+
+    # Uppercase the first letter of each word, b/c wikipedia wants "Camden, New Jersey"
+    # not "camden, new jersey".
+    s!(^|\s+)(\w)(\S+)!$1\u$2$3!g;
+
+    # For unusual names like "King of Prussia, Pennsylvania" wikipedia will only accept
+    # "of" and not "Of":
+    s! Of ! of !g;
+
+    # Wikipedia also requires a comma in many cases (e.g. "Paoli, Pennsylvania" not
+    # "Paoli Pennsylvania"), and they let us request multiple articles at once, so
+    # include variants to increase the odds that we get the right one even when the
+    # user enters the "wrong" search terms (but only for multi-word searches where the
+    # user hasn't already included a comma):
+    if(/ / && !/,/) {
+        my $orig_terms = $_;
+        my $terms_with_comma_after_city = $_;
+        $terms_with_comma_after_city =~ s!^(\S+)!$1,!;
+        $_ = $orig_terms . '|' . $terms_with_comma_after_city;
+
+        # if it contains three words or more, include a comma-before-state variant:
+    	if(/ \S+ /) {
+            my $terms_with_comma_before_state = $orig_terms;
+            $terms_with_comma_before_state =~ s! (\S+)$!, $1!;
+            $_ .= '|' . $terms_with_comma_before_state;
+        }
+    }
+
+    # Allow state abbreviations:
+    s!(,|\s+)AL$!$1Alabama!i;
+    s!(,|\s+)AK$!$1Alaska!i;
+    s!(,|\s+)AZ$!$1Arizona!i;
+    s!(,|\s+)AR$!$1Arkansas!i;
+    s!(,|\s+)CA$!$1California!i;
+    s!(,|\s+)CO$!$1Colorado!i;
+    s!(,|\s+)CT$!$1Connecticut!i;
+    s!(,|\s+)DE$!$1Delaware!i;
+    s!(,|\s+)DC$!$1District of Columbia!i;
+    s!(,|\s+)FL$!$1Florida!i;
+    s!(,|\s+)GA$!$1Georgia!i;
+    s!(,|\s+)HI$!$1Hawaii!i;
+    s!(,|\s+)ID$!$1Idaho!i;
+    s!(,|\s+)IL$!$1Illinois!i;
+    s!(,|\s+)IN$!$1Indiana!i;
+    s!(,|\s+)IA$!$1Iowa!i;
+    s!(,|\s+)KS$!$1Kansas!i;
+    s!(,|\s+)KY$!$1Kentucky!i;
+    s!(,|\s+)LA$!$1Louisiana!i;
+    s!(,|\s+)ME$!$1Maine!i;
+    s!(,|\s+)MD$!$1Maryland!i;
+    s!(,|\s+)MA$!$1Massachusetts!i;
+    s!(,|\s+)MI$!$1Michigan!i;
+    s!(,|\s+)MN$!$1Minnesota!i;
+    s!(,|\s+)MS$!$1Mississippi!i;
+    s!(,|\s+)MO$!$1Missouri!i;
+    s!(,|\s+)MT$!$1Montana!i;
+    s!(,|\s+)NE$!$1Nebraska!i;
+    s!(,|\s+)NV$!$1Nevada!i;
+    s!(,|\s+)NH$!$1New Hampshire!i;
+    s!(,|\s+)NJ$!$1New Jersey!i;
+    s!(,|\s+)NM$!$1New Mexico!i;
+    s!(,|\s+)NY$!$1New York!i;
+    s!(,|\s+)NC$!$1North Carolina!i;
+    s!(,|\s+)ND$!$1North Dakota!i;
+    s!(,|\s+)OH$!$1Ohio!i;
+    s!(,|\s+)OK$!$1Oklahoma!i;
+    s!(,|\s+)OR$!$1Oregon!i;
+    s!(,|\s+)PA$!$1Pennsylvania!i;
+    s!(,|\s+)PR$!$1Puerto Rico!i;
+    s!(,|\s+)RI$!$1Rhode Island!i;
+    s!(,|\s+)SC$!$1South Carolina!i;
+    s!(,|\s+)SD$!$1South Dakota!i;
+    s!(,|\s+)TN$!$1Tennessee!i;
+    s!(,|\s+)TX$!$1Texas!i;
+    s!(,|\s+)UT$!$1Utah!i;
+    s!(,|\s+)VT$!$1Vermont!i;
+    s!(,|\s+)VI$!$1Virgin Islands!i;
+    s!(,|\s+)VA$!$1Virginia!i;
+    s!(,|\s+)WA$!$1Washington!i;
+    s!(,|\s+)WV$!$1West Virginia!i;
+    s!(,|\s+)WI$!$1Wisconsin!i;
+    s!(,|\s+)WY$!$1Wyoming!i;
+
+    return $_;
+};
+
+1;

--- a/share/spice/get_gpscoordinates/content.handlebars
+++ b/share/spice/get_gpscoordinates/content.handlebars
@@ -1,0 +1,4 @@
+<h4>
+    {{latd}}&deg; {{latm}}' {{lats}}" {{latNS}}, {{longd}}&deg; {{longm}}' {{longs}}" {{longEW}}
+    <br />({{lat_decimal}}, {{long_decimal}})
+</h4>

--- a/share/spice/get_gpscoordinates/get_gpscoordinates.js
+++ b/share/spice/get_gpscoordinates/get_gpscoordinates.js
@@ -1,0 +1,108 @@
+(function (env) {
+    "use strict";
+    env.ddg_spice_get_gpscoordinates = function(api_result){
+
+        if (api_result.error) {
+            return Spice.failed();   // Spice.failed('Cannot display coordinates: got an API error in get_gpscoordinates.');
+        }
+
+	var result_string = JSON.stringify(api_result);
+	var matches = [],
+	    coords = {};
+	if(matches = result_string.match(/lat_?d\s*=\s*(\d+)/))
+		coords.latd = matches[1];
+	if(matches = result_string.match(/lat_?m\s*=\s*(\d+)/))
+		coords.latm = matches[1];
+	if(matches = result_string.match(/lat_?s\s*=\s*(\d+)/))
+		coords.lats = matches[1];
+	if(matches = result_string.match(/lat_?NS\s*=\s*([NS])/))
+		coords.latNS = matches[1];
+	if(matches = result_string.match(/long_?d\s*=\s*(\d+)/))
+		coords.longd = matches[1];
+	if(matches = result_string.match(/long_?m\s*=\s*(\d+)/))
+		coords.longm = matches[1];
+	if(matches = result_string.match(/long_?s\s*=\s*(\d+)/))
+		coords.longs = matches[1];
+	if(matches = result_string.match(/long_?EW\s*=\s*([EW])/))
+		coords.longEW = matches[1];
+
+	//for(var i in coords)
+	//	console.log("coords." + i + "=" + coords[i]);
+
+	// Special case for the seconds component, because some wikipedia city articles include only degrees and minutes:
+	if(typeof(coords.lats) === 'undefined')
+		coords.lats = 0;
+	if(typeof(coords.longs) === 'undefined')
+		coords.longs = 0;
+
+	if(typeof(coords.latd) === 'undefined'   ||   typeof(coords.latm) === 'undefined'   ||   typeof(coords.latNS) === 'undefined'
+	|| typeof(coords.longd) === 'undefined'   ||   typeof(coords.longm) === 'undefined'   ||   typeof(coords.longEW) === 'undefined')
+	{
+		// Sometimes the wikipedia article has the coords in decimal format instead:
+		if(matches = result_string.match(/lat_?d\s*=\s*([\d\.-]+)/))
+			coords.lat_decimal = matches[1];
+		if(matches = result_string.match(/long_?d\s*=\s*([\d\.-]+)/))
+			coords.long_decimal = matches[1];
+
+		if(!coords.lat_decimal && !coords.long_decimal)
+			return Spice.failed();   // Spice.failed('Cannot display coordinates: degrees, minutes, and/or N/S/E/W were null, in get_gpscoordinates.');
+
+		if(coords.lat_decimal.match(/-/)) {
+			coords.lat_decimal = coords.lat_decimal.replace(/-/g, '');   // temporarily remove it to calculate the d/m/s values.
+			coords.latNS = 'S';
+		}
+		else
+			coords.latNS = 'N';
+
+		if(coords.long_decimal.match(/-/)) {
+			coords.long_decimal = coords.long_decimal.replace(/-/g, '');   // temporarily remove it to calculate the d/m/s values.
+			coords.longEW = 'W';
+		}
+		else
+			coords.longEW = 'E';
+
+		coords.latd = parseInt(coords.lat_decimal);
+		coords.latm = parseInt(60   * (coords.lat_decimal - coords.latd));
+		coords.lats = parseInt(3060 * (coords.lat_decimal - coords.latd - coords.latm/60));
+
+		coords.longd = parseInt(coords.long_decimal);
+		coords.longm = parseInt(60   * (coords.long_decimal - coords.longd));
+		coords.longs = parseInt(3060 * (coords.long_decimal - coords.longd - coords.longm/60));
+
+		// Re-add any negative signs:
+		if(coords.latNS === 'S')
+			coords.lat_decimal = '-' + coords.lat_decimal;
+		if(coords.longEW === 'W')
+			coords.long_decimal = '-' + coords.long_decimal;
+	}
+
+	if(!coords.lat_decimal) {
+		coords.lat_decimal = parseInt(coords.latd) + (coords.latm/60) + (coords.lats/3600);
+		if(coords.latNS.match(/s/i))
+			coords.lat_decimal = '-' + coords.lat_decimal;
+	}
+
+	if(!coords.long_decimal) {
+		coords.long_decimal = parseInt(coords.longd) + (coords.longm/60) + (coords.longs/3600);
+		if(coords.longEW.match(/w/i))
+			coords.long_decimal = '-' + coords.long_decimal;
+	}
+
+        Spice.add({
+            id: "get_gpscoordinates",
+            name: "GetGPSCoordinates",
+            data: coords,
+            meta: {
+                sourceName: "openstreetmap.org",
+                sourceUrl: "http://www.openstreetmap.org/?mlat=" + coords.lat_decimal + "&mlon=" + coords.long_decimal + "&zoom=12"
+            },
+            templates: {
+                group: 'base',
+                options:{
+                    content: Spice.get_gpscoordinates.content,
+                    moreAt: true
+                }
+            }
+        });
+    };
+}(this));

--- a/t/GetGPSCoordinates.t
+++ b/t/GetGPSCoordinates.t
@@ -29,8 +29,9 @@ ddg_spice_test(
     ),
     # Try to include some examples of queries on which it might
     # appear that your answer will trigger, but does not.
-    'buy a gps' => undef,
+    #'gps for sale' => undef,
     'gps coordinate conversion' => undef,
+    'gps coordinate software' => undef
 );
 
 done_testing;

--- a/t/GetGPSCoordinates.t
+++ b/t/GetGPSCoordinates.t
@@ -1,0 +1,37 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+spice is_cached => 1;
+
+ddg_spice_test(
+    [qw( DDG::Spice::GetGPSCoordinates)],
+    # At a minimum, be sure to include tests for all:
+    # - primary_example_queries
+    # - secondary_example_queries
+    'gps for paoli, pa' => test_spice(
+        '/js/spice/get_gpscoordinates/Paoli%2C%20Pennsylvania',
+        call_type => 'include',
+        caller => 'DDG::Spice::GetGPSCoordinates'
+    ),
+    'gps coordinates for philadelphia' => test_spice(
+        '/js/spice/get_gpscoordinates/Philadelphia',
+        call_type => 'include',
+        caller => 'DDG::Spice::GetGPSCoordinates'
+    ),
+    'denver gps coordinates' => test_spice(
+        '/js/spice/get_gpscoordinates/Denver',
+        call_type => 'include',
+        caller => 'DDG::Spice::GetGPSCoordinates'
+    ),
+    # Try to include some examples of queries on which it might
+    # appear that your answer will trigger, but does not.
+    'buy a gps' => undef,
+    'gps coordinate conversion' => undef,
+);
+
+done_testing;
+


### PR DESCRIPTION
**What does your Instant Answer do?**
Displays the GPS coordinates for any city, and a link to those coordinates in OpenStreetMap.


**What problem does your Instant Answer solve (Why is it better than organic links)?**
It's quicker and easier than wading through search results that may or may not actually show the specific coordinates for the requested city.


**What is the data source for your Instant Answer? (Provide a link if possible)**
Wikipedia


**Why did you choose this data source?**
It appears to have GPS coordinates for every major city and many small towns as well, with a fast open API


**Are there any other alternative (better) data sources?**
Possibly, but none that I found had an API or at least not one as fast as Wikipedia's.


**What are some example queries that trigger this Instant Answer?**
gps for denver, chicago gps coordinates, gps coordinates for paoli pa


**Which communities will this Instant Answer be especially useful for? (gamers, book lovers, etc)**
cartographers, people who work with weather stations, data geeks


**Is this Instant Answer connected to a DuckDuckHack [Instant Answer idea](https://duck.co/ideas)?**
no


**Which existing Instant Answers will this one supersede/overlap with?**
I don't see any (at least in the Spice tree?) that mention either GPS or coordinates


**Are you having any problems? Do you need our help with anything?**
When running the tests, some of my negative tests are failing.  For example, "gps for denver" is valid for my IA, but "gps for sale" is not.  This works properly in the browser (the IA is simply not displayed), but in the test it fails, because my code intentionally returns Spice.failed() from the JS in cases where the API returns no GPS coordinates, but the command-line test can't test for such JS returns (according to the DDG guys in the Gitter chat).
The test output is:

  Failed test 'Checking for not matching on gps for sale'
  at /home/codio/.../Test/Block.pm line 62.
  got: 'DDG::ZeroClickInfo::Spice=HASH(0x365ccd8)'
  expected: undef

For now I've just commented out those types of negative tests (other negative tests work properly, such as 'gps coordinate conversion' => undef).  I guess that's fine, but should there be a way to test for them that uses the JS output in the test?


**What are the terms of use for the API? Will DuckDuckGo need specific authorization (e.g. an API key)? Are there any costs associated with API usage?**
No API key or costs are involved


**Where did you hear about DuckDuckHack? (For first time contributors)**
Just browsing around the DDG site and the about-us page


**What does the Instant Answer look like? (Provide a screenshot for new or updated Instant Answers)**


## Checklist
Please place an 'X' where appropriate.

```
[x] Added metadata and attribution information
[x] Wrote test file and added to t/ directory
[x] Verified that instant answer adheres to design guidelines (https://duck.co/duckduckhack/design_styleguide)
[x] Verified that instant answer adheres to code styleguide (https://duck.co/duckduckhack/code_styleguide)
[x] Tested cross-browser compatibility

    Please let us know which browsers/devices you've tested on:
    - Linux (LinuxMint 17)
        [x] Google Chrome
        [x] Firefox

    - Windows 8
        [] Google Chrome
        [] Firefox
        [] Opera
        [] IE 10

    - Windows 7
        [x] Google Chrome
        [x] Firefox
        [x] Opera
        [] IE 8
        [x] IE 9
        [x] IE 10
        [x] IE 11

    - Windows XP
        [x] IE 8

    - Mac OSX
        [x] Google Chrome
        [x] Firefox
        [x] Opera
        [x] Safari

    - iOS (iPhone)
        [x] Safari Mobile
        [x] Google Chrome
        [x] Opera

    - iOS (iPad)
        [] Safari Mobile
        [] Google Chrome
        [] Opera

    - Android
        [] Firefox
        [] Native Browser
        [] Google Chrome
        [] Opera
```
![screenshot](https://cloud.githubusercontent.com/assets/12973907/8564075/4e644f96-2515-11e5-8400-f6424b911d4e.png)
