### PR TITLE
Lastfm - added relevancy block, stop words and tests

### DIFF
--- a/lib/DDG/Spice/Lastfm/Artist.pm
+++ b/lib/DDG/Spice/Lastfm/Artist.pm
@@ -26,6 +26,10 @@ triggers any => 'similar', 'band', 'bands', 'musician', 'musicians', 'artist', '
 handle query_lc => sub {
     my $synonyms = "bands?|musicians?|players?|artists?|performers?|singers?|rappers?|djs?|vocalists?|songsters?";
 
+    #Ignore Queries like "apple watch bands"
+    if(m{watch\ bands?}) {
+        return;
+    }
     #Queries like "bands similar to incubus" or "artists similar ben folds"
     if(m{(?:$synonyms)\s+similar\s+(?:to\s+)?(\S+(?:\s+\S+)*)}) {
         return $1, 'similar';

--- a/lib/DDG/Spice/Lastfm/Artist.pm
+++ b/lib/DDG/Spice/Lastfm/Artist.pm
@@ -19,28 +19,19 @@ attribution github => ['https://github.com/jagtalon','Jag Talon'],
 spice to => 'http://ws.audioscrobbler.com/2.0/?format=json&method=artist.getinfo&artist=$1&autocorrect=1&api_key={{ENV{DDG_SPICE_LASTFM_APIKEY}}}&callback={{callback}}_$2';
 spice from => '(?:([^/]*)/([^/]*)|)';
 
-triggers any => 'similar', 'band', 'bands', 'musician', 'musicians', 'artist', 'artists', 'performer', 'performers', 'singer', 'singers', 'rapper', 'dj', 'rappers', 'vocalist', 'vocalists', 'djs', 'songster', 'songsters';
+triggers any => 'band', 'bands', 'musician', 'musicians', 'artist', 'artists', 'performer', 'performers', 'singer', 'singers', 'rapper', 'dj', 'rappers', 'vocalist', 'vocalists', 'djs', 'songster', 'songsters';
 
 
 
 handle query_lc => sub {
     my $synonyms = "bands?|musicians?|players?|artists?|performers?|singers?|rappers?|djs?|vocalists?|songsters?";
 
+    # ignoring queries that has 'similar' in them
+    return if $_ =~ m/\bsimilar\b/;
+
     #Ignore Queries like "apple watch bands"
     if(m{watch\ bands?}) {
         return;
-    }
-    #Queries like "bands similar to incubus" or "artists similar ben folds"
-    if(m{(?:$synonyms)\s+similar\s+(?:to\s+)?(\S+(?:\s+\S+)*)}) {
-        return $1, 'similar';
-    }
-    #Queries like "similar bands to incubus" or "similar artists ben folds"
-    if(m{similar\s+(?:$synonyms)\s+(?:to\s+)?(\S+(?:\s+\S+)*)}) {
-        return $1, 'similar';
-    }
-    #Queries like "30 seconds to mars similar bands" or "ben folds similar musicians"
-    if(m{(\S+(?:\s+\S+)*)\s+similar\s+(?:$synonyms)}) {
-        return $1, 'similar';
     }
     #Queries like "weezer band"
     if(m{(\S+(?:\s+\S+)*)\s+(?:$synonyms)$}) {

--- a/share/spice/lastfm/artist/lastfm_artist.js
+++ b/share/spice/lastfm/artist/lastfm_artist.js
@@ -19,6 +19,11 @@
                     title: item.name
                 };
             },
+            relevancy: {
+                primary: [
+                    { required: 'bio.summary' },
+                ]
+            },
             templates: {
                 group: 'info',
                 options: {

--- a/t/LastfmArtist.t
+++ b/t/LastfmArtist.t
@@ -9,21 +9,6 @@ ddg_spice_test(
     [
         'DDG::Spice::Lastfm::Artist'
     ],
-    'bands similar to incubus' => test_spice(
-        '/js/spice/lastfm/artist/incubus/similar',
-        call_type => 'include',
-        caller => 'DDG::Spice::Lastfm::Artist',
-    ),
-    'similar artists ben folds' => test_spice(
-        '/js/spice/lastfm/artist/ben%20folds/similar',
-        call_type => 'include',
-        caller => 'DDG::Spice::Lastfm::Artist',
-    ),
-    '30 seconds to mars similar bands' => test_spice(
-        '/js/spice/lastfm/artist/30%20seconds%20to%20mars/similar',
-        call_type => 'include',
-        caller => 'DDG::Spice::Lastfm::Artist',
-    ),
     'weezer band' => test_spice(
         '/js/spice/lastfm/artist/weezer/all',
         call_type => 'include',
@@ -34,6 +19,12 @@ ddg_spice_test(
         call_type => 'include',
         caller => 'DDG::Spice::Lastfm::Artist',
     ),
+
+    # have to implement the front-end method for these to work
+    # needed method - ddg_spice_lastfm_artist_similar
+    'bands similar to incubus' => undef,
+    'similar artists ben folds' => undef,
+    '30 seconds to mars similar bands' => undef,
 
     'watch band' => undef,
     'apple watch bands' => undef,

--- a/t/LastfmArtist.t
+++ b/t/LastfmArtist.t
@@ -1,0 +1,43 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+ddg_spice_test(
+    [
+        'DDG::Spice::Lastfm::Artist'
+    ],
+    'bands similar to incubus' => test_spice(
+        '/js/spice/lastfm/artist/incubus/similar',
+        call_type => 'include',
+        caller => 'DDG::Spice::Lastfm::Artist',
+    ),
+    'similar artists ben folds' => test_spice(
+        '/js/spice/lastfm/artist/ben%20folds/similar',
+        call_type => 'include',
+        caller => 'DDG::Spice::Lastfm::Artist',
+    ),
+    '30 seconds to mars similar bands' => test_spice(
+        '/js/spice/lastfm/artist/30%20seconds%20to%20mars/similar',
+        call_type => 'include',
+        caller => 'DDG::Spice::Lastfm::Artist',
+    ),
+    'weezer band' => test_spice(
+        '/js/spice/lastfm/artist/weezer/all',
+        call_type => 'include',
+        caller => 'DDG::Spice::Lastfm::Artist',
+    ),
+    'artist kanye west' => test_spice(
+        '/js/spice/lastfm/artist/kanye%20west/all',
+        call_type => 'include',
+        caller => 'DDG::Spice::Lastfm::Artist',
+    ),
+
+    'watch band' => undef,
+    'apple watch bands' => undef,
+    'android wear watch bands' => undef,
+);
+
+done_testing;


### PR DESCRIPTION
Fixes #2050.

 - Added relevancy block to ensure that artist description is available
 - Added stop words `/watch bands?/`
 - Added tests, there were none.

**Bug Found:** While the spice has code for showing similar artists, it doesn't implement the method to show them. `ddg_spice_lastfm_artist_similar` callback method is called for any `similar artist` queries, but it's not implemented. Hence the query fails with a JS error. 

    Uncaught ReferenceError: ddg_spice_lastfm_artist_similar is not defined

/cc @jagtalon: Am I missing something?