### PR TITLE
Amazon Prime Badge - Spice Update

### DIFF
--- a/share/spice/amazon/amazon.js
+++ b/share/spice/amazon/amazon.js
@@ -24,11 +24,17 @@
             templates: {
                 group: 'products',
                 options: {
-                    buy: 'products_amazon_buy'
+                    buy: 'products_amazon_buy',
+                    badge: 'products_amazon_badge'
                 }
             },
             relevancy: {
                 dup: ['ASIN','img_m','img']
+            },
+            normalize: function(item) {
+                item.showBadge = item.is_prime;
+
+                return item;
             },
             onItemShown: function(item) {
                 var arg = item.rating,


### PR DESCRIPTION
Showing the 'Prime' badge on appropriate items.  Requires an internal PR.