### PR TITLE
Fix #2316: Problem with loading animation

### DIFF
--- a/share/spice/riffsy/riffsy.css
+++ b/share/spice/riffsy/riffsy.css
@@ -13,12 +13,12 @@
     -ms-transform: scale(0.5, 0.5);
     -webkit-transform: scale(0.5, 0.5);
     transform: scale(0.5, 0.5);
-    -moz-animation: loader-animate 0.5s steps(16) infinite;
-    -webkit-animation: loader-animate 0.5s steps(16) infinite;
-    animation: loader-animate 0.5s steps(16) infinite;
+    -moz-animation: loaderAnimate 0.5s steps(16) infinite;
+    -webkit-animation: loaderAnimate 0.5s steps(16) infinite;
+    animation: loaderAnimate 0.5s steps(16) infinite;
 }
 
-@-moz-keyframes loader-animate {
+@-moz-keyframes loaderAnimate {
     0%, from {
         background-position: 1024px;
     }
@@ -26,7 +26,7 @@
         background-position: 0px;
     }
 }
-@-webkit-keyframes loader-animate {
+@-webkit-keyframes loaderAnimate {
     0%, from {
         background-position: 1024px;
     }
@@ -34,7 +34,7 @@
         background-position: 0px;
     }
 }
-@keyframes loader-animate {
+@keyframes loaderAnimate {
     0%, from {
         background-position: 1024px;
     }


### PR DESCRIPTION
A keyframe with the same name has conflicted with Riffsy's keyframe. A better solution for this is to have gif detection integrated into the global image template (thinking of working on this soon!), but for now, we don't want it broken so here's a patch that renames the keyframe so that it doesn't conflict.

https://v.usetapes.com/g3M3Cu1VWN

-----
IA Page: https://duck.co/ia/view/riffsy