### PR TITLE
Timer - Updated Triggering and Parsing - Fixes #1937

### DIFF
--- a/lib/DDG/Spice/Timer.pm
+++ b/lib/DDG/Spice/Timer.pm
@@ -23,16 +23,38 @@ handle remainder => sub {
     my $raw = lc($req->query_raw);
     my $trgx = join('|', @triggers);
 
-    # check to make sure the query matches a trigger perfectly
-    if($qry eq '' && in_array($raw, @triggers)) {
-        return '';
-    }
-
-    # makes sure trigger is wrapped with whitespace
+    # Verify that the trigger words are wrapped with whitespace or that
+    # the trigger is at the start or end of the string with white space
+    # on either side of it. This prevents triggering on queries such as
+    # "countdown.js", "timer.x", "five-alarm", etc
     if($raw !~ /(^|\s)($trgx)(\s|$)/) {
         return;
     }
 
+    # When the query is empty and we know that the trigger word matches
+    # the trigger exactly (whitespace check) we can return a valid result
+    if($qry eq '') {
+        return '';
+    }
+
+    # Trim both sides of the raw query to have the raw regex work
+    # properly. Since we need to make sure /^<trigger> for $/ doesn't
+    # trigger.
+    $raw =~ s/^\s+//;
+    $raw =~ s/\s+$//;
+
+    # Parse the raw query to remove common terms. This allows us to
+    # catch the more specific queries and handle them. We also strip
+    # the extra bounding whitespace. Keep in mind that the trigger is
+    # set to startend, causing "online timer for ..." to not trigger.
+    #
+    # WARNING: Keep a required space after "for", forcing there to be
+    # additional text for the timer, or "timer online for" will trigger.
+    #
+    # Matches on...
+    # <specific time> online <trigger> ------- 10 minute online timer
+    # <trigger> online <specific time> ------- timer online 10 minutes
+    # <trigger> online for <specific time> --- timer online for 10 min
     $raw =~ s/\s*(online )?($trgx)( online)?( for )?\s*//;
 
     if($raw eq '') {
@@ -45,18 +67,5 @@ handle remainder => sub {
 
     return;
 };
-
-
-sub in_array {
-    my($needle, @haystack) = @_;
-
-    for(@haystack) {
-        if($_ eq $needle) {
-            return 1;
-        }
-    }
-
-    return 0;
-}
 
 1;

--- a/lib/DDG/Spice/Timer.pm
+++ b/lib/DDG/Spice/Timer.pm
@@ -25,7 +25,7 @@ handle remainder => sub {
 
     # check to make sure the query matches a trigger perfectly
     if($qry eq '' && in_array($raw, @triggers)) {
-        return $qry;
+        return '';
     }
 
     # makes sure trigger is wrapped with whitespace
@@ -36,11 +36,11 @@ handle remainder => sub {
     $raw =~ s/\s*(online )?($trgx)( online)?( for )?\s*//;
 
     if($raw eq '') {
-        return $raw;
+        return '';
     }elsif($raw =~ /^(\s?([\d.]+ ?(m(in((ute)?s?)?)?|s(ec((ond)?s?)?)?|h(ours?)?|hr))\s?)+$/) {
-        return $raw;
+        return '';
     }elsif($raw =~ /^( ?((\d{1,2}:)?\d{1,2}:\d{2}) ?)/) {
-        return $raw;
+        return '';
     }
 
     return;

--- a/t/Timer.t
+++ b/t/Timer.t
@@ -21,17 +21,19 @@ ddg_spice_test(
     'timer 77 mins 13 secs' => test_spice(@test_args),
     'online timer' => test_spice(@test_args),
     'timer online' => test_spice(@test_args),
+    'online alarm' => test_spice(@test_args),
+    'countdown online' => test_spice(@test_args),
     '1 minute timer' => test_spice(@test_args),
     '2min30sec online timer' => test_spice(@test_args),
     '3 hr 5 min timer' => test_spice(@test_args),
     'timer 30 seconds' => test_spice(@test_args),
-    'time 2 minutes' => test_spice(@test_args),
     '3.5 minute timer' => test_spice(@test_args),
     'alarm 30 minutes' => test_spice(@test_args),
     'timer for 15 mins' => test_spice(@test_args),
     'timer for 77 mins 13 secs' => test_spice(@test_args),
     'timer 2:30' => test_spice(@test_args),
     'timer 1:20:30' => test_spice(@test_args),
+    'countdown for 10 minutes' => test_spice(@test_args),
     'blahblah timer' => undef,
     'wwdc 2015 countdown' => undef,
     'timer 5 hellos' => undef,
@@ -39,7 +41,8 @@ ddg_spice_test(
     'Time::Piece' => undef,
     'timer.x' => undef,
     'countdown.x' => undef,
-    'alarm.x' => undef
+    'alarm.x' => undef,
+    'five-timer' => undef # issue 1937
 );
 
 done_testing;

--- a/t/Timer.t
+++ b/t/Timer.t
@@ -42,7 +42,9 @@ ddg_spice_test(
     'timer.x' => undef,
     'countdown.x' => undef,
     'alarm.x' => undef,
-    'five-timer' => undef # issue 1937
+    'timer online for ' => undef,
+    'countdown.js 10 minutes' => undef,
+    'five-alarm' => undef # issue 1937
 );
 
 done_testing;


### PR DESCRIPTION
Hello,
This update fixes some triggering issues with the Timer. This includes fixing triggering such as "five-timer", along with removing the "time" trigger.

This update also adds a few extra triggers. Before the "online" and "for" keyword was only applied to the "timer" trigger, now it's applied to all the `startend` triggers. This allows for queries such as "online alarm" and "countdown for 10 minutes".

I can rollback the triggering even more if you want.

Fixes issue #1937 
Instant Answer: https://duck.co/ia/view/timer