### PR TITLE
Deprecate item_custom

### DIFF
--- a/share/spice/envato/envato.js
+++ b/share/spice/envato/envato.js
@@ -72,7 +72,7 @@
             }
 
             spice.templates = {
-                item_custom: 'audio_item',
+                item: 'audio_item',
                 options: {
                     footer: Spice.envato.audio
                 }

--- a/share/spice/forecast/forecast.js
+++ b/share/spice/forecast/forecast.js
@@ -243,7 +243,7 @@
         },
 
         templates: {
-            item_custom: Spice.forecast.forecast_item,
+            item: Spice.forecast.forecast_item,
             detail_mobile: Spice.forecast.forecast_detail_mobile
         }
     });

--- a/share/spice/sound_cloud/sound_cloud.js
+++ b/share/spice/sound_cloud/sound_cloud.js
@@ -32,7 +32,7 @@
                 itemType: 'Tracks'
             },
             templates: {
-                item_custom: 'audio_item',
+                item: 'audio_item',
                 options: {
                     footer: Spice.sound_cloud.footer
                 }


### PR DESCRIPTION
There's no need for `item_custom` anymore, they're treated the same as regular `item` template overrides.

@andrey-p 
cc @moollaza 