### PR TITLE
Coderwall: remove image and switch to text template

### DIFF
--- a/share/spice/coderwall/coderwall.js
+++ b/share/spice/coderwall/coderwall.js
@@ -58,7 +58,7 @@
             },
 
             templates: {
-                group: 'text'
+                group: 'icon'
             }
         });
     };

--- a/share/spice/coderwall/coderwall.js
+++ b/share/spice/coderwall/coderwall.js
@@ -43,10 +43,13 @@
                   subtitles.push(item.title);
                 }
                 return {
+                    // Remove image for now
+                    // cropped photos look bad
+
                     // some thumbnail URIs are relative to coderwall.com
-                    image: /^\//.test(item.thumbnail)
-                        ? 'https://coderwall.com/' + item.thumbnail
-                        : item.thumbnail,
+                    // image: /^\//.test(item.thumbnail)
+                    //     ? 'https://coderwall.com/' + item.thumbnail
+                    //     : item.thumbnail,
                     title: item.name,
                     subtitle: subtitles,
                     altSubtitle: item.location,
@@ -55,10 +58,7 @@
             },
 
             templates: {
-                group: 'icon',
-                variants: {
-                    iconImage: 'large'
-                }
+                group: 'text'
             }
         });
     };


### PR DESCRIPTION
@abeyang I removed the image, but the icon template is obviously meant to use an icon so there was padding on the title/subtitles.

I assume we should be using the text template instead? Here's the result:

![coderwall_jpcamara_at_duckduckgo](https://cloud.githubusercontent.com/assets/873785/10046072/b55290c2-61d4-11e5-833e-24a89c78da52.png)

Here's the icon template, without the image: 

![coderwall_jpcamara_at_duckduckgo](https://cloud.githubusercontent.com/assets/873785/10046104/cd8e7fca-61d4-11e5-956d-37f5d7648bdc.png)

**Update**: Just realized the `text_detail` template doesn't support an `altSubtitle` I guess we'll have to use the `Icon` template and some CSS. Alternatively, we could add an altSubtitle to the text template?
