### PR TITLE
AQI: properly fail on an empty array

### DIFF
--- a/share/spice/aqi/aqi.js
+++ b/share/spice/aqi/aqi.js
@@ -1,7 +1,7 @@
 (function(env){
   "use strict";
   env.ddg_spice_aqi = function(api_result) {
-    if (api_result.error || !api_result) {
+    if (!api_result || api_result.length === 0) {
       return Spice.failed('aqi');
     }
 


### PR DESCRIPTION
When testing I noticed that we cause an error when the array is empty (no result). This tests for that and properly calls `Spice.failed`

https://duck.co/ia/view/aqi