### PR TITLE
Minor CSS adjustments, change tab name to 'Bike Sharing'

### DIFF
--- a/share/spice/bike_sharing/citi_bike_nyc/bike_sharing_citi_bike_nyc.css
+++ b/share/spice/bike_sharing/citi_bike_nyc/bike_sharing_citi_bike_nyc.css
@@ -4,10 +4,6 @@
 
 .tile--citi_bike_nyc {
     text-align: center;
-    height: 12em;
-}
-
-.tile--citi_bike_nyc {
     width: 13em;
     height: 13em;
 }
@@ -17,7 +13,7 @@
 }
 
 .tile--citi_bike_nyc p.tx-clr--dk.tx--14 {
-  padding-top: 0;
+    padding-top: 0;
 }
 
 .tile--citi_bike_nyc p.tx-clr--dk.tx--25 {

--- a/share/spice/bike_sharing/citi_bike_nyc/bike_sharing_citi_bike_nyc.css
+++ b/share/spice/bike_sharing/citi_bike_nyc/bike_sharing_citi_bike_nyc.css
@@ -2,7 +2,7 @@
   font-size: 6px;
 }
 
-.tile--citi_bike_nyc {
+.tile--citi_bike_nyc.tile--c--n {
     text-align: center;
     width: 13em;
     height: 13em;

--- a/share/spice/bike_sharing/citi_bike_nyc/bike_sharing_citi_bike_nyc.css
+++ b/share/spice/bike_sharing/citi_bike_nyc/bike_sharing_citi_bike_nyc.css
@@ -3,20 +3,40 @@
     height: 12em;
 }
 
+.tile--citi_bike_nyc {
+    width: 13em;
+    height: 13em;
+}
+
 .tile--citi_bike_nyc .zci__header {
     height: 2.5em;
 }
 
+.tile--citi_bike_nyc p.tx-clr--dk.tx--14 {
+  padding-top: 0;
+}
+
+.tile--citi_bike_nyc p.tx-clr--dk.tx--25 {
+    padding-top: 0;
+    padding-bottom: 0;
+    line-height: 1.1;
+}
+
+.tile--citi_bike_nyc div.tile__content.side_by_side {
+    margin-top: 18px;
+}
+
 .tile--citi_bike_nyc .side_by_side {
-    overflow: auto;
     margin-left: auto;
     margin-right: auto;
     width: 100%;
 }
 
+
 .tile--citi_bike_nyc .side_by_side .left {
     float: left;
     border-right: 1px solid #E5E5E5;
+    padding-right: 7px;
 }
 
 .is-mobile .tile--citi_bike_nyc .side_by_side .left {
@@ -25,6 +45,7 @@
 
 .tile--citi_bike_nyc .side_by_side .right {
     float: right;
+    padding-left: 7px;
 }
 
 .is-mobile .tile--citi_bike_nyc .side_by_side .right {

--- a/share/spice/bike_sharing/citi_bike_nyc/bike_sharing_citi_bike_nyc.css
+++ b/share/spice/bike_sharing/citi_bike_nyc/bike_sharing_citi_bike_nyc.css
@@ -1,3 +1,7 @@
+.zci--citi_bike_nyc .mapview-marker__icn.ddgsi-circle {
+  font-size: 6px;
+}
+
 .tile--citi_bike_nyc {
     text-align: center;
     height: 12em;

--- a/share/spice/bike_sharing/citi_bike_nyc/bike_sharing_citi_bike_nyc.js
+++ b/share/spice/bike_sharing/citi_bike_nyc/bike_sharing_citi_bike_nyc.js
@@ -26,71 +26,71 @@
             query = source.match(/citi_bike_nyc\/([^\/]+)/)[1];
 
         DDG.require('moment.js', function() {
-            DDG.require('maps', function() {
-                moment.locale('en', {
-                    relativeTime : {
-                        past:   "%s ago",
-                        s:    "a sec",
-                        ss:   "%d sec",
-                        m:    "a min",
-                        mm:   "%d min",
-                        h:    "an hour",
-                        hh:   "%d hours",
-                        d:    "a day",
-                        dd:   "%d days",
-                        M:    "a month",
-                        MM:   "%d months",
-                        y:    "a year",
-                        yy:   "%d years"
+        DDG.require('maps', function() {
+            moment.locale('en', {
+                relativeTime : {
+                    past: "%s ago",
+                    s:    "1 sec",
+                    ss:   "%d sec",
+                    m:    "1 min",
+                    mm:   "%d min",
+                    h:    "1 hour",
+                    hh:   "%d hours",
+                    d:    "1 day",
+                    dd:   "%d days",
+                    M:    "1 month",
+                    MM:   "%d months",
+                    y:    "1 year",
+                    yy:   "%d years"
+                }
+            });
+            Spice.add({
+                id: 'citi_bike_nyc',
+                name: 'Bike Sharing',
+                meta: {
+                    sourceName: 'Citi Bike NYC',
+                    sourceUrl: 'https://www.citibikenyc.com/stations',
+                    itemType: 'Bike Stations',
+                    pinIcon: 'ddgsi-circle',
+                    pinIconSelected: 'ddgsi-star'
+                },
+                model: 'Place',
+                view: 'Places',
+                templates: {
+                    item: 'base_item',
+                    options: {
+                        content: Spice.bike_sharing_citi_bike_nyc.content
+                    },
+                    variants: {
+                        tile: 'narrow'
                     }
-                });
-                Spice.add({
-                    id: 'citi_bike_nyc',
-                    name: 'Citi Bike NYC',
-                    meta: {
-                        sourceName: 'Citi Bike NYC',
-                        sourceUrl: 'https://www.citibikenyc.com/stations',
-                        itemType: 'Bike Stations',
-                        pinIcon: 'ddgsi-circle',
-                        pinIconSelected: 'ddgsi-star'
-                    },
-                    model: 'Place',
-                    view: 'Places',
-                    templates: {
-                        item: 'base_item',
-                        options: {
-                            content: Spice.bike_sharing_citi_bike_nyc.content
-                        },
-                        variants: {
-                            tile: 'narrow'
-                        }
-                    },
-                    sort_fields: {
-                        distance: function(a, b) {
-                            return a.distanceToReference - b.distanceToReference;
-                        }
-                    },
-                    sort_default: 'distance',
-                    data: api_result.stationBeanList,
-                    normalize: function(item) {
-                        if (item.testStation || item.statusKey != 1) {
-                            return null;
-                        }
-                        if (references[query]) {
-                            var pointOfReference = L.latLng(references[query]);
-                        }
-                        return {
-                            name: item.stationName,
-                            lat: item.latitude,
-                            lon: item.longitude,
-                            distanceToReference: pointOfReference ? L.latLng(item.latitude, item.longitude).distanceTo(pointOfReference) : item.id,
-                            title: item.stationName,
-                            availableDocks: item.availableDocks,
-                            availableBikes: item.availableBikes,
-                            lastCommunication: moment(new Date(item.lastCommunicationTime)).fromNow()
-                        };
+                },
+                sort_fields: {
+                    distance: function(a, b) {
+                        return a.distanceToReference - b.distanceToReference;
                     }
-                });
+                },
+                sort_default: 'distance',
+                data: api_result.stationBeanList,
+                normalize: function(item) {
+                    if (item.testStation || item.statusKey != 1) {
+                        return null;
+                    }
+                    if (references[query]) {
+                        var pointOfReference = L.latLng(references[query]);
+                    }
+                    return {
+                        name: item.stationName,
+                        lat: item.latitude,
+                        lon: item.longitude,
+                        distanceToReference: pointOfReference ? L.latLng(item.latitude, item.longitude).distanceTo(pointOfReference) : item.id,
+                        title: item.stationName,
+                        availableDocks: item.availableDocks,
+                        availableBikes: item.availableBikes,
+                        lastCommunication: moment(new Date(item.lastCommunicationTime)).fromNow()
+                    };
+                }
+            });
             });
         });
     }

--- a/share/spice/bike_sharing/citi_bike_nyc/content.handlebars
+++ b/share/spice/bike_sharing/citi_bike_nyc/content.handlebars
@@ -1,15 +1,16 @@
 <div class="tile__body">
-    <h1 class="zci__header tx--l7">{{title}}</h1>
+    <h1 class="zci__header tx--14">{{title}}</h1>
     <div class="tile__content side_by_side">
         <div class="left half">
-            <p class="tx-clr--dk">Bikes</p><br/><p class='tx-clr--dk t-xxl'>{{availableBikes}}</p>
+            <p class="tx-clr--dk tx--14">Bikes</p>
+            <p class='tx-clr--dk tx--25'>{{availableBikes}}</p>
         </div>
-
         <div class="right half">
-            <p class="tx-clr--dk">Docks</p><br/><p class='tx-clr--dk t-xxl'>{{availableDocks}}</p>
+            <p class="tx-clr--dk tx--14">Docks</p>
+            <p class='tx-clr--dk tx--25'>{{availableDocks}}</p>
         </div>
     </div>
-    <div class="tile__foot ">
-        <span class="tx--12 tx-clr--grey">Updated {{lastCommunication}}</span>
+    <div class="tile__foot">
+        <span class="tx--14 tx-clr--grey">Updated {{lastCommunication}}</span>
     </div>
 </div>

--- a/share/spice/gifs/gifs.js
+++ b/share/spice/gifs/gifs.js
@@ -26,7 +26,7 @@
                     return null;
                 }
                 return {
-                    thumbnail: item.images.fixed_height.url,
+                    thumbnail: item.images.fixed_height_still.url,
                     image: item.images.fixed_height.url,
                     url: item.url,
                     height: item.images.fixed_height.height,

--- a/share/spice/gifs/gifs.js
+++ b/share/spice/gifs/gifs.js
@@ -26,7 +26,7 @@
                     return null;
                 }
                 return {
-                    thumbnail: item.images.fixed_height_still.url,
+                    thumbnail: item.images.fixed_height.url,
                     image: item.images.fixed_height.url,
                     url: item.url,
                     height: item.images.fixed_height.height,


### PR DESCRIPTION
Final CSS and `name` adjustments.

Live here: https://beta.duckduckgo.com/?q=bike+sharing+nyc&ia=bikesharing

![bike_sharing_nyc_at_duckduckgo](https://cloud.githubusercontent.com/assets/873785/9646855/7080f2d4-51a5-11e5-9605-e9232aa0fed4.png)


/cc @abeyang @marianosimone @xuv

-----
IA Page: https://duck.co/ia/view/citi_bike_nyc