### PR TITLE
Parking: Reduce results array to 30 elements to increase page load speed

### DIFF
--- a/share/spice/parking/parking.js
+++ b/share/spice/parking/parking.js
@@ -1,25 +1,25 @@
 (function (env) {
     "use strict";
-    
+
     var userLanguage = navigator.languages || // New (experimental)
         navigator.systemLanguage || // IE
-        navigator.language;    // Old    
-    
-    var canUseIntl = (  
-        window.Intl && 
+        navigator.language;    // Old
+
+    var canUseIntl = (
+        window.Intl &&
         window.Intl.NumberFormat && // Check if Intl.NumberFormat exists
         // and test for issues like https://code.google.com/p/chromium/issues/detail?id=370849
         Intl.NumberFormat('en-us',{ style: 'currency', currency: 'USD' }).format(1) !==
-        Intl.NumberFormat('en-us',{ style: 'currency', currency: 'CAD' }).format(1));    
-    
+        Intl.NumberFormat('en-us',{ style: 'currency', currency: 'CAD' }).format(1));
+
     // item.price is an unformatted decimal number
     // item.currencyFormatted is an ISO 4217 currency code
-    // attempt to use Intl.NumberFormat to generate a localized price 
+    // attempt to use Intl.NumberFormat to generate a localized price
     // otherwise make pritty prices for USD and CAD or fallback on the ISO 4217 currency code
-    function priceFormatter(item) { 
+    function priceFormatter(item) {
         if (canUseIntl) {
             return  new Intl.NumberFormat(
-                userLanguage, {   
+                userLanguage, {
                     style: 'currency',
                     currency: item.currencyFormatted,
                     maximumFractionDigits: 2,
@@ -27,44 +27,44 @@
                 .format(item.price);
         } else {
             var prefix = item.currencyFormatted.toUpperCase();
-            
+
             if(prefix === 'USD') {
                 prefix = '$';
             }
             if(prefix === 'CAD'){
                 prefix = 'CA$';
             }
-            
+
             return prefix + parseFloat(item.price).toFixed(2);
-        }      
+        }
     }
-    
+
     function timeFormatter(time){
         // Shorten the times to fit within the tiles
         return time.replace(':00','').replace(' ','').toLocaleLowerCase()
     }
-    
-    
+
+
     env.ddg_spice_parking = function(api_result){
-        
+
         // Check that results were returned successfully
         if (!api_result || !api_result.success || api_result.resultsCount === 0) {
             return Spice.failed('parking');
         }
-        
+
         function normalize(item){
             // Skip unless there's at least one image
             if (!item.images[0]) {
                 return null;
             }
-            
+
             // Get a localized price
             item.price = priceFormatter(item);
-            
+
             var normalizedItem = {
                 name: item.publicName || item.displayName,
-                subtitle: (item.openTime === item.closeTime) ? 
-                    'Open All Day' : 
+                subtitle: (item.openTime === item.closeTime) ?
+                    'Open All Day' :
                     timeFormatter(item.openTime) + ' - ' + timeFormatter(item.closeTime),
                 distance: Math.round(item.distance * 10) / 10 + ' mi',
                 url: item.affiliateUrl,
@@ -72,25 +72,25 @@
                 price: item.price + '+',
                 address_lines: [(item.displayAddress || item.address1), item.cityStateAndPostal]
             };
-            
+
             return normalizedItem;
         }
-        
+
         // Render the response
        DDG.require('maps', function() {
         Spice.add({
             id: 'parking',
             name: 'Parking',
             model: 'Place',
-            view: 'Places',            
+            view: 'Places',
             data: api_result.data.locations,
             meta: {
                 type: 'Parking',
                 primaryText: 'Parking Near: ' + api_result.data.search.displayText,
                 sourceName: 'Parking Panda',
                 sourceUrl: 'https://www.parkingpanda.com/Search/?ref=duckduck&location=' + api_result.data.search.query
-            },            
-            normalize: normalize,            
+            },
+            normalize: normalize,
             templates: {
                 group: 'places',
                 item: 'base_flipping_item',

--- a/share/spice/parking/parking.js
+++ b/share/spice/parking/parking.js
@@ -83,7 +83,7 @@
             name: 'Parking',
             model: 'Place',
             view: 'Places',
-            data: api_result.data.locations,
+            data: api_result.data.locations.splice(0, 30), //take 30 items for now to speed up page load
             meta: {
                 type: 'Parking',
                 primaryText: 'Parking Near: ' + api_result.data.search.displayText,


### PR DESCRIPTION
@AlexCutlipParkingPanda We're noticing that the page is taking too long to load on mobile so I'm fixing like this for now.

As a better solution, can your API return fewer results initially? OR can it take a request parameter that specifies the number of results? Right now it's sending ~140 which is too many. 

/cc @bsstoner @andrey-p 

Live here: https://moollaza.duckduckgo.com/?q=parking+manhattan&ia=parking