### PR TITLE
Add vendor prefixes to the transform CSS property

### DIFF
--- a/share/spice/yoga_asanas/yoga_asanas.css
+++ b/share/spice/yoga_asanas/yoga_asanas.css
@@ -9,6 +9,7 @@
     left: 50%;
     transform: translate(-50%,0);
     -webkit-transform: translate(-50%, 0);
+    -ms-transform: translate(-50%, 0);
 }
 
 .zci--yoga_asanas .tile__media {

--- a/share/spice/yoga_asanas/yoga_asanas.css
+++ b/share/spice/yoga_asanas/yoga_asanas.css
@@ -8,6 +8,7 @@
     bottom: -10px;
     left: 50%;
     transform: translate(-50%,0);
+    -webkit-transform: translate(-50%, 0);
 }
 
 .zci--yoga_asanas .tile__media {


### PR DESCRIPTION
I added 

```css
-webkit-transform: translate(-50%, 0);
-ms-transform: translate(-50%, 0);
```

So that this IA will work on IE 9 and Safari