### PR TITLE
Seat Geek: Resolve price align bug on mobile

### DIFF
--- a/share/spice/seat_geek/events_by_artist/seat_geek_events_by_artist.css
+++ b/share/spice/seat_geek/events_by_artist/seat_geek_events_by_artist.css
@@ -5,7 +5,6 @@
 .zci--seat_geek_events_by_artist .price,
 .zci--seat_geek_events_by_artist .noprice {
     margin-top: 1.75em;
-    height: 1.1em;
     float: left;
 }
 
@@ -22,6 +21,6 @@
     width: 9.3em;
 }
 
-    .is-mobile .zci--seat_geek_events_by_artist .where.city {
-        width: 7em;
-    }
+.is-mobile .zci--seat_geek_events_by_artist .where.city {
+    width: 7em;
+}


### PR DESCRIPTION
Resolves #1848.  

Not perfect alignment but it works for now.  I suppose the css for `dateBadge` needs to be fixed internally?  It doesn't align to the bottom of the tile footer.

![screen shot 2015-07-13 at 2 19 23 am](https://cloud.githubusercontent.com/assets/5793364/8639214/9e2360c8-2905-11e5-925a-d5a3722fe48f.png)
