### PR TITLE
Widen flights window

### DIFF
--- a/lib/DDG/Spice/Airlines.pm
+++ b/lib/DDG/Spice/Airlines.pm
@@ -64,12 +64,9 @@ handle query_lc => sub {
 
     my $query = $_;
 
-    # get the current time, minus six hours
-    # the API requires a date/time, and this allows us to search for all flights that 
-    # arrived six hours prior to the current time and flights that will arrive up to
-    # 18 hours ahead of the current time
+    # get the current time
     my ($second, $minute, $hour, $dayOfMonth,
-        $month, $year, $dayOfWeek, $dayOfYear, $daylightSavings) = gmtime(time - 21600);
+        $month, $year, $dayOfWeek, $dayOfYear, $daylightSavings) = gmtime(time);
                 
     $month += 1;
     $year += 1900;

--- a/lib/DDG/Spice/Airlines.pm
+++ b/lib/DDG/Spice/Airlines.pm
@@ -21,8 +21,8 @@ spice to => 'https://api.flightstats.com/flex/flightstatus/rest/v2/jsonp/flight/
 spice from => '(.*)/(.*)/(.*)/(.*)/(.*)/(.*)';
 spice proxy_cache_valid => '418 1d';
 
-triggers any => '///***never trigger***///';
-# triggers query_lc => qr/^(\d+)\s+(.*?)(?:[ ]air.*?)?$|^(.*?)(?:[ ]air.*?)?\s+(\d+)$/;
+# triggers any => '///***never trigger***///';
+triggers query_lc => qr/^(\d+)\s+(.*?)(?:[ ]air.*?)?$|^(.*?)(?:[ ]air.*?)?\s+(\d+)$/;
 
 # Get the list of airlines and strip out the words.
 my %airlines = ();

--- a/lib/DDG/Spice/Airlines.pm
+++ b/lib/DDG/Spice/Airlines.pm
@@ -21,8 +21,8 @@ spice to => 'https://api.flightstats.com/flex/flightstatus/rest/v2/jsonp/flight/
 spice from => '(.*)/(.*)/(.*)/(.*)/(.*)/(.*)';
 spice proxy_cache_valid => '418 1d';
 
-# triggers any => '///***never trigger***///';
-triggers query_lc => qr/^(\d+)\s+(.*?)(?:[ ]air.*?)?$|^(.*?)(?:[ ]air.*?)?\s+(\d+)$/;
+triggers any => '///***never trigger***///';
+# triggers query_lc => qr/^(\d+)\s+(.*?)(?:[ ]air.*?)?$|^(.*?)(?:[ ]air.*?)?\s+(\d+)$/;
 
 # Get the list of airlines and strip out the words.
 my %airlines = ();

--- a/share/spice/airlines/airlines.js
+++ b/share/spice/airlines/airlines.js
@@ -60,8 +60,8 @@
         var callParameters = decodeURIComponent(source).split('/');
         
         // determine the original date that we made an upstream request
-        var apiRequestDayOfMonth = callParameters[8];
-        var apiRequestHour = callParameters[9];
+        var originalRequestDayOfMonth = callParameters[8];
+        var originalRequestHour = callParameters[9];
 
         // for every API request, we make an additional request to 
         // grab results for late-night arrivals from the night before and 
@@ -71,16 +71,16 @@
         var apiResponseDate = new Date(Date.UTC(api_result.request.date.year,
                                        api_result.request.date.month-1,
                                        api_result.request.date.day,
-                                       apiRequestHour, 0, 0));
+                                       originalRequestHour, 0, 0));
 
         // if this response is for the original same-day request...
