### PR TITLE
Quixey: update apple and android icons. Add hardcoded windows icon also

### DIFF
--- a/share/spice/quixey/quixey.js
+++ b/share/spice/quixey/quixey.js
@@ -295,12 +295,17 @@
     Handlebars.registerHelper("Quixey_platform_icon", function(icon_url) {
         // Apple IDs
         if (this.id === 2004 || this.id === 2015) {
-            return "https://icons.duckduckgo.com/i/itunes.apple.com.ico";
+            return "https://icons.duckduckgo.com/ip2/apple.com.ico";
         }
 
         // Android ID
         if (this.id === 2005) {
-            return "https://icons.duckduckgo.com/ip2/www.android.com.ico";
+            return "https://icons.duckduckgo.com/ip2/developer.android.com.ico";
+        }
+
+        // Microsoft Windows ID
+        if (this.id === 8556073) {
+            return "https://icons.duckduckgo.com/ip2/blogs.windows.com.ico";
         }
 
         return "/iu/?u=" + icon_url + "&f=1";


### PR DESCRIPTION
- Quixey API is serving us icons that consistently cause a 502 error. I resolved this by displaying on our own favicons
- Our favicon urls have changed, so this updates Apple and Android accordingly. I've also added support for Microsoft icons because those were producing 502 errors as well.

Result:

<img width="1092" alt="flight_tracking_apps_at_duckduckgo" src="https://cloud.githubusercontent.com/assets/873785/11214879/8e5e3c92-8d11-11e5-8942-c81232d1fda0.png">


//cc @jagtalon 
