### PR TITLE
Google+ Style Updates - Fix for #2344

### DIFF
--- a/share/spice/google_plus/google_plus.css
+++ b/share/spice/google_plus/google_plus.css
@@ -19,7 +19,7 @@
     padding-bottom: 20px;
 }
 
-.tile--google_plus .tile__title__main
+.tile--google_plus .tile__title__main {
     max-height: 2.5em;
     overflow: hidden;
     display: block;

--- a/share/spice/google_plus/google_plus.css
+++ b/share/spice/google_plus/google_plus.css
@@ -11,8 +11,6 @@
     text-align: center;
     vertical-align: middle;
     font-weight: 400;
-    display: table-cell;
-    width: 150px;
 }
 
 .tile--google_plus .tile__body {

--- a/share/spice/google_plus/google_plus.css
+++ b/share/spice/google_plus/google_plus.css
@@ -11,8 +11,16 @@
     text-align: center;
     vertical-align: middle;
     font-weight: 400;
+    display: table-cell;
+    width: 150px;
 }
 
 .tile--google_plus .tile__body {
     padding-bottom: 20px;
+}
+
+.tile--google_plus .tile__title__main
+    max-height: 2.5em;
+    overflow: hidden;
+    display: block;
 }


### PR DESCRIPTION
This is a fix for issue #2344 

Changed the CSS for the Google+ results to fix issues where the spice tiles would vary in height depending on length of text.

I don't have a full development setup yet, so I couldn't test it on all browsers, but I did run this through duckpan and took some screenshots in Firefox. It looks the same in Chrome also (but chrome has text ellipsis which is better).

***Old Images (before update)***
[Desktop Preview in Firefox](https://cloud.githubusercontent.com/assets/14809478/12006591/8781d138-abaa-11e5-9016-79111668af7d.png)
[Mobile (small window) Preview in Firefox](https://cloud.githubusercontent.com/assets/14809478/12006593/878410ba-abaa-11e5-8c89-124c0d14ac8e.png)

***Updated Images***
[Desktop Preview in Firefox](https://cloud.githubusercontent.com/assets/14809478/12006594/87847636-abaa-11e5-90c3-0b076203e4d4.png)
[Mobile Expanded Preview in Firefox](https://cloud.githubusercontent.com/assets/14809478/12006590/877f44f4-abaa-11e5-84b8-1ac853143303.png)
[Mobile Collapsed Preview in Firefox](https://cloud.githubusercontent.com/assets/14809478/12006592/8783c984-abaa-11e5-8f32-1d6c195bde5b.png)

-----
IA Page: https://duck.co/ia/view/google_plus