-        if (apiRequestDayOfMonth == apiResponseDate.getUTCDate()) {
+        if (originalRequestDayOfMonth == apiResponseDate.getUTCDate()) {
 
             var apiRequestDate;
 
             //  and the current hour is before 4AM, get the previous day's flights as well
             //  (so we can show arrivals for late-night flights)
-            if (apiRequestHour < 4) {
+            if (originalRequestHour < 4) {
                 apiRequestDate = new Date(apiResponseDate.getTime() - 24 * 60 * 60 * 1000);    
 
             // otherwise, get the next day's flights so that we have at least
@@ -99,7 +99,7 @@
                     + apiRequestDate.getUTCFullYear() + "/"
                     + (apiRequestDate.getUTCMonth()+1) + "/"
                     + apiRequestDate.getUTCDate() + "/"
-                    + apiRequestHour);
+                    + originalRequestHour);
         }
 
         env.ddg_spice_airlines.display(api_result);

--- a/share/spice/airlines/airlines.js
+++ b/share/spice/airlines/airlines.js
@@ -49,43 +49,57 @@
 
     env.ddg_spice_airlines = function(api_result) {
 
-        // Check if we have anything returned.
+        // Check if FlightStats returned anything
         if (!api_result || !api_result.flightStatuses || !api_result.appendix || !api_result.appendix.airlines) {
             return;
         }
 
-        // determine the original date that we made an upstream request for
-        var script = $('[src*="/js/spice/airlines/"]')[0],
-            source = $(script).attr("src");
-        var decodedSource = decodeURIComponent(source);
-        var callParameters = decodedSource.split('/');
+        // extract parameters from the Flightstats request
+        var script = $('[src*="/js/spice/airlines/"]')[0];
+        var source = $(script).attr("src");
+        var callParameters = decodeURIComponent(source).split('/');
+        
+        // determine the original date that we made an upstream request
         var apiRequestDayOfMonth = callParameters[8];
         var apiRequestHour = callParameters[9];
 
-        // determine the date of the API response
+        // for every API request, we make an additional request to 
+        // grab results for late-night arrivals from the night before and 
+        // red eyes for the next day (relative to UTC)
+        //
+        // more broadly, this allows us to grab a larger window of flights
         var apiResponseDate = new Date(Date.UTC(api_result.request.date.year,
                                        api_result.request.date.month-1,
                                        api_result.request.date.day,
                                        apiRequestHour, 0, 0));
 
-        // if this response is for the same day, we need to also get
-        // the next day's worth of arrivals
+        // if this response is for the original same-day request...
         if (apiRequestDayOfMonth == apiResponseDate.getUTCDate()) {
 
-            // increment the request by one day in milliseconds
-            var apiRequestDate = new Date(apiResponseDate.getTime() + 24 * 60 * 60 * 1000);
+            var apiRequestDate;
 
+            //  and the current hour is before 4AM, get the previous day's flights as well
+            //  (so we can show arrivals for late-night flights)
+            if (apiRequestHour < 4) {
+                apiRequestDate = new Date(apiResponseDate.getTime() - 24 * 60 * 60 * 1000);    
+
+            // otherwise, get the next day's flights so that we have at least
+            // 24 hours worth of flights even as the current day approaches an end
+            } else {
+                apiRequestDate = new Date(apiResponseDate.getTime() + 24 * 60 * 60 * 1000);
+            }
+            
             // prevent AJAX from appending a timestamp to the URL
             $.ajaxSetup({ cache: true });
 
-            // make upstream call
+            // make an additional upstream call 
             $.getScript("/js/spice/airlines/"
                     + callParameters[4] + "/"
                     + callParameters[5] + "/"
                     + apiRequestDate.getUTCFullYear() + "/"
                     + (apiRequestDate.getUTCMonth()+1) + "/"
                     + apiRequestDate.getUTCDate() + "/"
-                    + callParameters[9]);
+                    + apiRequestHour);
         }
 
         env.ddg_spice_airlines.display(api_result);
@@ -129,6 +143,26 @@
 
         // package up the flights into the result array
         for (var i = 0; i < flight.length; i++) {
+
+            // if this flight arrived more than 3 hours ago, do not add it
+            if (flight[i].operationalTimes.actualGateArrival) {
+
+                var arrivalTime = new Date(flight[i].operationalTimes.actualGateArrival.dateUtc);
+
+                if (Date.now() - arrivalTime.getTime() > 3 * 60 * 60 * 1000) {
+                    continue;
+                }
+            }
+
+            // if this flight is departing more than 24 hours into the future, do not add it
+            if (flight[i].operationalTimes.scheduledGateDeparture) {
+
+                var departureTime = new Date(flight[i].operationalTimes.scheduledGateDeparture.dateUtc);
+                
+                if (departureTime.getTime() - Date.now() > 24 * 60 * 60 * 1000) {
+                    continue;
+                }
+            }
 
             var airlineName = dictFlightStats[flight[i].carrierFsCode].name;
             var airlineCode = flight[i].carrierFsCode;
@@ -210,9 +244,6 @@
                     isDeparted: false
                 };
 
-            if (!flight[i].operationalTimes.actualGateArrival 
-                    || (Date.now() - Date(flight[i].operationalTimes.actualGateArrival.dateUTC) < 3 * 60 * 60 * 1000)) {
-
             results.push({
                 flight: flight[i],
                 airlineName: airlineName,
@@ -225,7 +256,6 @@
                 scheduledDepartureDate: scheduledDepartureDate,
                 scheduledArrivalDate: scheduledArrivalDate
             });
-            }
         }
 
         if (results.length === 0) {

--- a/share/spice/airlines/airlines.js
+++ b/share/spice/airlines/airlines.js
@@ -78,9 +78,9 @@
 
             var apiRequestDate;
 
-            //  and the current hour is before 4AM, get the previous day's flights as well
+            //  and the current hour is before 3AM, get the previous day's flights as well
             //  (so we can show arrivals for late-night flights)
-            if (originalRequestHour < 4) {
+            if (originalRequestHour < 3) {
                 apiRequestDate = new Date(apiResponseDate.getTime() - 24 * 60 * 60 * 1000);    
 
             // otherwise, get the next day's flights so that we have at least

--- a/share/spice/flights/route/flights_route.js
+++ b/share/spice/flights/route/flights_route.js
@@ -225,7 +225,6 @@
                 data: results,
                 id: "route",
                 name: "Route",
-                allowMultipleCalls: true,
                 meta: {
                     minItemsForModeSwitch: 3,
                     sourceName: 'FlightStats',

--- a/share/spice/flights/route/flights_route.js
+++ b/share/spice/flights/route/flights_route.js
@@ -225,6 +225,7 @@
                 data: results,
                 id: "route",
                 name: "Route",
+                allowMultipleCalls: true,
                 meta: {
                     minItemsForModeSwitch: 3,
                     sourceName: 'FlightStats',


### PR DESCRIPTION
Re: #2000

Stop-gap fix to address the missing flights by making an additional request for either the prior day or the next day depending on the UTC time. I also added some heuristic changes to suppress flights that arrived more than three hours in the past, as well as flights that have scheduled departures more than 24 hours into the future. I would like to merge a fix for this issue first, and then do a second round where we clean up flights by route.