### PR TITLE
PeopleInSpace: Fixing #2345

### DIFF
--- a/share/spice/people_in_space/people_in_space.js
+++ b/share/spice/people_in_space/people_in_space.js
@@ -1,7 +1,7 @@
 (function (env) {
     "use strict";
 
-    var codes = {"canada":"ca", "china":"cn", "denmark":"dk", "france":"fr", "germany":"de", "italy":"it", "japan":"jp", "kazakhstan":"kz", "netherlands":"nl", "russia":"ru", "spain":"sp", "sweden":"se", "uk":"uk", "usa":"us"};
+    var codes = {"canada":"ca", "china":"cn", "denmark":"dk", "england" : "uk", "france":"fr", "germany":"de", "italy":"it", "japan":"jp", "kazakhstan":"kz", "netherlands":"nl", "russia":"ru", "spain":"sp", "sweden":"se", "uk":"uk", "usa":"us"};
 
     function getObject(obj, number) {
         if (number > 0) {


### PR DESCRIPTION
Fixes: https://github.com/duckduckgo/zeroclickinfo-spice/issues/2345

The API incorrectly returns "England" as the country for Tim Peak ( :gb: ! ), whereas it should be United Kingdom or UK; therefore no flag was rendered. 

I've added England as an alias for the UK flag to work around this issue.

-----
IA Page: https://duck.co/ia/view/people_in_space