### PR TITLE
News Articles Spice

### DIFF
--- a/lib/DDG/Spice/Articles.pm
+++ b/lib/DDG/Spice/Articles.pm
@@ -8,7 +8,7 @@ use YAML::XS 'LoadFile';
 primary_example_queries "engadget";
 secondary_example_queries "nyt";
 description "Shows latest articles for popular news sites with Atom/RSS feeds";
-name "Articles";
+name "Articles By";
 code_url "https://github.com/brianrisk/zeroclickinfo-spice/lib/DDG/Articles.pm";
 topics "economy_and_finance";
 category "facts";

--- a/lib/DDG/Spice/Articles.pm
+++ b/lib/DDG/Spice/Articles.pm
@@ -1,0 +1,51 @@
+package DDG::Spice::Articles;
+
+use DDG::Spice;
+use Text::Trim;
+use YAML::XS 'LoadFile';
+
+# meta data
+primary_example_queries "engadget";
+secondary_example_queries "nyt";
+description "Shows latest articles for popular news sites with Atom/RSS feeds";
+name "Articles";
+code_url "https://github.com/brianrisk/zeroclickinfo-spice/lib/DDG/Articles.pm";
+topics "economy_and_finance";
+category "facts";
+attribution github => ['https://github.com/brianrisk','Brian Risk'],
+            email => ['brian@geneffects.com','Brian Risk'],
+            web => ["https://www.geneffects.com", "Geneffects"],
+            twitter => "brianrisk";
+            
+# Note: adding sites to this spice is easy.
+# The fiel 'share/spice/articles/sites.yml' contains the list
+# of trigger words (the names of the sites) and the location 
+# of their Atom/RSS feed.
+my $site_hash = LoadFile(share('sites.yml')); 
+
+# triggers sorted by length so more specific is used first
+my @site_keys = sort { length $b <=> length $a } keys($site_hash);
+my $site_qr = join "|", @site_keys;
+
+# defining our triggers
+triggers any => @site_keys;
+
+# set spice parameters
+spice to => 'https://ajax.googleapis.com/ajax/services/feed/load?v=2.0&q=$1&num=10';
+spice wrap_jsonp_callback => 1;
+spice proxy_cache_valid => "418 1d";
+
+handle sub {
+
+    my $query = lc $_;
+    
+    # find which blog name was used
+    return unless $query =~ m/\b($site_qr)\b/;
+    my $site = $1;
+    
+    # returning the URL of the Atom/RSS
+    return $site_hash->{$site};
+    
+};
+
+1;

--- a/lib/DDG/Spice/Articles.pm
+++ b/lib/DDG/Spice/Articles.pm
@@ -28,7 +28,7 @@ my @site_keys = sort { length $b <=> length $a } keys($site_hash);
 my $site_qr = join "|", @site_keys;
 
 # defining our triggers
-triggers any => @site_keys;
+triggers start => @site_keys;
 
 # set spice parameters
 spice to => 'https://ajax.googleapis.com/ajax/services/feed/load?v=2.0&q=$1&num=10';

