### PR TITLE
Fix flight status

### DIFF
--- a/share/spice/airlines/content.handlebars
+++ b/share/spice/airlines/content.handlebars
@@ -11,7 +11,7 @@
   </div>
   <div>
     <span class="tile__status">
-      {{{airline_status flight departureDate arrivalDate}}}
+      {{{airline_status flight departureDate arrivalDate scheduledDepartureDate scheduledArrivalDate}}}
     </span>
   </div>
 </div>

--- a/share/spice/flights/route/content.handlebars
+++ b/share/spice/flights/route/content.handlebars
@@ -11,7 +11,7 @@
   </div>
   <div>
     <span class="tile__status">
-      {{{airline_status flight departureDate arrivalDate}}}
+      {{{airline_status flight departureDate arrivalDate scheduledDepartureDate scheduledArrivalDate}}}
     </span>
   </div>
 </div>


### PR DESCRIPTION
The flights and routes instant answers do not correctly show the status for delayed flights. After a little investigation, this appears to be related to the handlebars template, which is not passing in the needed scheduled arrival or scheduled departure information. This pull request includes updates to both files to pass the appropriate variables.

I was able to test this for the routes IA only (I think the airline one may only have deep triggers), but it appears to produce the desired effect:

<img width="740" alt="napkin 08-22-15 3 24 29 pm" src="https://cloud.githubusercontent.com/assets/194728/9425758/a6c89a98-48e2-11e5-94bf-16dde7497bcd.png">

I only tested in one browser, because this did not change the HTML output or the JavaScript. Let me know if there are further tests or prep work I should complete.

Thanks!