### PR TITLE
Final Adjustments for Coupon Spice

### DIFF
--- a/share/spice/coupons/coupons.css
+++ b/share/spice/coupons/coupons.css
@@ -1,13 +1,7 @@
-/* 
-    Created on : Dec 17, 2015, 3:40:46 PM
-    Author     : ingo.wachsmuth@sparheld.de
-*/
-
-
-.zci--coupons .tile--coupons  .tile__media {
+.zci--coupons .tile--coupons .tile__media {
     width: auto;
-    height: auto;
-    padding: 24px;
+    height: 60px;
+    padding: 2em 2em 1.5em;
 }
 
 .zci--coupons .tile--coupons .tile__content {
@@ -15,12 +9,9 @@
 }
 
 .zci--coupons .tile--coupons .tile__body {
-    padding-top: 0px;
-    padding-left: 24px;
-    padding-right: 24px;
-    padding-bottom: 24px;
+    padding: 0 2em 2em;
 }
 
-.zci--coupons .tile--coupons  .tile__content  .tile__content--sm {
-    height: 2em;
+.zci--coupons .tile--coupons .tile__content .tile__content--sm {
+    height: auto;
 }

--- a/share/spice/coupons/coupons.js
+++ b/share/spice/coupons/coupons.js
@@ -36,11 +36,10 @@
                         tileBody: "text-center"
                     },
                     variants: {
-                        tileTitle: "3line" // to allow for 3 line title
+                        tileTitle: "3line-large"
                     }
                 }
             });
         });
     };
-}(this)
-        );
+}(this));

--- a/share/spice/coupons/coupons.js
+++ b/share/spice/coupons/coupons.js
@@ -18,8 +18,10 @@
                     sourceUrl: api_result.result.homeurl
                 },
                 normalize: function (item) {
+                    // remove brand name from end of title string
+                    var re = new RegExp(item.parent.title + "$", "i");
                     return {
-                        title: item.title,
+                        title: item.title.replace(re, ""),
                         description: item.parent.title,
                         url: item.url.coupon,
                         image: item.url.logo


### PR DESCRIPTION
- Minor changes to CSS
- Use `em` for padding, reduce padding below brand image
- set image height to prevent tile content from shifting
- use bolder font for tile title
- strip brand name from coupon description via regex (@ingowachsmuth-sparheld -- would this be possible on your end?)

/cc @ingowachsmuth-sparheld @abeyang 

Result:

![code_promo_food_at_duckduckgo](https://cloud.githubusercontent.com/assets/873785/11962064/e8c99db6-a8aa-11e5-98cd-2c38ba21f86c.png)

-----
IA Page: https://duck.co/ia/view/coupons