### PR TITLE
removed use of global isNumber helper

### DIFF
--- a/share/spice/geometry/geometry.js
+++ b/share/spice/geometry/geometry.js
@@ -420,7 +420,7 @@
         data.svg = shape.svg;
         pairs = shape.pairs;
         parameter = shape.getParameter(query);
-        if(isNumber(parameter)) //force array
+        if(DDG.isNumber(parameter)) //force array
             parameter = [parameter];
 
         //loop through all formulas of this shape


### PR DESCRIPTION
@moollaza I was doing some cleaning up of the DDG utils and noticed one of them exposed `DDG.isNumber` in the global scope. I'll be removing `isNumber` from the global scope to keep things tidy.

The geometry spice is the only place where the global `isNumber` is used instead of `DDG.isNumber`.