--- a/share/spice/articles/articles.js
+++ b/share/spice/articles/articles.js
@@ -18,11 +18,11 @@
 
         Spice.add({
             id: 'articles',
-            name: 'Articles',
+            name: 'Articles By',
             data: articles,
             meta: {
                 count: articles.length,
-                itemType: 'Articles'
+                itemType: 'Articles By'
             },
             templates: {
                 group: 'text',

--- a/share/spice/articles/articles.js
+++ b/share/spice/articles/articles.js
@@ -1,0 +1,43 @@
+(function (env) {
+    "use strict";
+    env.ddg_spice_articles = function (api_result) {
+        
+        if (!api_result) {
+            Spice.failed('articles');
+        }
+        
+        if (api_result.error) {
+            Spice.failed('articles');
+        }
+        
+        var articles = api_result.responseData.feed.entries;
+        
+        if (articles.length == 0) {
+            Spice.failed('articles');
+        }
+
+        Spice.add({
+            id: 'articles',
+            name: 'Articles',
+            data: articles,
+            meta: {
+                count: articles.length,
+                itemType: 'Articles'
+            },
+            templates: {
+                group: 'text',
+                detail: false,
+                item_detail: false,
+            },
+            normalize: function(item) {
+                return {
+                    title: item.name,
+                    subtitle: item.publishedDate,
+                    url: item.link,
+                    description: item.contentSnippet
+                };
+            },
+        });
+    }
+}(this));
+

--- a/share/spice/articles/sites.yml
+++ b/share/spice/articles/sites.yml
@@ -1,0 +1,8 @@
+engadget: http://www.engadget.com/rss.xml
+huffington: http://www.huffingtonpost.com/feeds/original_posts/index.xml
+msnbc: http://rss.msnbc.msn.com/id/3032091/device/rss/rss.xml
+nyt: http://www.nytimes.com/services/xml/rss/nyt/HomePage.xml
+the times: http://www.nytimes.com/services/xml/rss/nyt/HomePage.xml
+new york times: http://www.nytimes.com/services/xml/rss/nyt/HomePage.xml
+bbc: http://feeds.bbci.co.uk/news/rss.xml
+boingboing: http://boingboing.net/feed

--- a/share/spice/articles/sites.yml
+++ b/share/spice/articles/sites.yml
@@ -1,3 +1,4 @@
+# news sites
 engadget: http://www.engadget.com/rss.xml
 huffington: http://www.huffingtonpost.com/feeds/original_posts/index.xml
 msnbc: http://rss.msnbc.msn.com/id/3032091/device/rss/rss.xml
@@ -6,3 +7,20 @@ the times: http://www.nytimes.com/services/xml/rss/nyt/HomePage.xml
 new york times: http://www.nytimes.com/services/xml/rss/nyt/HomePage.xml
 bbc: http://feeds.bbci.co.uk/news/rss.xml
 boingboing: http://boingboing.net/feed
+538: http://fivethirtyeight.com/features/feed/
+fivethirtyeight: http://fivethirtyeight.com/features/feed/
+
+# companies
+microsoft: http://blogs.microsoft.com/feed/
+apple: https://www.apple.com/main/rss/hotnews/hotnews.rss
+google: http://googleblog.blogspot.com/atom.xml
+wal-mart: http://corporate.walmart.com/_news_/rss/blog-posts
+walmart: http://corporate.walmart.com/_news_/rss/blog-posts
+samsung: http://feeds.feedburner.com/SamsungVillage
+toyota: http://blog.toyota.co.uk/feed
+coke: http://www.coca-colacompany.com/feeds/articles
+coca-cola: http://www.coca-colacompany.com/feeds/articles
+mcdonalds: http://www.aboutmcdonalds.com/rss/mcd/rss_amazing_stories.xml
+
+# people
+nate silver: http://fivethirtyeight.com/contributors/nate-silver/feed/

--- a/share/spice/articles/sites.yml
+++ b/share/spice/articles/sites.yml
@@ -10,17 +10,5 @@ boingboing: http://boingboing.net/feed
 538: http://fivethirtyeight.com/features/feed/
 fivethirtyeight: http://fivethirtyeight.com/features/feed/
 
-# companies
-microsoft: http://blogs.microsoft.com/feed/
-apple: https://www.apple.com/main/rss/hotnews/hotnews.rss
-google: http://googleblog.blogspot.com/atom.xml
-wal-mart: http://corporate.walmart.com/_news_/rss/blog-posts
-walmart: http://corporate.walmart.com/_news_/rss/blog-posts
-samsung: http://feeds.feedburner.com/SamsungVillage
-toyota: http://blog.toyota.co.uk/feed
-coke: http://www.coca-colacompany.com/feeds/articles
-coca-cola: http://www.coca-colacompany.com/feeds/articles
-mcdonalds: http://www.aboutmcdonalds.com/rss/mcd/rss_amazing_stories.xml
-
 # people
 nate silver: http://fivethirtyeight.com/contributors/nate-silver/feed/


### PR DESCRIPTION
New IA triggered by names of popular news sites.  The spice fetches the most recent articles from the site's RSS feed and displays as items.  Example triggers:
* engadget
* huffington
* nyt