### PR TITLE
First implementation of Citi Bike NYC Bike Sharing IA

### DIFF
--- a/lib/DDG/Spice/BikeSharing/CitiBikeNYC.pm
+++ b/lib/DDG/Spice/BikeSharing/CitiBikeNYC.pm
@@ -1,0 +1,31 @@
+package DDG::Spice::BikeSharing::CitiBikeNYC;
+
+use strict;
+use DDG::Spice;
+
+name 'Citi Bike NYC';
+source 'Citi Bike NYC';
+icon_url 'http://www.citibikenyc.com/assets/images/favicon.ico';
+description 'Search Citi Bike stations in New York City';
+primary_example_queries 'citibike nyc', 'citi bike ny';
+secondary_example_queries 'citibike stations near brooklyn';
+category 'geography';
+topics 'everyday', 'travel', 'entertainment', 'geography';
+code_url 'https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/BikeSharing/CitiBikeNYC.pm';
+attribution github => 'marianosimone',
+            web  => ['http://www.marianosimone.com',  'Mariano Simone'];
+
+triggers any => 'citibike', 'citi bike', 'bike sharing', 'bike share';
+
+spice to => 'https://www.citibikenyc.com/stations/json';
+spice wrap_jsonp_callback => 1;
+spice is_cached => 0;
+spice proxy_cache_valid => '200 304 15m';
+
+handle remainder => sub {
+    $loc->city.' '.$_ =~ /(ny|new york|nyc|new york city|brooklyn|manhattan|queens)/i;
+    return unless $1;
+    return $1;
+};
+
+1;

--- a/share/spice/bike_sharing/citi_bike_nyc/bike_sharing_citi_bike_nyc.css
+++ b/share/spice/bike_sharing/citi_bike_nyc/bike_sharing_citi_bike_nyc.css
@@ -1,0 +1,32 @@
+.tile--citi_bike_nyc {
+    text-align: center;
+    height: 12em;
+}
+
+.tile--citi_bike_nyc .zci__header {
+    height: 2.5em;
+}
+
+.tile--citi_bike_nyc .side_by_side {
+    overflow: auto;
+    margin-left: auto;
+    margin-right: auto;
+    width: 100%;
+}
+
+.tile--citi_bike_nyc .side_by_side .left {
+    float: left;
+    border-right: 1px solid #E5E5E5;
+}
+
+.is-mobile .tile--citi_bike_nyc .side_by_side .left {
+    width: 50%;
+}
+
+.tile--citi_bike_nyc .side_by_side .right {
+    float: right;
+}
+
+.is-mobile .tile--citi_bike_nyc .side_by_side .right {
+    width: 50%;
+}

