### PR TITLE
Remove z-indexes from currency + people in space

### DIFF
--- a/share/spice/currency/currency.css
+++ b/share/spice/currency/currency.css
@@ -54,7 +54,6 @@
 .zci--currency .tile--s img {
     height: 32px;
     vertical-align: top;
-    z-index: 2;
     position: relative;
 }
 

--- a/share/spice/people_in_space/people_in_space.css
+++ b/share/spice/people_in_space/people_in_space.css
@@ -65,7 +65,6 @@
     position: absolute;
     height: 32px;
     width: 32px;
-    z-index: 1000;
     top: 86px;
     left: 95px;
 }


### PR DESCRIPTION
@moollaza @jagtalon 

Is causing issues with attribution and doesn't seem necessary:

![o337ol5hmxpiwjkdzq4v1kglsirit_ifhbmv9lcz4x0](https://cloud.githubusercontent.com/assets/126358/8862723/b9b6bd86-3160-11e5-89a6-485322644a10.png)

cc @sdougbrown @malbin 