### PR TITLE
Update field to use for hearts for sound_cloud

### DIFF
--- a/share/spice/sound_cloud/sound_cloud.js
+++ b/share/spice/sound_cloud/sound_cloud.js
@@ -69,7 +69,7 @@
 
                 return {
                     image: image,
-                    hearts: o.favoritings_count || 0,
+                    hearts: o.likes_count || 0,
                     duration: o.duration,
                     title: o.title,
                     url: o.permalink_url,


### PR DESCRIPTION
They must have changed their API recently and deprecated one of my favorite field names of all time, `favoritings_count`

@moollaza @jagtalon @chrismorast 