### PR TITLE
Pwned Spice: Update design with larger snippet, footer and subtitle

### DIFF
--- a/lib/DDG/Spice/Pwned.pm
+++ b/lib/DDG/Spice/Pwned.pm
@@ -14,7 +14,7 @@ spice wrap_jsonp_callback => 1;
 spice error_fallback => 'Email address not found';
 
 handle remainder_lc => sub {
-    return $_ if $_ =~ /.+\@.+/;
+    return $_ if $_ =~ /\b([a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,})\b/;
     return;
 };
 

--- a/share/spice/pwned/footer.handlebars
+++ b/share/spice/pwned/footer.handlebars
@@ -1,0 +1,4 @@
+<div class="one-line">
+	 <span class="ddgsi ddgsi-clock"></span>
+	 {{date}}
+ </div>

--- a/share/spice/pwned/pwned.js
+++ b/share/spice/pwned/pwned.js
@@ -5,62 +5,58 @@
             return Spice.failed('pwned');
         }
 
-        Spice.add({
-            id: "pwned",
-            name: "Pwned",
-            data: api_result,
-            meta: {
-                sourceName: "Have I Been Pwned",
-                sourceUrl: 'https://haveibeenpwned.com/'
-            },
-            normalize: function(item) {
+        var query = DDG.get_query(),
+            re    = /\b([a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,})\b/i, //capture email from query
+            email = re.exec(query)[1];
 
-                if (item.fallback) {
-                    return {
-                        title: item.fallback,
+		DDG.require("moment.js", function(){
+	        Spice.add({
+	            id: "pwned",
+	            name: "Pwned",
+	            data: api_result,
+	            meta: {
+	                sourceName: "Have I Been Pwned",
+	                sourceUrl: 'https://haveibeenpwned.com/account/' + email,
+                    primaryText: email + " is compromised:",
+                    snippetChars: 170
+	            },
+	            normalize: function(item) {
+
+	                if (item.fallback) {
+	                    return {
+	                        title: item.fallback
+	                    };
+	                } else {
+	                    return {
+	                        title: item.Name,
+							altSubtitle: item.Domain,
+							date: moment(item.BreachDate).format("MMM DD, YYYY"),
+	                        description: DDG.strip_html(item.Description).replace(/&quot;/g, "\"")
+	                    };
+	                }
+	            },
+	            templates: {
+	                group: 'icon',
+					item_detail: false,
+					detail: false,
+					variants: {
+                        tileTitle: "1line-large",
+                        tileSnippet: "large"
+					},
+                    options: {
+                        footer: Spice.pwned.footer
                     }
-                } else {
-                    var boxData = [{heading: 'Account Information:'}];
-                    if (item.Title) {
-                        boxData.push({
-                            label: "Title",
-                            value: item.Title
-                        });
-                    }
-                    if (item.Name) {
-                        boxData.push({
-                            label: "Name",
-                            value: item.Name,
-                        });
-                    }
-                    if (item.Domain) {
-                        boxData.push({
-                            label: "Domain",
-                            value: item.Domain
-                        });
-                    }
-                    if (item.DataClasses) {
-                        boxData.push({
-                            label: "Exposed Information: ",
-                            value: item.DataClasses.join(", ")
-                        });
-                    }
-                    return {
-                        title: item.Name,
-                        description: DDG.strip_html(item.Description),
-                        subtitle: item.DataClasses.join(", "),
-                        infoboxData: boxData,
-                    }
-                }
-            },
-            templates: {
-                group: 'text'
-            }
-        });
+	            },
+			    relevancy: {
+			        type: api_result.fallback ? null : "primary", // detect when api returned error
+			        primary: [
+			            {required: 'Title'},
+			            {required: 'Name'},
+			            {required: 'Domain'},
+			            {required: 'DataClasses'}
+			        ]
+			    }
+        	});
+		});
     };
 }(this));
-
-
-
-
-


### PR DESCRIPTION
Continuing #2267...

Made some adjustments to this IA. The result looks like this:

![have_i_been_pwned_test_hotmail_com_at_duckduckgo_and_1____projects_zeroclickinfo-spice__bash_](https://cloud.githubusercontent.com/assets/873785/11138778/985621e0-8994-11e5-9076-a702a9b94048.png)

I tried using the Clearbit [company logo API](http://blog.clearbit.com/logo) to produce icons for each company and it works pretty well, but in the cases where they have no logo, we end up show ugly `alt` text:

![have_i_been_pwned_test_hotmail_com_at_duckduckgo](https://cloud.githubusercontent.com/assets/873785/11138793/e6feb2ee-8994-11e5-9593-7eca3bc7d1b6.png)


---

I think we need some padding between the footer and snippet, but that should be handled at the template level, because it will affect all IAs -- /cc @abeyang 

/cc @b2ddg 