### PR TITLE
Created Tides spice

### DIFF
--- a/lib/DDG/Spice/Tides.pm
+++ b/lib/DDG/Spice/Tides.pm
@@ -17,8 +17,7 @@ code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/
 attribution github => ["mattr555", "Matt Ramina"],
             twitter => "mattr555";
 
-spice to => 'http://api.wunderground.com/api/{{ENV{DDG_SPICE_WUNDERGROUND_APIKEY}}}/tide/q/$1.json';
-spice wrap_jsonp_callback => 1;
+spice to => 'http://api.wunderground.com/api/{{ENV{DDG_SPICE_WUNDERGROUND_APIKEY}}}/tide/q/$1.json?callback={{callback}}';
 
 triggers any => "tide", "tides";
 
@@ -26,8 +25,11 @@ handle remainder => sub {
     s/(when is|high|low|\?|\s)//g;
     return unless $_ eq '' || m/^\d{5}$/;
 
-    return join(',', $loc->latitude, $loc->longitude) if $_ eq '';
-    return $_;
+    if ($loc || $_){
+        return join(',', $loc->latitude, $loc->longitude) if $_ eq '';
+        return $_;
+    }
+    return;
 };
 
 1;

--- a/lib/DDG/Spice/Tides.pm
+++ b/lib/DDG/Spice/Tides.pm
@@ -25,7 +25,7 @@ handle remainder => sub {
     s/(when is|high|low|\?|\s)//g;
     return unless $_ eq '' || m/^\d{5}$/;
 
-    if ($loc || $_){
+    if ((defined $loc && defined $loc->latitude && defined $loc->longitude) || $_){
         return join(',', $loc->latitude, $loc->longitude) if $_ eq '';
         return $_;
     }

--- a/lib/DDG/Spice/Tides.pm
+++ b/lib/DDG/Spice/Tides.pm
@@ -1,0 +1,33 @@
+package DDG::Spice::Tides;
+# ABSTRACT: High and Low Tide prediction for your location
+
+use DDG::Spice;
+
+spice is_cached => 1; #we can cache the response and just filter out the tide events that have already happened on the front
+
+name "Tides";
+source "WUnderground";
+icon_url "/i/wunderground.com.ico";
+description "Get high and low tide times for your location or zip code";
+primary_example_queries "tides", "tide 02201";
+secondary_example_queries "when is high tide?";
+category "location_aware";
+topics "special_interest", "geography", "travel";
+code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/Tides.pm";
+attribution github => ["mattr555", "Matt Ramina"],
+            twitter => "mattr555";
+
+spice to => 'http://api.wunderground.com/api/{{ENV{DDG_SPICE_WUNDERGROUND_APIKEY}}}/tide/q/$1.json';
+spice wrap_jsonp_callback => 1;
+
+triggers any => "tide", "tides";
+
+handle remainder => sub {
+    s/(when is|high|low|\?|\s)//g;
+    return unless $_ eq '' || m/^\d{5}$/;
+
+    return join(',', $loc->latitude, $loc->longitude) if $_ eq '';
+    return $_;
+};
+
+1;

--- a/share/spice/tides/tides.js
+++ b/share/spice/tides/tides.js
@@ -1,7 +1,7 @@
 (function (env) {
     "use strict";
     env.ddg_spice_tides = function(api_result){
-        if (!api_result || !api_result.tide) {
+        if (!api_result || api_result.error || !api_result.tide) {
             return Spice.failed('tides');
         }
 
@@ -18,7 +18,7 @@
         var tide_display = {};
         $.each(tides, function(i, v){
             //time: type and height
-            var time = moment({y: v.date.year, M: v.date.mon, d: v.date.mday, h: v.date.hour, m: v.date.min}).format('ddd h:mm A');
+            var time = moment({y: v.date.year, M: v.date.mon - 1, d: v.date.mday, h: v.date.hour, m: v.date.min}).format('ddd h:mm A');
             tide_display[time] = v.data.type + ', ' + v.data.height;
         })
 
@@ -26,8 +26,8 @@
             id: "tides",
             name: "Tides",
             data: {
-                title: 'Tides at ' + api_result.tide.tideInfo[0].tideSite,
-                subtitle: rising ? 'Currently rising' : 'Currently receding',
+                title: rising ? 'Currently rising' : 'Currently receding',
+                subtitle: 'Tides at ' + api_result.tide.tideInfo[0].tideSite,
                 record_data: tide_display
             },
             meta: {

--- a/share/spice/tides/tides.js
+++ b/share/spice/tides/tides.js
@@ -1,0 +1,47 @@
+(function (env) {
+    "use strict";
+    env.ddg_spice_tides = function(api_result){
+        if (!api_result || !api_result.tide) {
+            return Spice.failed('tides');
+        }
+
+        var now = new Date().getTime() / 1000;
+        var tides = $.grep(api_result.tide.tideSummary, function(i){
+            //filtering out events that are not high/low tides or have already happened
+            return !!i.data.height && i.date.epoch > now;
+        });
+
+        //is the tide rising or receding?
+        var rising = tides[0].data.type == "High Tide";
+
+        DDG.require('moment.js', function(){
+        var tide_display = {};
+        $.each(tides, function(i, v){
+            //time: type and height
+            var time = moment({y: v.date.year, M: v.date.mon, d: v.date.mday, h: v.date.hour, m: v.date.min}).format('ddd h:mm A');
+            tide_display[time] = v.data.type + ', ' + v.data.height;
+        })
+
+        Spice.add({
+            id: "tides",
+            name: "Tides",
+            data: {
+                title: 'Tides at ' + api_result.tide.tideInfo[0].tideSite,
+                subtitle: rising ? 'Currently rising' : 'Currently receding',
+                record_data: tide_display
+            },
+            meta: {
+                sourceName: "WUnderground.com",
+                sourceUrl: 'http://www.wunderground.com/'
+            },
+            templates: {
+                group: 'list',
+                options: {
+                    content: 'record',
+                    moreAt: true
+                }
+            }
+        });
+        });
+    };
+}(this));

--- a/t/Tides.t
+++ b/t/Tides.t
@@ -1,0 +1,32 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+spice is_cached => 1;
+
+ddg_spice_test(
+    [qw( DDG::Spice::Tides)],
+    'tides' => test_spice(
+        '/js/spice/tides/40.1246%2C-75.5385', #phoenixville PA
+        call_type => 'include',
+        caller => 'DDG::Spice::Tides'
+    ),
+    'tide 02201' => test_spice(
+        '/js/spice/tides/02201',
+        call_type => 'include',
+        caller => 'DDG::Spice::Tides'
+    ),
+    'when is high tide?' => test_spice(
+        '/js/spice/tides/40.1246%2C-75.5385',
+        call_type => 'include',
+        caller => 'DDG::Spice::Tides'
+    ),
+    'tide charts' => undef,
+    'xtide' => undef
+);
+
+done_testing;
+


### PR DESCRIPTION
**What does your Instant Answer do?**
Provides the next high and low tide times for either your location or a specified US zip code

**What problem does your Instant Answer solve (Why is it better than organic links)?**
It's better because it gives you a chart for right now, in your own location

**What is the data source for your Instant Answer? (Provide a link if possible)**
WUnderground - http://www.wunderground.com/weather/api/d/docs?d=data/tide

**Why did you choose this data source?**
It uses data presumably generated from [XTide](http://www.flaterco.com/xtide/) and can search for the nearest tide site from your location.

**Are there any other alternative (better) data sources?**
We could use XTide ourselves as I outlined in the emails.

**What are some example queries that trigger this Instant Answer?**
`when is high tide`, `tide`, `tide 10001`

**Which communities will this Instant Answer be especially useful for? (gamers, book lovers, etc)**
People who live near the beach (like myself!)

**Is this Instant Answer connected to a DuckDuckHack [Instant Answer idea](https://duck.co/ideas)?**
No, but I have emailed the team regarding 

**Which existing Instant Answers will this one supersede/overlap with?**
none

**Are you having any problems? Do you need our help with anything?**
Nope, but I think the design could probably be improved.

**What are the terms of use for the API? Will DuckDuckGo need specific authorization (e.g. an API key)? Are there any costs associated with API usage?**
We would need to register a key. The problem is that WUnderground is only free for 500 ~~queries/month~~, and jumps pretty sharply in price because tides are only returned on the "cumulus plan."

_EDIT_: my bad, it's 500/day, not as bad :stuck_out_tongue: 

**What does the Instant Answer look like? (Provide a screenshot for new or updated Instant Answers)**
![screenshot - 08292015 - 12 30 56 pm](https://cloud.githubusercontent.com/assets/4411471/9563220/251ea3e8-4e4b-11e5-8604-b9f823ce6a77.png)
## Checklist

Please place an 'X' where appropriate.

```
[x] Added metadata and attribution information
[x] Wrote test file and added to t/ directory
[x] Verified that instant answer adheres to design guidelines (https://duck.co/duckduckhack/design_styleguide)
[x] Verified that instant answer adheres to code styleguide (https://duck.co/duckduckhack/code_styleguide)
[] Tested cross-browser compatibility

    Please let us know which browsers/devices you've tested on:
    - Linux
        [x] Chrome

    - iOS (iPhone)
        [x] Safari Mobile
```

IA Page: https://duck.co/ia/view/tides
