### PR TITLE
FlashVersion: Use DDG.require for 'flash_detect.js' file

### DIFF
--- a/share/spice/flash_version/flash_version.js
+++ b/share/spice/flash_version/flash_version.js
@@ -1,34 +1,31 @@
 (function(env) {
     "use strict";
-
+    
     env.ddg_spice_flash_version = function() {
-
-	if(!FlashDetect) {
-	    return Spice.failed('flash_version');
-	}
-
-	// Display the plugin.
-	Spice.add({
+        
+        if(!FlashDetect) {
+            return Spice.failed('flash_version');
+        }
+        
+        Spice.add({
             data: {
-		installed: FlashDetect.installed,
-		raw: FlashDetect.raw
-	    },
-	    id: 'flash_version',
-	    name: 'Software',
-	    meta: {
-		sourceName: 'Adobe',
-		sourceUrl: 'https://get.adobe.com/flashplayer/',
-		sourceIcon: true
-	    },
+                installed: FlashDetect.installed,
+                raw: FlashDetect.raw
+            },
+            id: 'flash_version',
+            name: 'Software',
+            meta: {
+                sourceName: 'Adobe',
+                sourceUrl: 'https://get.adobe.com/flashplayer/',
+                sourceIcon: true
+            },
             templates: {
-		group: 'base',
-		options: {
-		    content: Spice.flash_version.content,
-		    moreAt: true
-		}
+                group: 'base',
+                options: {
+                    content: Spice.flash_version.content,
+                    moreAt: true
+                }
             }
-	});
+        });
     };
 }(this));
-
-ddg_spice_flash_version();

--- a/share/spice/flash_version/flash_version.js
+++ b/share/spice/flash_version/flash_version.js
@@ -3,29 +3,33 @@
     
     env.ddg_spice_flash_version = function() {
         
-        if(!FlashDetect) {
-            return Spice.failed('flash_version');
-        }
-        
-        Spice.add({
-            data: {
-                installed: FlashDetect.installed,
-                raw: FlashDetect.raw
-            },
-            id: 'flash_version',
-            name: 'Software',
-            meta: {
-                sourceName: 'Adobe',
-                sourceUrl: 'https://get.adobe.com/flashplayer/',
-                sourceIcon: true
-            },
-            templates: {
-                group: 'base',
-                options: {
-                    content: Spice.flash_version.content,
-                    moreAt: true
-                }
+        DDG.require('flash_detect.js', function(){
+            
+            if(!FlashDetect) {
+                return Spice.failed('flash_version');
             }
+            
+            Spice.add({
+                data: {
+                    installed: FlashDetect.installed,
+                    raw: FlashDetect.raw
+                },
+                id: 'flash_version',
+                name: 'Software',
+                meta: {
+                    sourceName: 'Adobe',
+                    sourceUrl: 'https://get.adobe.com/flashplayer/',
+                    sourceIcon: true
+                },
+                templates: {
+                    group: 'base',
+                    options: {
+                        content: Spice.flash_version.content,
+                        moreAt: true
+                    }
+                }
+            });
+
         });
     };
 }(this));

--- a/share/spice/flash_version/flash_version.js
+++ b/share/spice/flash_version/flash_version.js
@@ -33,3 +33,5 @@
         });
     };
 }(this));
+
+ddg_spice_flash_version();

--- a/share/spice/flash_version/flash_version.js
+++ b/share/spice/flash_version/flash_version.js
@@ -3,7 +3,7 @@
     
     env.ddg_spice_flash_version = function() {
         
-        DDG.require('flash_detect.js', function(){
+        DDG.require('flashDetect', function(){
             
             if(!FlashDetect) {
                 return Spice.failed('flash_version');


### PR DESCRIPTION
Partially fixing #99

>DDG can tell you your flash version but it doesn't give you the last 3 numbers:  by @zekiel 

Unable to implement this functionality. 

+ Unable to show the last three numbers without using [SWFObject](https://code.google.com/p/swfobject/) to embed a swf file - which is not recommended.
+ All js implementation of flash detection including Adobe official kit only display 3 version numbers. See http://isflashinstalled.com/

**This PR relates to [comments made](https://github.com/duckduckgo/zeroclickinfo-spice/issues/99#issuecomment-49634404) by @bsstoner regarding the removal of FlashDetect from core.**

We should include [flash_detect_min.js](http://www.featureblend.com/flash_detect_1-0-4/flash_detect_min.js) and call it using `DDG.require` the same way we do `moment.js` - this will require internal changes.
