### PR TITLE
make CitiBikeNYC titles a little smaller, so 3rd line is not shown

### DIFF
--- a/share/spice/bike_sharing/citi_bike_nyc/bike_sharing_citi_bike_nyc.css
+++ b/share/spice/bike_sharing/citi_bike_nyc/bike_sharing_citi_bike_nyc.css
@@ -9,7 +9,7 @@
 }
 
 .tile--citi_bike_nyc .zci__header {
-    height: 2.5em;
+    height: 2.4em;
 }
 
 .tile--citi_bike_nyc p.tx-clr--dk.tx--14 {


### PR DESCRIPTION
Small fix to what @jagtalon found here: https://github.com/duckduckgo/zeroclickinfo-spice/pull/2176

![48852d48-5ada-11e5-9b6a-4a2349c55533](https://cloud.githubusercontent.com/assets/104916/9946691/e12d9b36-5d62-11e5-9cf9-0dbb78393520.png)
