### PR TITLE
Expatisan: Switch to HTTPS, because HTTP redirects

### DIFF
--- a/lib/DDG/Spice/Expatistan.pm
+++ b/lib/DDG/Spice/Expatistan.pm
@@ -17,7 +17,7 @@ attribution github => ['https://github.com/hunterlang','Hunter Lang'];
 
 triggers any => "cost of living";
 
-spice to => 'http://www.expatistan.com/api/spice?q=$1&api_key={{ENV{DDG_SPICE_EXPATISTAN_APIKEY}}}';
+spice to => 'https://www.expatistan.com/api/spice?q=$1&api_key={{ENV{DDG_SPICE_EXPATISTAN_APIKEY}}}';
 
 handle query_lc => sub {
     return $_ if $_;


### PR DESCRIPTION
Fixes #2250 

HTTP API now redirects to HTTPS, which is breaking the IA in production. This fixes that.

Working here: https://moollaza.duckduckgo.com/?q=cost+of+living+in+philadelphia&ia=answer