### PR TITLE
quandl home values: fixed indiana bug

### DIFF
--- a/share/spice/quandl/home_values/metro.yml
+++ b/share/spice/quandl/home_values/metro.yml
@@ -308,7 +308,6 @@ hudson:	00694
 humboldt:	00448
 huntingdon:	00742
 idaho falls:	00286
-indiana:	00551
 indianapolis:	00035
 indianola:	00927
 iowa city:	00252

--- a/share/spice/quandl/home_values/states.yml
+++ b/share/spice/quandl/home_values/states.yml
@@ -27,7 +27,7 @@ wa:	00013
 massachusetts:	00014
 ma:	00014
 indiana:	00015
-in:	00015
+#in:	00015
 arizona:	00016
 az:	00016
 tennessee:	00017

--- a/t/Quandl.t
+++ b/t/Quandl.t
@@ -73,7 +73,20 @@ ddg_spice_test(
 		call_type => 'include',
 		caller => 'DDG::Spice::Quandl::HomeValues',
 	),
+
+    # make sure "in" does not trigger "Indiana"
+    'home values in new york' => test_spice(
+		'/js/spice/quandl/home_values/S00003_A',
+		call_type => 'include',
+		caller => 'DDG::Spice::Quandl::HomeValues',
+	),
     
+    # make sure "indiana" still triggers
+    'home values in indiana' => test_spice(
+		'/js/spice/quandl/home_values/S00015_A',
+		call_type => 'include',
+		caller => 'DDG::Spice::Quandl::HomeValues',
+	),
     
     # No results for a single region alone
 	'27510' => undef,


### PR DESCRIPTION
The problem was that the abbreviation for "Indiana" is "IN", so "home values in California" was triggering on the "in".