### PR TITLE
Fixes issue #2235

### DIFF
--- a/lib/DDG/Spice/Currency.pm
+++ b/lib/DDG/Spice/Currency.pm
@@ -43,7 +43,7 @@ my $question_prefix = qr/(?:convert|what (?:is|are|does)|how (?:much|many) (?:is
 my $number_re = number_style_regex();
 my $cardinal_re = join('|', qw(hundred thousand k million m billion b trillion));
 
-my $guard = qr/^$question_prefix(\p{Currency_Symbol})?\s?($number_re*)(\p{Currency_Symbol})?\s?($cardinal_re)?\s?($currency_qr)?(?:s)?(?:$into_qr|$vs_qr|\s)?($number_re*)\s?($currency_qr)?(\p{Currency_Symbol})?(?:s)?\??$/i;
+my $guard = qr/^$question_prefix(\p{Currency_Symbol})?\s?($number_re*)\s?(\p{Currency_Symbol})?\s?($cardinal_re)?\s?($currency_qr)?(?:s)?(?:$into_qr|$vs_qr|\s)?($number_re*)\s?($currency_qr)?(\p{Currency_Symbol})?(?:s)?\??$/i;
 
 triggers query_lc => qr/\p{Currency_Symbol}|$currency_qr/;
 

--- a/lib/DDG/Spice/Currency.pm
+++ b/lib/DDG/Spice/Currency.pm
@@ -43,7 +43,7 @@ my $question_prefix = qr/(?:convert|what (?:is|are|does)|how (?:much|many) (?:is
 my $number_re = number_style_regex();
 my $cardinal_re = join('|', qw(hundred thousand k million m billion b trillion));
 
-my $guard = qr/^$question_prefix(\p{Currency_Symbol})?($number_re*)(\p{Currency_Symbol})?\s?($cardinal_re)?\s?($currency_qr)?(?:s)?(?:$into_qr|$vs_qr|\s)?($number_re*)\s?($currency_qr)?(\p{Currency_Symbol})?(?:s)?\??$/i;
+my $guard = qr/^$question_prefix(\p{Currency_Symbol})?\s?($number_re*)(\p{Currency_Symbol})?\s?($cardinal_re)?\s?($currency_qr)?(?:s)?(?:$into_qr|$vs_qr|\s)?($number_re*)\s?($currency_qr)?(\p{Currency_Symbol})?(?:s)?\??$/i;
 
 triggers query_lc => qr/\p{Currency_Symbol}|$currency_qr/;
 

--- a/t/Currency.t
+++ b/t/Currency.t
@@ -201,6 +201,13 @@ ddg_spice_test(
         caller => 'DDG::Spice::Currency',
         is_cached => 0
     ),
+    
+    '321 $ to yen' => test_spice(
+        '/js/spice/currency/321/usd/jpy',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
 
    '$45 to ؋' => test_spice(
         '/js/spice/currency/45/usd/afn',

--- a/t/Currency.t
+++ b/t/Currency.t
@@ -187,7 +187,20 @@ ddg_spice_test(
         caller => 'DDG::Spice::Currency',
         is_cached => 0
     ),
-
+    
+    '€ 20 to $' => test_spice(
+        '/js/spice/currency/20/eur/usd',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
+    
+    '$ 321 into yen' => test_spice(
+        '/js/spice/currency/321/usd/jpy',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
 
    '$45 to ؋' => test_spice(
         '/js/spice/currency/45/usd/afn',


### PR DESCRIPTION
Fixes issue #2235.
Change trigger to handle space between leading/trailing currency symbol and number. 