### PR TITLE
Write to STDOUT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ language: perl
 perl:
   - '5.16'
 script:
-  - dzil smoke --release --author 2> /dev/null
+  - dzil smoke --release --author


### PR DESCRIPTION
Supresses the output also means that failed tests don't show the reason for failure in Travis making it impossible to figure out the cause of the problem when looking at the failed Travis tests.

We've already done this to Goodies.

to @zachthompson 