### PR TITLE
Fix movies lo-res fallback image so we don't have empty tiles

### DIFF
--- a/share/spice/in_theaters/in_theaters.js
+++ b/share/spice/in_theaters/in_theaters.js
@@ -1,20 +1,6 @@
 (function(env) {
     "use strict";
     
-    // A change in the Rotten Tomatoes API returns images that end in _tmb.
-    // This changes this to _det.
-    function toDetail(img) {
-        if(/resizing\.flixster\.com/.test(img)) {
-            // Everything before the size of the image can be removed and it would still work.
-            img = img.replace(/.+\/\d+x\d+\/(.+)/, "http://$1");
-            // Better use the _det size (which is smaller) instead of the _ori size.
-            return img.replace(/_ori/, "_det");
-        }
-        
-        // Otherwise, use the old string replacement strategy.
-        return img.replace(/tmb\.(jpg|png)/, "det.$1");
-    }
-    
     function get_image(critics_rating) {
         if(!critics_rating) {
             return;
@@ -76,18 +62,14 @@
                     position = "-272px -144px";
                 }
                 
-                // Modify the image from _tmb.jpg to _det.jpg
-                var image = toDetail(item.posters.detailed)
-                
                 if(item.alternate_ids && item.alternate_ids.imdb) {
                     return {
                         rating: item.ratings.critics_score >= 0 ? item.ratings.critics_score / 20 : 0,
-                        //image: image,
                         icon_image: get_image(item.ratings.critics_rating),
                         abstract: Handlebars.helpers.ellipsis(item.synopsis, 200),
                         heading: item.title,
-                        img: image,
-                        //img_m: image,
+                        fallback_image: item.posters.detailed,
+                        image: null,
                         url: item.links.alternate,
                         is_retina: ((DDG.is3x || DDG.is2x) ? 'is_retina' : 'no_retina')
                     };
@@ -119,13 +101,16 @@
                     var path = data && data.movie_results && data.movie_results.length && data.movie_results[0].poster_path,
                         image = path && "https://image.tmdb.org/t/p/w185" + path;
 
-                    if (image) {
-                        item.set({
-                            img: image,
-                            img_m: image,
-                            image: image
-                        });
-                    }
+                    item.set({
+                        // fallback to lo-res if call to get hi-res fails for some reason,
+                        // at least lo-res is better than showing an empty white tile:
+                        image: image || item.fallback_image,
+
+                        // don't fall back on detail pane because it looks silly
+                        // with the tiny image
+                        img: image,
+                        img_m: image
+                    });
                 });
             }
         });


### PR DESCRIPTION
Using the lo-res image as a fallback for movies tiles so we don't have empty white tiles. Not ideal, but imo better than a broken looking tile.

What it currently looks like in production:
<img width="1004" alt="screen shot 2015-09-28 at 6 32 59 am" src="https://cloud.githubusercontent.com/assets/126358/10136852/add04634-65c4-11e5-9a91-0ca54e740ef0.png">

With stretched image (tiles are in slightly different order on my dev box cause of caching):
![screen shot 2015-09-28 at 9 39 15 am](https://cloud.githubusercontent.com/assets/126358/10136898/ebdb4582-65c4-11e5-9155-397034152572.png)

@jagtalon 
cc @andrey-p @moollaza 
