### PR TITLE
GitHub - Escape query parameter

### DIFF
--- a/share/spice/github/github.js
+++ b/share/spice/github/github.js
@@ -33,7 +33,7 @@
                 data: results,
                 meta: {
                     itemType: itemType,
-                    searchTerm: query,
+                    searchTerm: unescape(query),
                     sourceUrl: 'https://www.github.com/search?q=' +  encodeURIComponent(query),
                     sourceName: 'GitHub'
                 },

--- a/t/Github.t
+++ b/t/Github.t
@@ -27,7 +27,11 @@ ddg_spice_test(
         call_type => 'include',
         caller => 'DDG::Spice::Github'
     ),
-
+    'github @duckduckgo' => test_spice(
+        '/js/spice/github/%40duckduckgo',
+        call_type => 'include',
+        caller => 'DDG::Spice::Github'
+    ),
     'github status' => undef
 );
 


### PR DESCRIPTION
Fixes #2268.

![screen shot 2015-11-09 at 10 05 41 am](https://cloud.githubusercontent.com/assets/5793364/11024458/94b65370-86c9-11e5-9e53-67839cc4dac2.png)
