### PR TITLE
Fix number of stories condition for adding news

### DIFF
--- a/share/spice/news/news.js
+++ b/share/spice/news/news.js
@@ -2,6 +2,11 @@
     "use strict";
     env.ddg_spice_news = function (api_result) {
 
+        if (!api_result) {
+            Spice.failed('news');
+            return;
+        }
+
         // Words that we have to skip in DDG.isRelevant.
         var skip = [
             "news",
@@ -77,7 +82,7 @@
 
         var searchTerm = DDG.get_query().replace(/(?: news|news ?)/i, '').trim();
 
-        if (api_result.error || goodStories < 3) {
+        if (goodStories < 3) {
             Spice.failed('news');
 
         } else {

--- a/share/spice/news/news.js
+++ b/share/spice/news/news.js
@@ -79,20 +79,22 @@
 
         if (api_result.error || goodStories < 3) {
             Spice.failed('news');
-        }
 
-        Spice.add({
-            id: 'news',
-            name: 'News',
-            data: goodStories,
-            meta: {
-                count: goodStories.length,
-                searchTerm: searchTerm,
-                itemType: 'News articles'
-            },
-            templates: {
-                item: 'news_item'
-            }
-        });
+        } else {
+
+            Spice.add({
+                id: 'news',
+                name: 'News',
+                data: goodStories,
+                meta: {
+                    count: goodStories.length,
+                    searchTerm: searchTerm,
+                    itemType: 'News articles'
+                },
+                templates: {
+                    item: 'news_item'
+                }
+            });
+        }
     }
 }(this));

--- a/share/spice/news/news.js
+++ b/share/spice/news/news.js
@@ -77,7 +77,7 @@
 
         var searchTerm = DDG.get_query().replace(/(?: news|news ?)/i, '').trim();
 
-        if (api_result.error || goodStories >= 3) {
+        if (api_result.error || goodStories < 3) {
             Spice.failed('news');
         }
 

--- a/share/spice/news/news.js
+++ b/share/spice/news/news.js
@@ -3,8 +3,7 @@
     env.ddg_spice_news = function (api_result) {
 
         if (!api_result) {
-            Spice.failed('news');
-            return;
+            return Spice.failed('news');
         }
 
         // Words that we have to skip in DDG.isRelevant.

--- a/share/spice/news/news.js
+++ b/share/spice/news/news.js
@@ -82,7 +82,7 @@
         var searchTerm = DDG.get_query().replace(/(?: news|news ?)/i, '').trim();
 
         if (goodStories < 3) {
-            Spice.failed('news');
+            return Spice.failed('news');
 
         } else {
 


### PR DESCRIPTION
The correct condition for calling Spice.fail() for news should be if we have less than 3 good stories. The condition was correct in https://github.com/duckduckgo/zeroclickinfo-spice/blob/d010d02cf7dbd095561ee5d36f1505d3cc10f1c4/share/spice/news/news.js#L80, and then the inequality was flipped in https://github.com/duckduckgo/zeroclickinfo-spice/blob/0cfee129b2e052c264d234b57f183524f6b4acb5/share/spice/news/news.js#L80.

This PR flips the inequality condition and only allows us to call either Spice.failed() or Spice.add(), but not both. (I think that the current code always calls Spice.add() even if we call Spice.fail()?)