### PR TITLE
Issue #2099 - Last.fm Artist: reign in triggering

### DIFF
--- a/lib/DDG/Spice/Lastfm/Artist.pm
+++ b/lib/DDG/Spice/Lastfm/Artist.pm
@@ -19,7 +19,7 @@ attribution github => ['https://github.com/jagtalon','Jag Talon'],
 spice to => 'http://ws.audioscrobbler.com/2.0/?format=json&method=artist.getinfo&artist=$1&autocorrect=1&api_key={{ENV{DDG_SPICE_LASTFM_APIKEY}}}&callback={{callback}}_$2';
 spice from => '(?:([^/]*)/([^/]*)|)';
 
-triggers any => 'band', 'bands', 'musician', 'musicians', 'artist', 'artists', 'performer', 'performers', 'singer', 'singers', 'rapper', 'dj', 'rappers', 'vocalist', 'vocalists', 'djs', 'songster', 'songsters';
+triggers any => 'band', 'bands', 'musician', 'musicians', 'artists', 'performer', 'performers', 'singer', 'singers', 'rapper', 'dj', 'rappers', 'vocalist', 'vocalists', 'djs', 'songster', 'songsters';
 
 
 

--- a/t/LastfmArtist.t
+++ b/t/LastfmArtist.t
@@ -14,11 +14,6 @@ ddg_spice_test(
         call_type => 'include',
         caller => 'DDG::Spice::Lastfm::Artist',
     ),
-    'artist kanye west' => test_spice(
-        '/js/spice/lastfm/artist/kanye%20west/all',
-        call_type => 'include',
-        caller => 'DDG::Spice::Lastfm::Artist',
-    ),
 
     # have to implement the front-end method for these to work
     # needed method - ddg_spice_lastfm_artist_similar


### PR DESCRIPTION
Fix issue #2099 -  Last.fm Artist: reign in triggering

As suggested by @moollaza I dropped the word artist ...

Maybe Another way could be to filter the more frequent queries with word artist.

example code :
```
handle query_lc => sub {
    my $synonyms = "bands?|musicians?|players?|artists?|performers?|singers?|rappers?|djs?|vocalists?|songsters?";

...
    #Ignore Queries like "(music or street) artist"
    if(m{(music|street)\ artists?}) {
        return;
    }

```