### PR TITLE
Rhymes: verify api_result exists before checking length

### DIFF
--- a/share/spice/rhymes/rhymes.js
+++ b/share/spice/rhymes/rhymes.js
@@ -5,7 +5,7 @@
         var query = DDG.get_query()
         .replace(/^(what|rhymes?( with| for)?) |\?/gi, "");
 
-        if (!api_result.length) {
+        if (!(api_result && api_result.length)) {
             return Spice.failed('rhymes');
         }
 


### PR DESCRIPTION
API was down this morning and was causing console errors as `api_result.lenth` can't be called when `api_result` doesn't exist

/cc @jagtalon  @bsstoner 