### PR TITLE
Fix timer CSS/Handlebars for dark theme

### DIFF
--- a/share/spice/timer/timer.css
+++ b/share/spice/timer/timer.css
@@ -41,7 +41,6 @@
     width: 140px;
     height: 140px;
     border: none;
-    background-color: #e0e0e0;
 }
 
 .zci--timer a#add_timer_btn {

--- a/share/spice/timer/timer_wrapper.handlebars
+++ b/share/spice/timer/timer_wrapper.handlebars
@@ -1,5 +1,5 @@
 {{!-- timers get added programmatically --}}
 
-<div class="tile" class="bg-clr--platinum-light" id="add_timer_container">
+<div class="tile bg-clr--platinum-light" id="add_timer_container">
     <a id="add_timer_btn" class="tx-clr--slate">{{#unless isMobile}}+{{else}}Add Timer{{/unless}}</a>
 </div>


### PR DESCRIPTION
Small adjustment to timer_wrapper markup and CSS so that the "add timer" button works correctly in the dark theme.

**Current:**

![timer_at_duckduckgo](https://cloud.githubusercontent.com/assets/873785/9859064/5da709c2-5af2-11e5-9655-fb88fbc175c8.png)


**Result:**

![timer_at_duckduckgo](https://cloud.githubusercontent.com/assets/873785/9859040/466cd7e6-5af2-11e5-82dd-8d96ee8eeb7b.png)


/cc @abeyang @andrey-p 