### PR TITLE
set timezone to lastCommunicationDate string before parsing as date

### DIFF
--- a/share/spice/bike_sharing/citi_bike_nyc/bike_sharing_citi_bike_nyc.js
+++ b/share/spice/bike_sharing/citi_bike_nyc/bike_sharing_citi_bike_nyc.js
@@ -87,7 +87,7 @@
                         title: item.stationName,
                         availableDocks: item.availableDocks,
                         availableBikes: item.availableBikes,
-                        lastCommunication: moment(new Date(item.lastCommunicationTime)).fromNow()
+                        lastCommunication: moment(new Date(item.lastCommunicationTime.replace(/\-/g,'/') + " EDT")).fromNow()
                     };
                 }
             });


### PR DESCRIPTION
Investigating #2156, I discovered that there's no problem with the date format, except for the fact that the timezone is NOT specified, so it depends on the user's timezone.

Adding EDT to the `lastCommunicationTime` should be enough to ensure consistent results