### PR TITLE
Skip host veriication with LWP SSL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 ---
 sudo: false
+env:
+  - PERL_LWP_SSL_VERIFY_HOSTNAME=0
 before_install:
   - export HARNESS_OPTIONS=j10:c HARNESS_TIMER=1
   - git config --global user.name "Dist Zilla Plugin TravisCI"


### PR DESCRIPTION
Travis breaks when trying to connect to HTTPS links on S3.  This disables the host verification checks for tests.