--- a/share/spice/bike_sharing/citi_bike_nyc/bike_sharing_citi_bike_nyc.js
+++ b/share/spice/bike_sharing/citi_bike_nyc/bike_sharing_citi_bike_nyc.js
@@ -27,6 +27,23 @@
 
         DDG.require('moment.js', function() {
             DDG.require('maps', function() {
+                moment.locale('en', {
+                    relativeTime : {
+                        past:   "%s ago",
+                        s:    "a sec",
+                        ss:   "%d sec",
+                        m:    "a min",
+                        mm:   "%d min",
+                        h:    "an hour",
+                        hh:   "%d hours",
+                        d:    "a day",
+                        dd:   "%d days",
+                        M:    "a month",
+                        MM:   "%d months",
+                        y:    "a year",
+                        yy:   "%d years"
+                    }
+                });
                 Spice.add({
                     id: 'citi_bike_nyc',
                     name: 'Citi Bike NYC',

--- a/share/spice/bike_sharing/citi_bike_nyc/bike_sharing_citi_bike_nyc.js
+++ b/share/spice/bike_sharing/citi_bike_nyc/bike_sharing_citi_bike_nyc.js
@@ -1,0 +1,78 @@
+(function(env) {
+    "use strict";
+
+    var references = {
+        manhattan: {
+            lat: 40.7590615,
+            lon: -73.969231
+        },
+        brooklyn: {
+            lat: 40.645244,
+            lon: -73.9449975
+        },
+        queens: {
+            lat: 40.651018,
+            lon: -73.87119
+        }
+    };
+
+    env.ddg_spice_bike_sharing_citi_bike_nyc = function(api_result) {
+        if (!api_result || !api_result.stationBeanList) {
+            return Spice.failed('citi_bike_nyc');
+        }
+
+        var script = $('[src*="/js/spice/bike_sharing/citi_bike_nyc/"]')[0],
+            source = $(script).attr("src"),
+            query = source.match(/citi_bike_nyc\/([^\/]+)/)[1];
+
+        DDG.require('moment.js', function() {
+            DDG.require('maps', function() {
+                Spice.add({
+                    id: 'citi_bike_nyc',
+                    name: 'Citi Bike NYC',
+                    meta: {
+                        sourceName: 'Citi Bike NYC',
+                        sourceUrl: 'https://www.citibikenyc.com/stations',
+                        itemType: 'Bike Stations'
+                    },
+                    model: 'Place',
+                    view: 'Places',
+                    templates: {
+                        item: 'base_item',
+                        options: {
+                            content: Spice.bike_sharing_citi_bike_nyc.content
+                        },
+                        variants: {
+                            tile: 'narrow'
+                        }
+                    },
+                    sort_fields: {
+                        distance: function(a, b) {
+                            return a.distanceToReference - b.distanceToReference;
+                        }
+                    },
+                    sort_default: 'distance',
+                    data: api_result.stationBeanList,
+                    normalize: function(item) {
+                        if (item.testStation || item.statusKey != 1) {
+                            return null;
+                        }
+                        if (references[query]) {
+                            var pointOfReference = L.latLng(references[query]);
+                        }
+                        return {
+                            name: item.stationName,
+                            lat: item.latitude,
+                            lon: item.longitude,
+                            distanceToReference: pointOfReference ? L.latLng(item.latitude, item.longitude).distanceTo(pointOfReference) : item.id,
+                            title: item.stationName,
+                            availableDocks: item.availableDocks,
+                            availableBikes: item.availableBikes,
+                            lastCommunication: moment(new Date(item.lastCommunicationTime)).fromNow()
+                        };
+                    }
+                });
+            });
+        });
+    }
+}(this));

--- a/share/spice/bike_sharing/citi_bike_nyc/bike_sharing_citi_bike_nyc.js
+++ b/share/spice/bike_sharing/citi_bike_nyc/bike_sharing_citi_bike_nyc.js
@@ -50,7 +50,9 @@
                     meta: {
                         sourceName: 'Citi Bike NYC',
                         sourceUrl: 'https://www.citibikenyc.com/stations',
-                        itemType: 'Bike Stations'
+                        itemType: 'Bike Stations',
+                        pinIcon: 'ddgsi-circle',
+                        pinIconSelected: 'ddgsi-star'
                     },
                     model: 'Place',
                     view: 'Places',

--- a/share/spice/bike_sharing/citi_bike_nyc/content.handlebars
+++ b/share/spice/bike_sharing/citi_bike_nyc/content.handlebars
@@ -1,0 +1,15 @@
+<div class="tile__body">
+    <h1 class="zci__header tx--l7">{{title}}</h1>
+    <div class="tile__content side_by_side">
+        <div class="left half">
+            <p class="tx-clr--dk">Bikes</p><br/><p class='tx-clr--dk t-xxl'>{{availableBikes}}</p>
+        </div>
+
+        <div class="right half">
+            <p class="tx-clr--dk">Docks</p><br/><p class='tx-clr--dk t-xxl'>{{availableDocks}}</p>
+        </div>
+    </div>
+    <div class="tile__foot ">
+        <span class="tx--12 tx-clr--grey">Updated {{lastCommunication}}</span>
+    </div>
+</div>

--- a/t/BikeSharingCitiBikeNYC.t
+++ b/t/BikeSharingCitiBikeNYC.t
@@ -1,0 +1,26 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+ddg_spice_test(
+    [qw( DDG::Spice::BikeSharing::CitiBikeNYC )],
+    'citi bike ny' => test_spice(
+        '/js/spice/bike_sharing/citi_bike_nyc/ny',
+        call_type => 'include',
+        caller => 'DDG::Spice::BikeSharing::CitiBikeNYC',
+    is_cached => 0,
+    ),
+    'citibike stations near brooklyn' => test_spice(
+        '/js/spice/bike_sharing/citi_bike_nyc/brooklyn',
+        call_type => 'include',
+        caller => 'DDG::Spice::BikeSharing::CitiBikeNYC',
+    is_cached => 0,
+    ),
+    'citibike' => undef,
+    'citibike washington' => undef,
+);
+
+done_testing;


### PR DESCRIPTION
# CitiBike NYC Bike Sharing Stations

**What does your Instant Answer do?**

Show stations of the Citi Bike Bike Sharing Program (in NY), along with information about bike and docks availability.

This is a way to bring into DDG the functionality of the [official map](https://member.citibikenyc.com/map/), and it's useful for both tourists (to discover stations) and NYC citizens (to know current status)

**Data Source**

The data source is the [official Citi Bike API](https://www.citibikenyc.com/stations/json), and its policy can be found [here](http://www.citibikenyc.com/data-sharing-policy)

**What are some example queries that trigger this Instant Answer?**

```
citibike ny
citi bike nyc
citi bike ny stations
bike sharing brooklyn
```
**What does the Instant Answer look like?**

![citibike_brooklyn_at_duckduckgo](https://cloud.githubusercontent.com/assets/104916/9470658/f1a8bd56-4b1a-11e5-9155-fba917e2a587.png)

## Checklist

```
[X] Added metadata and attribution information
[X] Wrote test file and added to t/ directory
[X] Verified that instant answer adheres to design guidelines (https://duck.co/duckduckhack/design_styleguide)
[X] Verified that instant answer adheres to code styleguide (https://duck.co/duckduckhack/code_styleguide)
[X] Tested cross-browser compatibility

    Please let us know which browsers/devices you've tested on:
    - Windows 8
        [X] Google Chrome
        [X] Firefox
        [] Opera
        [] IE 10

    - Windows 7
        [] Google Chrome
        [] Firefox
        [] Opera
        [] IE 8
        [] IE 9
        [] IE 10

    - Windows XP
        [] IE 8

    - Mac OSX
        [X] Google Chrome
        [] Firefox
        [] Opera
        [] Safari

    - iOS (iPhone)
        [] Safari Mobile
        [] Google Chrome
        [] Opera

    - iOS (iPad)
        [] Safari Mobile
        [] Google Chrome
        [] Opera

    - Android
        [] Firefox
        [] Native Browser
        [] Google Chrome
        [] Opera
```

-----
IA Page: https://duck.co/ia/view/citi_bike_nyc