### PR TITLE
Twitch: Remove minItemsForModeSwitch

### DIFF
--- a/share/spice/twitch/featured/twitch_featured.js
+++ b/share/spice/twitch/featured/twitch_featured.js
@@ -7,7 +7,6 @@
         }
         
         Spice.add({
-            minItemsForModeSwitch: 3,
             id: "twitch_featured",
             name: "Gaming",
             data: api_result.featured,

--- a/share/spice/twitch/streams/twitch_streams.js
+++ b/share/spice/twitch/streams/twitch_streams.js
@@ -14,7 +14,6 @@
             moreAt = decodedQuery.replace(/ /g,"+");
         
         Spice.add({
-            minItemsForModeSwitch: 3,
             id: "twitch_streams",
             name: "Gaming",
             data: api_result.streams,


### PR DESCRIPTION
There doesn't seem to be any reason to show 3 items in a grid so it's probably best to remove this. Removing this will use the default instead which is 12 items.