### PR TITLE
Fix #2205 - apply 'disc' class to cryptocurrency IA

### DIFF
--- a/share/spice/cryptocurrency/cryptocurrency.css
+++ b/share/spice/cryptocurrency/cryptocurrency.css
@@ -51,17 +51,18 @@
     display: none;
 }
 
-.zci--cryptocurrency .tile--s img {
-    height: 32px;
-    vertical-align: top;
-    z-index: 2;
-    position: relative;
+.zci--cryptocurrency .currency--disc {
+     line-height: 32px;
+     height: 32px;
+     vertical-align: top;
+     position: relative;
+     width: 32px;
 }
 
-    .is-mobile .zci--cryptocurrency .tile--s img {
+.is-mobile .zci--cryptocurrency .tile--s img {
         border: 0.2em solid rgba(50,50,50, .2);
         border-radius: 50%;
-    }
+}
 
 .zci--cryptocurrency .tile--s .cryptocurrency--symbol {
     margin-top: 0.6em;

--- a/share/spice/cryptocurrency/cryptocurrency.css
+++ b/share/spice/cryptocurrency/cryptocurrency.css
@@ -60,7 +60,7 @@
 }
 
 .is-mobile .zci--cryptocurrency .tile--s img {
-        border: 0.2em solid rgba(50,50,50, .2);
+        border: solid rgba(50,50,50, .2);
         border-radius: 50%;
 }
 

--- a/share/spice/cryptocurrency/item.handlebars
+++ b/share/spice/cryptocurrency/item.handlebars
@@ -3,8 +3,9 @@
         <span class="btn--container">
             <a class="ddgsi btn btn--lite" href="/?q=1+{{toCurrencySymbol}}">↩</a>
         </span>
-        <span class="cryptocurrency--border"></span>
-        <img src="{{toFlag}}" alt="Flag of {{toCurrencySymbol}}">
+        <div class="disc currency--disc">
+          <img class="disc__img" src="{{toFlag}}" alt="Flag of {{toCurrencySymbol}}">
+        </div>
         <div class="cryptocurrency--symbol">{{toCurrencySymbol}}</div>
         <div class="cryptocurrency--amount one-line">{{convertedAmount}}</div>
         <div class="one-line cryptocurrency--rate {{#unless initial}}tx-clr--lt{{/unless}}">{{#if initial}}{{currencyName}}{{else}}{{rate}}{{/if}}</div>


### PR DESCRIPTION
I just got the latest duckduckhack newsletter and decided to fix one of the low-hanging fruits. :smile: 

The cryptocurrency symbols are now using the `disc` class when searching for "[50 LTC][0]" for example. I was triggering a conversion by searching for "[50 LTC in EUR][1]" first, but that's not using any of the CSS classes I was looking at. But I hope I got all the right places.

[0]: https://duckduckgo.com/?q=10+ltc&ia=cryptocurrency
[1]: https://duckduckgo.com/?q=50+ltc+in+eur&ia=cryptocurrency

-----
IA Page: https://duck.co/ia/view/cryptocurrency