### PR TITLE
Add guard for empty lastfm response

### DIFF
--- a/share/spice/lastfm/artist/lastfm_artist.js
+++ b/share/spice/lastfm/artist/lastfm_artist.js
@@ -2,6 +2,8 @@
     "use strict";
 
     env.ddg_spice_lastfm_artist_all = function(api_result) {
+        if (!api_result || !api_result.artist || !api_result.artist.url) { return; }
+
         Spice.add({
             id: 'lastfm_artist',
             name: 'Music',
@@ -33,6 +35,8 @@
     };
 
     env.ddg_spice_lastfm_artist_tracks = function(api_result) {
+        if (!api_result || !api_result.toptracks || !api_result.toptracks.track) { return; }
+
         var songs = [];
         // TODO: Use a template for this
         for(var i = 0; i < api_result.toptracks.track.length; i++) {


### PR DESCRIPTION
Guard against empty/bad api responses from last.fm

<img width="1000" alt="screen shot 2015-08-13 at 8 47 44 am" src="https://cloud.githubusercontent.com/assets/126358/9250029/0012db24-4198-11e5-98de-ae47672db0ff.png">

@moollaza @russellholt 