### PR TITLE
first implementation of bike sharing for the Bay Area (CA)

### DIFF
--- a/lib/DDG/Spice/BikeSharing/BayAreaBikeShareCA.pm
+++ b/lib/DDG/Spice/BikeSharing/BayAreaBikeShareCA.pm
@@ -1,0 +1,39 @@
+package DDG::Spice::BikeSharing::BayAreaBikeShareCA;
+
+use strict;
+use DDG::Spice;
+
+name 'Bay Area Bike ShareCA';
+source 'Bay Area Bike Share CA';
+icon_url 'http://www.bayareabikeshare.com/assets/images/bayarea/icons/favicon.ico';
+description 'Search Bay Area Bike Share stations in the Bay Area, CA';
+primary_example_queries 'bike share bay area', 'bike share san francisco';
+secondary_example_queries 'bike share stations near san jose';
+category 'geography';
+topics 'everyday', 'travel', 'entertainment', 'geography';
+code_url 'https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/BikeSharing/BayAreaBikeShareCA.pm';
+attribution github => 'marianosimone',
+            web  => ['http://www.marianosimone.com',  'Mariano Simone'];
+
+triggers any => 'bike sharing', 'bike share', 'bikeshare';
+
+spice to => 'http://www.bayareabikeshare.com/stations/json';
+spice wrap_jsonp_callback => 1;
+spice is_cached => 0;
+spice proxy_cache_valid => '200 304 15m';
+
+my @places = ("bay area", "san francisco", "sfo", "sf", "san jose", "mountain view", "palo alto", "redwood", "redwood city");
+my $place_re = join "|", @places;
+
+handle remainder => sub {
+    my $place = $_ || undef;
+
+    unless ($place) {
+        $place = $loc->city if $loc && $loc->city;
+    }
+
+    return unless $place && $place =~ m/\b($place_re)\b/;
+    return $1;
+};
+
+1;

--- a/share/spice/bike_sharing/bay_area_bike_share_ca/bike_sharing_bay_area_bike_share_ca.css
+++ b/share/spice/bike_sharing/bay_area_bike_share_ca/bike_sharing_bay_area_bike_share_ca.css
@@ -1,0 +1,37 @@
+/* Resize map-pin icon */
+.zci--bay_area_bike_share_ca .mapview-marker__icn.ddgsi-circle {
+    font-size: 6px;
+}
+
+.tile--bay_area_bike_share_ca.tile--c--n {
+    text-align: center;
+    height: 11.5em;
+    width: 11.5em;
+}
+
+.tile--bay_area_bike_share_ca .tile__title {
+    font-weight: bold;
+}
+
+.tile--bay_area_bike_share_ca p.tx-clr--dk.tx--25 {
+    padding-top: 0;
+    padding-bottom: 0;
+    line-height: 1.1;
+}
+
+.tile--bay_area_bike_share_ca .tile__foot {
+    max-height: none;
+}
+
+.tile--bay_area_bike_share_ca .side_by_side .left {
+    border-right: 1px solid #E5E5E5;
+    padding-right: 10px;
+}
+
+.tile--bay_area_bike_share_ca .side_by_side .right {
+    padding-left: 10px;
+}
+
+.is-mobile .tile--bay_area_bike_share_ca .side_by_side div {
+    width: 50%;
+}

