### PR TITLE
Remove unnecessary CSS

### DIFF
--- a/share/spice/dogo_news/dogo_news.css
+++ b/share/spice/dogo_news/dogo_news.css
@@ -1,3 +1,0 @@
-.zci--dogo_news .tile--dogo_news .tile__foot {
-    padding-bottom: 0.2em;
-}


### PR DESCRIPTION
No longer needed, seems to breaking footer padding.

Result:
![dogo_news_at_duckduckgo](https://cloud.githubusercontent.com/assets/873785/9076297/bc48b670-3aee-11e5-8a86-43ee25fba245.png)

/cc @abeyang 