### PR TITLE
IndegoPHL: Move to text template + footer, shrink tile size

### DIFF
--- a/share/spice/bike_sharing/indego_phl/bike_sharing_indego_phl.css
+++ b/share/spice/bike_sharing/indego_phl/bike_sharing_indego_phl.css
@@ -1,6 +1,10 @@
 /* Resize map-pin icon */
 .zci--bike_sharing_indego_phl .mapview-marker__icn.ddgsi-circle {
-  font-size: 6px;
+	font-size: 6px;
+}
+
+.tile--bike_sharing_indego_phl .tile__title {
+	font-weight: bold;
 }
 
 .tile--bike_sharing_indego_phl.tile--c--n {
@@ -21,11 +25,11 @@
 
 .tile--bike_sharing_indego_phl .side_by_side .left {
     border-right: 1px solid #E5E5E5;
-    padding-right: 7px;
+    padding-right: 10px;
 }
 
 .tile--bike_sharing_indego_phl .side_by_side .right {
-    padding-left: 7px;
+    padding-left: 10px;
 }
 
 .is-mobile .tile--bike_sharing_indego_phl .side_by_side div {

--- a/share/spice/bike_sharing/indego_phl/bike_sharing_indego_phl.css
+++ b/share/spice/bike_sharing/indego_phl/bike_sharing_indego_phl.css
@@ -4,8 +4,8 @@
 
 .tile--bike_sharing_indego_phl.tile--c--n {
     text-align: center;
-    width: 13em;
-    height: 13em;
+    width: 11.5em;
+    height: 11.5em;
 }
 
 .tile--bike_sharing_indego_phl .zci__header {
@@ -20,6 +20,10 @@
     padding-top: 0;
     padding-bottom: 0;
     line-height: 1.1;
+}
+
+.tile--bike_sharing_indego_phl .tile__foot {
+    max-height: none;
 }
 
 .tile--bike_sharing_indego_phl div.tile__content.side_by_side {

--- a/share/spice/bike_sharing/indego_phl/bike_sharing_indego_phl.css
+++ b/share/spice/bike_sharing/indego_phl/bike_sharing_indego_phl.css
@@ -1,3 +1,4 @@
+/* Resize map-pin icon */
 .zci--bike_sharing_indego_phl .mapview-marker__icn.ddgsi-circle {
   font-size: 6px;
 }
@@ -6,14 +7,6 @@
     text-align: center;
     width: 11.5em;
     height: 11.5em;
-}
-
-.tile--bike_sharing_indego_phl .zci__header {
-    height: 2.5em;
-}
-
-.tile--bike_sharing_indego_phl p.tx-clr--dk.tx--14 {
-    padding-top: 0;
 }
 
 .tile--bike_sharing_indego_phl p.tx-clr--dk.tx--25 {
@@ -26,32 +19,15 @@
     max-height: none;
 }
 
-.tile--bike_sharing_indego_phl div.tile__content.side_by_side {
-    margin-top: 18px;
-}
-
-.tile--bike_sharing_indego_phl .side_by_side {
-    margin-left: auto;
-    margin-right: auto;
-    width: 100%;
-}
-
-
 .tile--bike_sharing_indego_phl .side_by_side .left {
-    float: left;
     border-right: 1px solid #E5E5E5;
     padding-right: 7px;
 }
 
-.is-mobile .tile--bike_sharing_indego_phl .side_by_side .left {
-    width: 50%;
-}
-
 .tile--bike_sharing_indego_phl .side_by_side .right {
-    float: right;
     padding-left: 7px;
 }
 
-.is-mobile .tile--bike_sharing_indego_phl .side_by_side .right {
+.is-mobile .tile--bike_sharing_indego_phl .side_by_side div {
     width: 50%;
 }

--- a/share/spice/bike_sharing/indego_phl/bike_sharing_indego_phl.js
+++ b/share/spice/bike_sharing/indego_phl/bike_sharing_indego_phl.js
@@ -61,7 +61,8 @@
                             footer: Spice.bike_sharing_indego_phl.footer
                         },
                         variants: {
-                            tile: 'narrow'
+                            tile: 'narrow',
+                            tileTitle: "3line"
                         }
                     },
                     sort_fields: {

--- a/share/spice/bike_sharing/indego_phl/bike_sharing_indego_phl.js
+++ b/share/spice/bike_sharing/indego_phl/bike_sharing_indego_phl.js
@@ -37,12 +37,28 @@
                         pinIcon: 'ddgsi-circle',
                         pinIconSelected: 'ddgsi-star'
                     },
+                    data: api_result.features,
+                    normalize: function(item) {
+                        if (item.geometry.length < 2 || item.geometry.length > 2 || item.properties.kioskPublicStatus !== 'Active') {
+                            return null;
+                        }
+                        return {
+                            title: item.properties.name,
+                            name: item.properties.name,
+                            lat: (item.geometry.coordinates[1]).toString(),
+                            lon: (item.geometry.coordinates[0]).toString(),
+                            docksAvailable: item.properties.docksAvailable,
+                            bikesAvailable: item.properties.bikesAvailable
+                        };
+                    },
                     model: 'Place',
                     view: 'Places',
                     templates: {
-                        item: 'base_item',
+                        group: "text",
+                        detail: false,
+                        item_detail: false,
                         options: {
-                            content: Spice.bike_sharing_indego_phl.content
+                            footer: Spice.bike_sharing_indego_phl.footer
                         },
                         variants: {
                             tile: 'narrow'
@@ -53,21 +69,7 @@
                             return a.distanceToReference - b.distanceToReference;
                         }
                     },
-                    sort_default: 'distance',
-                    data: api_result.features,
-                    normalize: function(item) {
-                        if (item.geometry.length < 2 || item.geometry.length > 2 || item.properties.kioskPublicStatus !== 'Active') {
-                            return null;
-                        }
-                        return {
-                            name: item.properties.name,
-                            lat: (item.geometry.coordinates[1]).toString(),
-                            lon: (item.geometry.coordinates[0]).toString(),
-                            title: item.properties.name,
-                            docksAvailable: item.properties.docksAvailable,
-                            bikesAvailable: item.properties.bikesAvailable,
-                        };
-                    }
+                    sort_default: 'distance'
                 });
             });
         });

