### PR TITLE
Fixing minor css issues (Issue #2072)

### DIFF
--- a/share/spice/dogo_news/dogo_news.css
+++ b/share/spice/dogo_news/dogo_news.css
@@ -1,3 +1,7 @@
-.zci--dogo_news .tile--dogo_news .tile__foot {
-    padding-bottom: 0.2em;
+.zci--dogo_news .tile__title {
+    margin-bottom: 0.5em;
+}
+
+.zci--dogo_news .has-foot .tile__content--lg {
+    height: 6.2em;   
 }


### PR DESCRIPTION
Fixed the minor css issues mentioned in issue #2072.  We removed our custom ```.tile__foot``` css in order to rely on the default footer css.

-----
IA Page: https://duck.co/ia/view/dogo_news