### PR TITLE
Modify news callback to accept a hash

### DIFF
--- a/share/spice/news/news.js
+++ b/share/spice/news/news.js
@@ -2,7 +2,7 @@
     "use strict";
     env.ddg_spice_news = function (api_result) {
 
-        if (!api_result) {
+        if (!api_result || !api_result.results) {
             return Spice.failed('news');
         }
 
@@ -50,7 +50,7 @@
 
         // Check if the title is relevant to the query.
         var goodStories = [];
-        for(var i = 0, story; story = api_result[i]; i++) {
+        for(var i = 0, story; story = api_result.results[i]; i++) {
         // strip bold from story titles.
             story.title = story.title.replace(/<b>|<\/b>|:/g, "");
             if (DDG.isRelevant(story.title, skip)) {


### PR DESCRIPTION
This PR makes news work more like images and other services by accepting a hash (instead of just an array of stories). Requires simultaneous release with an internal PR.