### PR TITLE
Commented url in 'example.pm'  referencing spice caching documentation updated.

### DIFF
--- a/template/lib/DDG/Spice/Example.pm
+++ b/template/lib/DDG/Spice/Example.pm
@@ -5,8 +5,8 @@ package DDG::Spice::<: $ia_package_name :>;
 
 use DDG::Spice;
 
-# Caching - https://duck.co/duckduckhack/spice_advanced_backend#caching
-spice is_cached => 1; 
+# Caching - https://duck.co/duckduckhack/spice_advanced_backend#caching-api-responses
+spice is_cached => 1;
 
 # Metadata.  See https://duck.co/duckduckhack/metadata for help in filling out this section.
 name "<: $ia_name_separated :>";


### PR DESCRIPTION
I noticed that the url to the spice docs was out of date. It should reflect the current page anchor now.