### PR TITLE
Currency Tiles - Fix Border

### DIFF
--- a/share/spice/currency/currency.css
+++ b/share/spice/currency/currency.css
@@ -33,34 +33,11 @@
     padding-top: 1.4em;
 }
 
-.zci--currency .tile--s .currency--border {
-    display: inline-block;
-    width: 36px;
-    height: 36px;
-    position: absolute;
-    top: 15.5px;
-    left: 0;
-    right: 0;
-    margin-left: auto;
-    margin-right: auto;
-    border-radius: 50%;
-    background-color: rgba(50,50,50, .2);
-}
-
-.is-mobile .zci--currency .tile--s .currency--border {
-    display: none;
-}
-
-.zci--currency .tile--s img {
+.zci--currency .currency--disc {
+    line-height: 32px;
     height: 32px;
-    vertical-align: top;
-    position: relative;
+    width: 32px;
 }
-
-    .is-mobile .zci--currency .tile--s img {
-        border: 0.2em solid rgba(50,50,50, .2);
-        border-radius: 50%;
-    }
 
 .zci--currency .tile--s .currency--symbol {
     margin-top: 0.6em;

--- a/share/spice/currency/item.handlebars
+++ b/share/spice/currency/item.handlebars
@@ -3,8 +3,9 @@
         <span class="btn--container">
             <a class="ddgsi btn btn--lite" href="/?q=1+{{toCurrencySymbol}}">↩</a>
         </span>
-        <span class="currency--border"></span>
-        <img src="{{toFlag}}" alt="Flag of {{toCurrencySymbol}}">
+        <div class="disc currency--disc">
+            <img class="disc__img" src="{{toFlag}}" alt="Flag of {{toCurrencySymbol}}">
+        </div>
         <div class="currency--symbol">{{toCurrencySymbol}}</div>
         <div class="currency--amount one-line">{{convertedAmount}}</div>
         <div class="one-line currency--rate {{#unless initial}}tx-clr--lt{{/unless}}">{{#if initial}}{{currencyName}}{{else}}{{rate}}{{/if}}</div>


### PR DESCRIPTION
Uses the pre-built `disc` class to handle the styling for the flags in these currency tiles.  They now have an inset border. 

to @jagtalon 
cc @abeyang @moollaza @chrismorast 

---

IA Page: https://duck.co/ia/view/currency