--- a/share/spice/bike_sharing/indego_phl/bike_sharing_indego_phl.js
+++ b/share/spice/bike_sharing/indego_phl/bike_sharing_indego_phl.js
@@ -63,6 +63,9 @@
                         variants: {
                             tile: 'narrow',
                             tileTitle: "3line"
+                        },
+                        elClass: {
+                            tileTitle: "tx--14"
                         }
                     },
                     sort_fields: {

--- a/share/spice/bike_sharing/indego_phl/footer.handlebars
+++ b/share/spice/bike_sharing/indego_phl/footer.handlebars
@@ -1,4 +1,3 @@
-<h1 class="zci__header tx--14">{{title}}</h1>
 <div class="tile__content side_by_side">
     <div class="left half">
         <p class="tx-clr--dk tx--14">Bikes</p>


### PR DESCRIPTION
- Move to built-in `text` template
- Shrink tile sizeto 11.5 x 11.5em (144x144px)

to @abeyang 

/cc @AcriCAA @marianosimone @jagtalon 

@marianosimone can you please make the same changes to the BayAreaBikeSharing PR -- seeing as it also doesn't have the need for extra footer space as it doesn't have update times

-----

Result:

![1____projects_zeroclickinfo-spice__perl__and_bike_share_phl_at_duckduckgo](https://cloud.githubusercontent.com/assets/873785/9950480/f85db400-5d88-11e5-922c-3c2e5325ccea.png)
