### PR TITLE
Cryptocurrency error handling

### DIFF
--- a/share/spice/cryptocurrency/cryptocurrency.js
+++ b/share/spice/cryptocurrency/cryptocurrency.js
@@ -98,15 +98,15 @@
             script = $('[src*="/js/spice/cryptocurrency/"]')[0],
             source = $(script).attr("src");
 
-        if (typeof ticker !== 'undefined') {
+        if (ticker && ticker.base && ticker.target && ticker.price) {
 
             // Get amount from original query
             var query = source.match(/\/ticker\/(?:.*)\/(.+)/)[1],
                 queryAmount = parseFloat(decodeURIComponent(query)),
                 // Calculate price, rates, and amounts
-                base = api_result.ticker.base,
-                target = api_result.ticker.target,
-                price = parseFloat(api_result.ticker.price);
+                base = ticker.base,
+                target = ticker.target,
+                price = parseFloat(ticker.price);
 
             results = api_result;
             convertedAmount = queryAmount * price;
@@ -115,7 +115,7 @@
             // Format Time and Date
             timestamp = api_result.timestamp * 1000;
 
-        } else if (typeof rows !== 'undefined') {
+        } else if (rows && rows.length) {
 
             // Get amount from original query
             var query = source.match(/\/secondaries\/(.+)\/(?:.*)/)[1],


### PR DESCRIPTION
I can't reproduce this anymore, but a few weeks ago we were seeing cases that this error was being thrown:
```
TypeError: rows[0] is undefined
```

I'm assuming it was a case where `rows` was just an empty array. But in these cases where it threw the error it was not calling Spice.failed(), which would cause a bad fallback to images. I don't think there's any harm in adding these additional checks, but please let me know if you think we can't do this.