### PR TITLE
Detail ClassName Updates

### DIFF
--- a/share/spice/bbc/buy.handlebars
+++ b/share/spice/bbc/buy.handlebars
@@ -1,5 +1,5 @@
 {{#if programme.is_available_mediaset_pc_sd}}
-  <a href="http://www.bbc.co.uk/iplayer/episode/{{programme.pid}}" class="detail__links__btn">
+  <a href="http://www.bbc.co.uk/iplayer/episode/{{programme.pid}}" class="c-detail__links__btn">
   <img class="btn__icon" src="https://icons.duckduckgo.com/ip/www.bbc.com.ico" />
   Watch
   </a>

--- a/share/spice/bbc/subtitle_content.handlebars
+++ b/share/spice/bbc/subtitle_content.handlebars
@@ -1,4 +1,4 @@
-<p class="detail__source">
+<p class="c-detail__source">
   Run Time: {{duration}}
 </p>
 

--- a/share/spice/canistreamit/canistreamit.handlebars
+++ b/share/spice/canistreamit/canistreamit.handlebars
@@ -1,6 +1,6 @@
 <div class="sub tile__tx tile__rating one-line">
     <span>{{sub}}</span>
-    <span class="detail__separator"> | </span>
+    <span class="tile__sep sep"></span>
     {{{starRating rating}}}
     <span class="percentage">{{percentage}}</span>
 </div>

--- a/share/spice/dogo_books/dogo_books.css
+++ b/share/spice/dogo_books/dogo_books.css
@@ -23,7 +23,7 @@
     padding-bottom:148.333%;
 }
 
-.zci--dogo_books p.detail__desc {
+.zci--dogo_books .c-detail__desc {
     padding-bottom: 1.65em;
 }
 

--- a/share/spice/dogo_movies/dogo_movies.css
+++ b/share/spice/dogo_movies/dogo_movies.css
@@ -23,7 +23,7 @@
     padding-bottom:148.333%;
 }
 
-.zci--dogo_movies p.detail__desc {
+.zci--dogo_movies .c-detail__desc {
     padding-bottom: 1.65em;
 }
 

--- a/share/spice/dogo_movies/subtitle_content.handlebars
+++ b/share/spice/dogo_movies/subtitle_content.handlebars
@@ -3,7 +3,7 @@
     <span>Run Time: {{runtime}}</span>
     {{/if}}
     {{#and runtime mpaa}}
-    <span class="detail__separator"> | </span>
+    <span class="sep"></span>
     {{/and}}
     {{#if mpaa}}
     <span>{{mpaaText}}</span>

--- a/share/spice/in_theaters/in_theaters.css
+++ b/share/spice/in_theaters/in_theaters.css
@@ -6,24 +6,24 @@
     background: transparent no-repeat;
 }
 
-.zci--in_theaters .detail__title {
+.zci--in_theaters .c-detail__title {
     padding-bottom: 0;
 }
 
-.zci--in_theaters .detail__subtitle {
+.zci--in_theaters .c-detail__subtitle {
     margin-top: 0;
     padding-top: 0;
 }
 
-.is-mobile .zci--in_theaters .detail__subtitle {
+.is-mobile .zci--in_theaters .c-detail__subtitle {
     position: relative;
 }
 
-.zci--in_theaters p.detail__desc {
+.zci--in_theaters .c-detail__desc {
     padding-bottom: 1.65em;
 }
 
-.is-mobile .zci--in_theaters p.detail__desc {
+.is-mobile .zci--in_theaters .c-detail__desc {
     padding-bottom: 5em;    
 }
 
@@ -52,7 +52,7 @@
     width: 24px;
 }
 
-.zci--in_theaters .detail__subtitle sup {
+.zci--in_theaters .c-detail__subtitle sup {
     font-size: 0.5em;
 }
 

--- a/share/spice/in_theaters/subtitle_content.handlebars
+++ b/share/spice/in_theaters/subtitle_content.handlebars
@@ -14,7 +14,7 @@
     <span>Run Time: {{InTheaters_time runtime}}</span>
   {{/if}}
   {{#and runtime mpaa_rating}}
-    <span class="detail__separator"> | </span>
+    <span class="sep"></span>
   {{/and}}
   {{#if mpaa_rating}}
     <span>{{mpaa_rating}}</span>

--- a/share/spice/lastfm/artist/item.handlebars
+++ b/share/spice/lastfm/artist/item.handlebars
@@ -2,6 +2,6 @@
   <p>
     {{ellipsis summary 200}}
   </p>
-  <p class="detail__lastfm detail__songs">
+  <p class="c-detail__lastfm c-detail__songs js-lastfm-detail-songs">
   </p>
 </div>

--- a/share/spice/lastfm/artist/lastfm_artist.js
+++ b/share/spice/lastfm/artist/lastfm_artist.js
@@ -44,6 +44,6 @@
         }
 
         songs.splice(3);
-        $(".detail__songs").html("Top Tracks: " + songs.join(", "));
+        $(".js-lastfm-detail-songs").html("Top Tracks: " + songs.join(", "));
     };
 }(this));

--- a/share/spice/movie/movie.css
+++ b/share/spice/movie/movie.css
@@ -6,24 +6,24 @@
     background: transparent no-repeat;
 }
 
-.zci--movie .detail__title {
+.zci--movie .c-detail__title {
     padding-bottom: 0;
 }
 
-.zci--movie .detail__subtitle {
+.zci--movie .c-detail__subtitle {
     margin-top: 0;
     padding-top: 0;
 }
 
-.is-mobile .zci--movie .detail__subtitle {
+.is-mobile .zci--movie .c-detail__subtitle {
     position: relative;
 }
 
-.zci--movie p.detail__desc {
+.zci--movie .c-detail__desc {
     padding-bottom: 1.65em;
 }
 
-.is-mobile .zci--movie p.detail__desc {
+.is-mobile .zci--movie .c-detail__desc {
     padding-bottom: 5em;    
 }
 
@@ -52,7 +52,7 @@
     width: 24px;
 }
 
-.zci--movie .detail__subtitle sup {
+.zci--movie .c-detail__subtitle sup {
     font-size: 0.5em;
 }
 

--- a/share/spice/movie/subtitle_content.handlebars
+++ b/share/spice/movie/subtitle_content.handlebars
@@ -14,7 +14,7 @@
     <span>Run Time: {{movie_time runtime}}</span>
   {{/if}}
   {{#and runtime mpaa_rating}}
-    <span class="detail__separator"> | </span>
+    <span class="sep"></span>
   {{/and}}
   {{#if mpaa_rating}}
     <span>{{mpaa_rating}}</span>

--- a/share/spice/parking/item_back.handlebars
+++ b/share/spice/parking/item_back.handlebars
@@ -13,6 +13,6 @@
         </span>
     {{/if}}
     <div class="tile__foot tile--parking__foot__back">
-        <a href="{{url}}" class="btn btn--primary btn--parking detail__links__btn reserve-btn--parking">Reserve Parking</a>
+        <a href="{{url}}" class="btn btn--primary btn--parking reserve-btn--parking">Reserve Parking</a>
     </div>            
 </div>

--- a/share/spice/quixey/buy.handlebars
+++ b/share/spice/quixey/buy.handlebars
@@ -1,4 +1,4 @@
-<span class="detail__callout">
+<span class="c-detail__callout">
 {{#each editions}}
     <a href="{{{url}}}" class="btn">
         {{#with this.platforms.[0]}}

--- a/share/spice/recipes/recipes_item_detail.handlebars
+++ b/share/spice/recipes/recipes_item_detail.handlebars
@@ -3,10 +3,10 @@
         <img src="{{imageProxy image}}" alt="{{recipeName}}" class="detail__media__img" />
     </div>
     <div class="detail__body  detail__body--recipe">
-        <div class="detail__body__content  recipe">
-            <h5 class="detail__title  recipe__title"><a href='{{url}}' title="{{title}}">{{recipeName}}</a></h5>
-            <div class="detail__desc">
-                <p class="detail__source  recipe__subtitle">
+        <div class="detail__body__content  recipe  c-detail">
+            <h5 class="c-detail__title  recipe__title"><a href='{{url}}' title="{{title}}">{{recipeName}}</a></h5>
+            <div class="c-detail__desc">
+                <p class="c-detail__source  recipe__subtitle">
                     {{{include 'DDH.recipes.recipes_subtitle'}}}
                 </p>
                 <div class="recipe__content">

--- a/share/spice/rx_info/rx_info.css
+++ b/share/spice/rx_info/rx_info.css
@@ -8,23 +8,23 @@
     text-align: center;
 }
 
-.detail__title--rx_info {
+.c-detail__title--rx_info {
     padding-bottom: 0;
 }
 
-.detail__labeler--rx_info {
+.c-detail__labeler--rx_info {
     color: #888888;
 }
 
-.detail__ingredients__title--rx_info {
+.c-detail__ingredients__title--rx_info {
     font-size: 1.15em;
 }
 
-.detail__ingredients__snippet--rx_info {
+.c-detail__ingredients__snippet--rx_info {
     color: #666666;
 }
 
-.detail__desc__attribution--rx_info {
+.c-detail__desc__attribution--rx_info {
     color: #999999;
     font-size: 12px;
 }

--- a/share/spice/rx_info/rx_info.handlebars
+++ b/share/spice/rx_info/rx_info.handlebars
@@ -1,5 +1,5 @@
-{{{formatTitle heading el="h5" className="detail__title" classNameSec="detail__title--rx_info" noSub="true" href=url}}}
-<div class="detail__labeler--rx_info">{{labeler}}</div>
-<div class="detail__desc">
+{{{formatTitle heading el="h5" className="c-detail__title" classNameSec="c-detail__title--rx_info" noSub="true" href=url}}}
+<div class="c-detail__labeler--rx_info">{{labeler}}</div>
+<div class="c-detail__desc">
     {{{include 'DDH.rx_info.rx_info_description'}}}
 </div>

--- a/share/spice/rx_info/rx_info_description.handlebars
+++ b/share/spice/rx_info/rx_info_description.handlebars
@@ -1,19 +1,19 @@
 {{#if active}}
-    <h5 class="detail__ingredients__title--rx_info">Active Ingredients</h5>
+    <h5 class="c-detail__ingredients__title--rx_info">Active Ingredients</h5>
 
-    <div class="detail__ingredients__snippet--rx_info">
+    <div class="c-detail__ingredients__snippet--rx_info">
         {{active}}
     </div>
 {{/if}}
 
 {{#if inactive}}
-    <h5 class="detail__ingredients__title--rx_info">Inactive Ingredients</h5>
+    <h5 class="c-detail__ingredients__title--rx_info">Inactive Ingredients</h5>
 
-    <div class="detail__ingredients__snippet--rx_info">
+    <div class="c-detail__ingredients__snippet--rx_info">
         {{inactive}}
     </div>
 {{/if}}
 
-<h6 class="detail__desc__attribution--rx_info">
+<h6 class="c-detail__desc__attribution--rx_info">
     Image Source: <a href="http://rximage.nlm.nih.gov/" target="_blank">National Library of Medicine Office of High Performance Computing and Communications</a>
 </h6>

--- a/share/spice/stocks/content.handlebars
+++ b/share/spice/stocks/content.handlebars
@@ -15,6 +15,6 @@
 <div class="stocks__quotes  stocks__quote-{{quoteChangeDir}}">
     <span class="stocks__quote text--primary">{{quote}}</span>
     <span class="stocks__change">{{change}}</span>
-    <span class="stocks__change-sep  detail__sep"></span>
+    <span class="stocks__change-sep  sep"></span>
     <span class="stocks__change-pct">{{change_percent}}%</span>
 </div>

--- a/share/spice/stocks/stocks.css
+++ b/share/spice/stocks/stocks.css
@@ -24,9 +24,10 @@
 .zci--stocks .stocks__change-pct {
     font-weight: 300;
 }
-.zci--stocks .stocks__change-sep.detail__sep {
+.zci--stocks .stocks__change-sep.sep {
     margin: 0;
     height: .78em;
+    top: -0.025em;
 }
 .zci--stocks .stocks__quote-up .stocks__change,
 .zci--stocks .stocks__quote-up .stocks__change-pct {


### PR DESCRIPTION
We're going to be refactoring how detail panes work, in order to make it easier for open-source developers to create and modify these areas.  The first step is to break up the detail 'wrapping' elements from the 'content' elements.  This just tags a bunch of those content elements with the `.c-` prefix, wherever they appear in the Spice repo.

to @bsstoner 