### PR TITLE
Aur: Remove callback parameter

### DIFF
--- a/lib/DDG/Spice/Aur.pm
+++ b/lib/DDG/Spice/Aur.pm
@@ -3,7 +3,7 @@ package DDG::Spice::Aur;
 
 use strict;
 use DDG::Spice;
-spice is_cached => 1; 
+spice is_cached => 1;
 
 name "Aur";
 source "aur.archlinux.org";
@@ -17,7 +17,8 @@ attribution twitter => 'crazedpsyc',
                  cpan => 'CRZEDPSYC',
                  github => ['NateBrune', 'Nate Brune'];
 
-spice to => 'https://aur.archlinux.org/rpc.php?type=search&arg=$1&callback={{callback}}';
+spice to => 'https://aur.archlinux.org/rpc.php?type=search&arg=$1';
+spice wrap_jsonp_callback => 1;
 
 triggers any => "aur", "archlinux package", "arch package", "arch linux package";
 


### PR DESCRIPTION
Fixes #2241.

Added `spice wrap_jsonp_callback => 1;`, while removing the callback parameter in the API endpoint.
