### PR TITLE
Better display of flight status

### DIFF
--- a/share/spice/airlines/airlines.js
+++ b/share/spice/airlines/airlines.js
@@ -244,6 +244,9 @@
                     isDeparted: false
                 };
 
+            // Status
+            var status = onTime(flight[i], departureDate, arrivalDate, scheduledDepartureDate, scheduledArrivalDate);
+
             results.push({
                 flight: flight[i],
                 airlineName: airlineName,
@@ -254,7 +257,9 @@
                 departureDate: departureDate,
                 arrivalDate: arrivalDate,
                 scheduledDepartureDate: scheduledDepartureDate,
-                scheduledArrivalDate: scheduledArrivalDate
+                scheduledArrivalDate: scheduledArrivalDate,
+                status: status[0],
+                isOnTime: status[1]
             });
         }
 
@@ -335,11 +340,4 @@
         } else
             return hours + ":" + minutes + " " + suffix;
     });
-
-    Spice.registerHelper("airline_status", function(flight, departureDate, arrivalDate, scheduledDeparture, scheduledArrival) {
-        var result = onTime(flight, departureDate, arrivalDate, scheduledDeparture, scheduledArrival),
-            ok_class = result[1] ? "tile__ok" : "tile__not";
-        return '<div class="' + ok_class + '">' + result[0] + '</div>';
-    });
-
 }(this))

--- a/share/spice/airlines/airlines.js
+++ b/share/spice/airlines/airlines.js
@@ -31,7 +31,7 @@
         return date - now;
     }
 
-    // Check if the airplane is on-time or delayed.
+    // Check if the airplane is on-time or delayed. Returns ["stringStatus", boolIsOnTime]
     function onTime(flight, departureDate, arrivalDate, scheduledDeparture, scheduledArrival) {
 
         var deltaDepart = new Date(departureDate) - scheduledDeparture,
@@ -44,7 +44,12 @@
                 return ["On Time", true];
             }
         }
-        return [STATUS[flight.status], true];
+        if (flight.status === "L") {
+        	// still reflect on time / late for landed flights, but just based on arrival
+        	return [STATUS[flight.status], MILLIS_PER_MIN * 5 >= deltaArrive];
+        }
+        // all remaining status are canceled, diverted, non-operational, unknown, redirected, etc... return false to reflect not on time
+        return [STATUS[flight.status], false];
     }
 
     env.ddg_spice_airlines = function(api_result) {

--- a/share/spice/airlines/content.handlebars
+++ b/share/spice/airlines/content.handlebars
@@ -11,7 +11,7 @@
   </div>
   <div>
     <span class="tile__status">
-      {{{airline_status flight departureDate arrivalDate scheduledDepartureDate scheduledArrivalDate}}}
+      <span class="{{#if isOnTime}}tile__ok{{else}}tile__not{{/if}}">{{status}}</span>
     </span>
   </div>
 </div>

--- a/share/spice/flights/route/content.handlebars
+++ b/share/spice/flights/route/content.handlebars
@@ -11,7 +11,7 @@
   </div>
   <div>
     <span class="tile__status">
-      {{{airline_status flight departureDate arrivalDate scheduledDepartureDate scheduledArrivalDate}}}
+      <span class="{{#if isOnTime}}tile__ok{{else}}tile__not{{/if}}">{{status}}</span>
     </span>
   </div>
 </div>

--- a/share/spice/flights/route/flights_route.js
+++ b/share/spice/flights/route/flights_route.js
@@ -199,6 +199,9 @@
                                 isDeparted: false
                             };
 
+                        // Status
+                        var status = this.onTime(flight[i], departureDate, arrivalDate, scheduledDepartureDate, scheduledArrivalDate);
+
                         results.push({
                             flight: flight[i],
                             airlineName: dictFlightStats[carrierCodes[carriersIndex].fsCode].name,
@@ -209,7 +212,9 @@
                             departureDate: departureDate,
                             arrivalDate: arrivalDate,
                             scheduledDepartureDate: scheduledDepartureDate,
-                            scheduledArrivalDate: scheduledArrivalDate
+                            scheduledArrivalDate: scheduledArrivalDate,
+                            status: status[0],
+                            isOnTime: status[1]
                         });
 
                         break;
@@ -341,12 +346,4 @@
         } else
             return hours + ":" + minutes + " " + suffix;
     });
-
-
-    Spice.registerHelper("airline_status", function(flight, departureDate, arrivalDate, scheduledDeparture, scheduledArrival) {
-        var result = ddg_spice_flights.onTime(flight, departureDate, arrivalDate, scheduledDeparture, scheduledArrival),
-            ok_class = result[1] ? "tile__ok" : "tile__not";
-        return '<div class="' + ok_class + '">' + result[0] + '</div>';
-    });
-    
 }(this))

--- a/share/spice/flights/route/flights_route.js
+++ b/share/spice/flights/route/flights_route.js
@@ -279,7 +279,7 @@
         },
     
     
-        // Check if the airplane is on-time or delayed.
+        // Check if the airplane is on-time or delayed. Returns ["stringStatus", boolIsOnTime]
         onTime: function onTime(flight, departureDate, arrivalDate, scheduledDeparture, scheduledArrival) {
     
             var deltaDepart = new Date(departureDate) - scheduledDeparture,
@@ -292,7 +292,12 @@
                     return ["On Time", true];
                 }
             }
-            return [this.STATUS[flight.status], true];
+            if (flight.status === "L") {
+                // still reflect on time / late for landed flights, but just based on arrival
+                return [this.STATUS[flight.status], this.MILLIS_PER_MIN * 5 >= deltaArrive];
+            }
+            // all remaining status are canceled, diverted, non-operational, unknown, redirected, etc... return false to reflect not on time
+            return [this.STATUS[flight.status], false];
         }
     }
 


### PR DESCRIPTION
Inspired by my last PR... :-) Here are a few more tweaks to the flights and routes IAs that I think improve the handling of flight statuses. The exact changes are described below. Some of the changes are worthy of discussion, not sure if there is a right answer.

Changes:

* Eliminated the handlebars helper for flight status, since it was used once and made things more circuitous.
* Made status such as canceled, diverted, redirect and unknown print in "red" (```tile__not```) instead of "green" (```tile__ok```), to more accurate reflect the unexpected status. (See the attached screenshot.)
* Made flights that have landed late, just based on arrival time, print in "red" (```tile__not```) instead of "green" (```tile__ok```) to reflect the deviation from the scheduled arrival time. This change is more debatable, as I can see arguments for either style.

I tried to make changes in both the routes & airline IA at the same time.

Screenshot from testing, showing that the new handlebars code works and highlighting the second change describe above:

<img width="489" alt="napkin 08-26-15 6 55 12 pm" src="https://cloud.githubusercontent.com/assets/194728/9508792/07de6e10-4c27-11e5-9a5f-38558787a356.png">
