### PR TITLE
Dictionary: fix ID bugs

### DIFF
--- a/share/spice/dictionary/definition/dictionary_definition.css
+++ b/share/spice/dictionary/definition/dictionary_definition.css
@@ -1,29 +1,28 @@
-.zci--definition ul {
+.zci--dictionary_definition ul {
     margin-bottom: 0.25em;
     display: table;
 }
 
-.zci--definition ul li {
+.zci--dictionary_definition ul li {
     display: table-row;
 }
 
-.zci--definition .zci__def__definition {
+.zci--dictionary_definition .zci__def__definition {
     overflow: hidden;
     display: table-cell;
 }
 
-.zci--definition .zci__more-at {
+.zci--dictionary_definition .zci__more-at {
 	display: inline-block;
 }
 
-.zci__def__links {
+.zci--dictionary_definition .zci__def__links {
     padding-bottom: 0.37em;
 }
 
-.zci__def__word {
+.zci--dictionary_definition .zci__def__word {
     font-weight: 600;
 }
-
 
 .zci__def__part-of-speech {
     font-style: italic;
@@ -32,6 +31,6 @@
     min-width: 1em;
 }
 
-.zci--definition .play-btn__err{
+.zci--dictionary_definition .play-btn__err{
     margin-left: 0.75em;
 }

--- a/share/spice/dictionary/definition/dictionary_definition.js
+++ b/share/spice/dictionary/definition/dictionary_definition.js
@@ -37,7 +37,7 @@ var ddg_spice_dictionary = {
         "proper-noun": "n."
     },
 
-    id: 'definition',
+    id: 'dictionary_definition',
 
     $el: null,
 
@@ -62,7 +62,7 @@ var ddg_spice_dictionary = {
                 attributionText: definitions[0].attributionText
             },
 
-            // relevancy: {   
+            // relevancy: {
             //     primary: [
             //         { key: 'word', min_length: word.length, strict: false }
             //     ]
@@ -102,7 +102,7 @@ var ddg_spice_dictionary = {
     definition: function(api_result) {
         "use strict";
 
-        if (!api_result || !api_result.length) { return Spice.failed('definition'); }
+        if (!api_result || !api_result.length) { return Spice.failed('dictionary_definition'); }
 
         // Prevent jQuery from appending "_={timestamp}" in our url when we use $.getScript.
         // If cache was set to false, it would be calling /js/spice/dictionary/definition/hello?_=12345
@@ -150,11 +150,11 @@ var ddg_spice_dictionary = {
             }
         }
 
-         
+
         // Sometimes a word gets '||' at the beginning.
         // This removes that for us.
         hyphenated_word = hyphenated_word.replace(/^‖/, '');
-        
+
         // Replace the, rather lame, non-hyphenated version of the word.
         this.$el.find(".zci__def__word").text(hyphenated_word);
     },


### PR DESCRIPTION
**Hotfix**

- Update broken css
- Correct another reference to `id`
- update `Spice.failed()` to use proper `id`

Tested locally:

![define_superlative_at_duckduckgo](https://cloud.githubusercontent.com/assets/873785/9396133/b365029c-4760-11e5-96be-06fb495979b4.png)


/cc @jdorweiler @bsstoner 