--- a/share/spice/bike_sharing/bay_area_bike_share_ca/bike_sharing_bay_area_bike_share_ca.js
+++ b/share/spice/bike_sharing/bay_area_bike_share_ca/bike_sharing_bay_area_bike_share_ca.js
@@ -1,0 +1,114 @@
+(function(env) {
+    "use strict";
+
+    var references = {
+        'san francisco': {
+            lat: 37.7577,
+            lon: -122.4376
+        },
+        'redwood city': {
+            lat: 37.5081359,
+            lon: -122.2139269
+        },
+        'palo alto': {
+            lat: 37.42565,
+            lon: -122.13535
+        },
+        'mountain view': {
+            lat: 37.4133235,
+            lon: -122.081267
+        },
+        'san jose': {
+            lat: 37.2970155,
+            lon: -121.817413
+        }
+    };
+
+    references['sf'] = references['sfo'] = references['san francisco'];
+    references['redwood'] = references['redwood city'];
+
+    env.ddg_spice_bike_sharing_bay_area_bike_share_ca = function(api_result) {
+        if (!api_result || !api_result.stationBeanList) {
+            return Spice.failed('bay_area_bike_share_ca');
+        }
+
+        var script = $('[src*="/js/spice/bike_sharing/bay_area_bike_share_ca/"]')[0],
+            source = $(script).attr("src"),
+            query = source.match(/bay_area_bike_share_ca\/([^\/]+)/)[1];
+
+        if (query) {
+            query = decodeURIComponent(query);
+        }
+
+        DDG.require('moment.js', function() {
+        DDG.require('maps', function() {
+            moment.locale('en', {
+                relativeTime : {
+                    past: "%s ago",
+                    s:    "1 sec",
+                    ss:   "%d sec",
+                    m:    "1 min",
+                    mm:   "%d min",
+                    h:    "1 hour",
+                    hh:   "%d hours",
+                    d:    "1 day",
+                    dd:   "%d days",
+                    M:    "1 month",
+                    MM:   "%d months",
+                    y:    "1 year",
+                    yy:   "%d years"
+                }
+            });
+            Spice.add({
+                id: 'bay_area_bike_share_ca',
+                name: 'Bike Sharing',
+                meta: {
+                    sourceName: 'Bay Area Bike Share',
+                    sourceUrl: 'http://www.bayareabikeshare.com/stations',
+                    itemType: 'Bike Stations',
+                    pinIcon: 'ddgsi-circle',
+                    pinIconSelected: 'ddgsi-star'
+                },
+                model: 'Place',
+                view: 'Places',
+                templates: {
+                    group: 'text',
+                    detail: false,
+                    item_detail: false,
+                    options: {
+                        footer: Spice.bike_sharing_bay_area_bike_share_ca.footer
+                    },
+                    variants: {
+                        tile: 'narrow',
+                        tileTitle: "3line"
+                    }
+                },
+                sort_fields: {
+                    distance: function(a, b) {
+                        return a.distanceToReference - b.distanceToReference;
+                    }
+                },
+                sort_default: 'distance',
+                data: api_result.stationBeanList,
+                normalize: function(item) {
+                    if (item.testStation || item.statusKey != 1) {
+                        return null;
+                    }
+                    if (references[query]) {
+                        var pointOfReference = L.latLng(references[query]);
+                    }
+                    return {
+                        name: item.stationName,
+                        lat: item.latitude,
+                        lon: item.longitude,
+                        distanceToReference: pointOfReference ? L.latLng(item.latitude, item.longitude).distanceTo(pointOfReference) : item.id,
+                        title: item.stationName,
+                        availableDocks: item.availableDocks,
+                        availableBikes: item.availableBikes
+                    };
+                }
+            });
+            });
+        });
+    }
+}(this));

--- a/share/spice/bike_sharing/bay_area_bike_share_ca/footer.handlebars
+++ b/share/spice/bike_sharing/bay_area_bike_share_ca/footer.handlebars
@@ -1,0 +1,10 @@
+<div class="tile__content side_by_side">
+    <div class="left half">
+        <p class="tx-clr--dk tx--14">Bikes</p>
+        <p class='tx-clr--dk tx--25'>{{availableBikes}}</p>
+    </div>
+    <div class="right half">
+        <p class="tx-clr--dk tx--14">Docks</p>
+        <p class='tx-clr--dk tx--25'>{{availableDocks}}</p>
+    </div>
+</div>

--- a/t/BikeSharing/BayAreaBikeShareCA.t
+++ b/t/BikeSharing/BayAreaBikeShareCA.t
@@ -1,0 +1,26 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+ddg_spice_test(
+    [qw( DDG::Spice::BikeSharing::BayAreaBikeShareCA )],
+    'bike share san francisco' => test_spice(
+        '/js/spice/bike_sharing/bay_area_bike_share_ca/san%20francisco',
+        call_type => 'include',
+        caller => 'DDG::Spice::BikeSharing::BayAreaBikeShareCA',
+    is_cached => 0,
+    ),
+    'bike share stations near san jose' => test_spice(
+        '/js/spice/bike_sharing/bay_area_bike_share_ca/san%20jose',
+        call_type => 'include',
+        caller => 'DDG::Spice::BikeSharing::BayAreaBikeShareCA',
+    is_cached => 0,
+    ),
+    'bike share' => undef,
+    'bike sharing new york' => undef,
+);
+
+done_testing;


### PR DESCRIPTION
After NYC and PHI, now comes the Bay Area!

![bike_share_bay_area](https://cloud.githubusercontent.com/assets/104916/9837351/c0eb92da-5a09-11e5-82b9-f3d86fce0478.png)

https://duck.co/ia/view/bay_area_bike_share_ca
