### PR TITLE
Twitter: Fixes #2158

### DIFF
--- a/share/spice/twitter/twitter.js
+++ b/share/spice/twitter/twitter.js
@@ -45,6 +45,7 @@
                     title: item.name,
                     subtitle: subtitle,
                     altSubtitle: getURL(item),
+                    url: "https://twitter.com/" + item.user,
                     description: item.description
                 };
             },


### PR DESCRIPTION
The title link now points to the result's Twitter page, as described in the issue.

![screen shot 2015-09-14 at 9 00 52 pm](https://cloud.githubusercontent.com/assets/1508487/9867536/c0e3d836-5b23-11e5-8d76-2e1b0eeefd2b.png)
