### PR TITLE
Fix #2323: Problems with Fandango

### DIFF
--- a/share/spice/go_watch_it/go_watch_it.js
+++ b/share/spice/go_watch_it/go_watch_it.js
@@ -75,8 +75,10 @@
                 }
 
                 // Try to strip anything that comes before the price.
-                item.buy_line = item.buy_line.replace(/^[a-z ]+/i, "");
-                item.rent_line = item.rent_line.replace(/^[a-z ]+/i, "");
+                if(/\$/.test(item.buy_line) || /\$/.test(item.rent_line)) {
+                    item.buy_line = item.buy_line.replace(/^[a-z ]+/i, "");
+                    item.rent_line = item.rent_line.replace(/^[a-z ]+/i, "");
+                }
 
                 // Change the format line to match the other tiles.
                 if (item.format_line === "DVD & Blu-ray") {
@@ -254,7 +256,7 @@
     Spice.registerHelper("gwi_fallbackText", function(options) {
        var message = "Available";
        var rent_re = /rent_own/;
-       var subscription_re = /subscription/; 
+       var subscription_re = /subscription/;
         
        if(this.categories) {
            this.categories.forEach(function(elem) {
@@ -314,9 +316,9 @@
     });
     
     Spice.registerHelper("gwi_buyOrRent", function (buy_line, rent_line, options) {
-        if (buy_line && buy_line !== "" && !/\$0\.00/.test(buy_line)) {
+        if (buy_line && buy_line !== "" && !/\$0\.00/.test(buy_line) && /\$/.test(buy_line)) {
             this.rent_line = "";
-        } else if(rent_line && rent_line !== "" && !/\$0\.00/.test(rent_line)) {
+        } else if(rent_line && rent_line !== "" && !/\$0\.00/.test(rent_line) && /\$/.test(rent_line) && /\$/.test(rent_line)) {
             this.buy_line = "";    
         } else {
             return options.inverse(this);
@@ -327,7 +329,7 @@
 
     // Check to see if both buy_line and rent_line are present.
     Spice.registerHelper("gwi_ifHasBothBuyAndRent", function (buy_line, rent_line, options) {
-        if (buy_line && buy_line !== "" && rent_line && rent_line !== "" && !/\$0\.00/.test(buy_line) && !/\$0\.00/.test(rent_line)) {
+        if (buy_line && buy_line !== "" && rent_line && rent_line !== "" && !/\$0\.00/.test(buy_line) && !/\$0\.00/.test(rent_line) && /\$/.test(buy_line) && /\$/.test(rent_line)) {
             return options.fn(this);
         } else {
             return options.inverse(this);
@@ -336,8 +338,11 @@
 
     // Grab dollar amount from 'Rent from $X.XX' string.
     Spice.registerHelper("gwi_price", function (line, options) {
-        var strings = line.split("$");
-        return "$" + strings[strings.length - 1];
+        if(/\$/.test(line)) {
+            var strings = line.split("$");
+            return "$" + strings[strings.length - 1];
+        }
+        return line;
     });
 
     // Get the class for the footer element based on whether or not both the buy_line


### PR DESCRIPTION
GoWatchIt's code has gotten a bit unwieldy and is due for another look, but the following fix works. So we have some code that strips some text from the `buy_line` or the `rent_line` without even checking if it should be stripped or not. This patch makes sure that such a thing doesn't happen again.

Screenshots:
<img width="1717" alt="screen shot 2015-12-15 at 10 02 11 am" src="https://cloud.githubusercontent.com/assets/81969/11814255/cceb4cb2-a313-11e5-86a7-2302545a0ff6.png">
<img width="1717" alt="screen shot 2015-12-15 at 10 02 25 am" src="https://cloud.githubusercontent.com/assets/81969/11814258/ccf0d9fc-a313-11e5-8ae3-38555d99f6b0.png">
<img width="1717" alt="screen shot 2015-12-15 at 10 02 41 am" src="https://cloud.githubusercontent.com/assets/81969/11814260/ccf1b3fe-a313-11e5-95e8-81fcd346fc7e.png">
<img width="1717" alt="screen shot 2015-12-15 at 10 02 50 am" src="https://cloud.githubusercontent.com/assets/81969/11814259/ccf0efc8-a313-11e5-99ac-cf1672e11c26.png">
<img width="1717" alt="screen shot 2015-12-15 at 10 03 07 am" src="https://cloud.githubusercontent.com/assets/81969/11814256/ccef1fae-a313-11e5-979f-3cce555b97b2.png">
<img width="1717" alt="screen shot 2015-12-15 at 10 03 18 am" src="https://cloud.githubusercontent.com/assets/81969/11814257/ccf05ff4-a313-11e5-95af-2c73271558f2.png">
<img width="1717" alt="screen shot 2015-12-15 at 10 03 55 am" src="https://cloud.githubusercontent.com/assets/81969/11814261/ccf1d8c0-a313-11e5-865c-982cd962af8e.png">
<img width="1717" alt="screen shot 2015-12-15 at 10 04 15 am" src="https://cloud.githubusercontent.com/assets/81969/11814262/ccf86ee2-a313-11e5-8982-ab640007ad66.png">

---
https://duck.co/ia/view/go_watch_it