### PR TITLE
make bikeshare trigger CitiBike NYC IA

### DIFF
--- a/lib/DDG/Spice/BikeSharing/CitiBikeNYC.pm
+++ b/lib/DDG/Spice/BikeSharing/CitiBikeNYC.pm
@@ -15,7 +15,7 @@ code_url 'https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/
 attribution github => 'marianosimone',
             web  => ['http://www.marianosimone.com',  'Mariano Simone'];
 
-triggers any => 'citibike', 'citi bike', 'bike sharing', 'bike share';
+triggers any => 'citibike', 'citi bike', 'bike sharing', 'bike share', 'bikeshare';
 
 spice to => 'https://www.citibikenyc.com/stations/json';
 spice wrap_jsonp_callback => 1;

--- a/t/BikeSharing/CitiBikeNYC.t
+++ b/t/BikeSharing/CitiBikeNYC.t
@@ -19,6 +19,12 @@ ddg_spice_test(
         caller => 'DDG::Spice::BikeSharing::CitiBikeNYC',
     is_cached => 0,
     ),
+    'bikeshare queens' => test_spice(
+        '/js/spice/bike_sharing/citi_bike_nyc/queens',
+        call_type => 'include',
+        caller => 'DDG::Spice::BikeSharing::CitiBikeNYC',
+    is_cached => 0,
+    ),
     'citibike' => undef,
     'citibike washington' => undef,
 );


### PR DESCRIPTION
Thanks to @AcriCAA's suggestion, 'bikeshare' (and not only 'bike share') now trigger the CitiBike NYC IA