### PR TITLE
Hardcode Android icon to use DDG Favicon, like we do for Apple

### DIFF
--- a/share/spice/quixey/quixey.js
+++ b/share/spice/quixey/quixey.js
@@ -290,11 +290,17 @@
         return qprice(obj);
     });
 
-    // template helper to replace iphone and ipod icons with
-    // smaller 'Apple' icons
+    // template helper to replace iphone, ipod, and android icons with
+    // smaller 'Apple' and 'Android' icons
     Handlebars.registerHelper("Quixey_platform_icon", function(icon_url) {
+        // Apple IDs
         if (this.id === 2004 || this.id === 2015) {
             return "https://icons.duckduckgo.com/i/itunes.apple.com.ico";
+        }
+
+        // Android ID
+        if (this.id === 2005) {
+            return "https://icons.duckduckgo.com/ip2/www.android.com.ico";
         }
 
         return "/iu/?u=" + icon_url + "&f=1";


### PR DESCRIPTION
This fixes the current problem we're experiencing with broken Android icon links from the Quixey API.

This is the simplest and easiest solution to this problem. Quixey is having difficulty resolving it on their end so this essentially ignores the problem. We already use this solution for Apple icons so this is a pretty straightforward solution. 

Merging as hotfix. Tested and working fine. Live here: https://moollaza.duckduckgo.com/?q=flight+tracking+apps&ia=apps&iai=FlightAware+Flight+Tracker

/cc @jagtalon @bsstoner 