### PR TITLE
Flight(s) typo

### DIFF
--- a/share/spice/airlines/airlines.js
+++ b/share/spice/airlines/airlines.js
@@ -272,7 +272,7 @@
                 sourceUrl: "http://www.flightstats.com/go/FlightStatus/flightStatusByFlight.do?"
                     + "airlineCode=" + results[0].airlineCode 
                     + "&flightNumber=" + results[0].flightNumber,
-                itemType: results.length === 1 ? "flight" : "flights by departure time" 
+                itemType: results.length === 1 ? "Flight" : "Flights" 
             },
             normalize: function(item) {
 


### PR DESCRIPTION
I received the duckduckhack weekly update
where this was listed under 5 minutes fixes. It said, It should say "Flights" when we present multiple results. Otherwise, just say "Flight".
Submitting the patch for the same.

Fixes https://github.com/duckduckgo/zeroclickinfo-spice/issues/2068