### PR TITLE
Github: Check repository size in relevancy block

### DIFF
--- a/share/spice/github/github.js
+++ b/share/spice/github/github.js
@@ -49,6 +49,9 @@
                         }
                     },
                 normalize: function(item) {
+                    if (item.size === 0) {
+                        return;
+                    }
                     return {
                         title: item.name,
                         subtitle: item.owner.login + "/" + item.name,

--- a/share/spice/github/github.js
+++ b/share/spice/github/github.js
@@ -58,8 +58,7 @@
                 },
                 relevancy: {
                     primary: [
-                        { key: 'description', match: /.+/, strict: false }, // Reject things without a description.
-                        { key: 'size', match: /^[1-9][0-9]*$/, strict: false }
+                        { key: 'description', match: /.+/, strict: false } // Reject things without a description.
                     ]
                 },
                 sort_fields: {

--- a/share/spice/github/github.js
+++ b/share/spice/github/github.js
@@ -58,7 +58,8 @@
                 },
                 relevancy: {
                     primary: [
-                        { key: 'description', match: /.+/, strict: false } // Reject things without a description.
+                        { key: 'description', match: /.+/, strict: false }, // Reject things without a description.
+                        { key: 'size', match: /^[1-9][0-9]*$/, strict: false }
                     ]
                 },
                 sort_fields: {


### PR DESCRIPTION
Fixing #2318 

@moollaza I'm attempting to use a relevancy block to match any number that is not 0 for the [size](https://gist.github.com/MrChrisW/23dabf7d791d98cd2d61#file-gistfile1-txt-L98) value returned from the API, this should fix #2318. 

However this doesn't seem to work as expected and I'm receiving a console error `TypeError: h.match is not a function` referring to the function used to check relevancy. 

I can just check the size in the `normalize` block and return nothing if 0, however I felt this was the more "correct" way to do it. Let me know if I'm missing something... :frowning: 