### PR TITLE
Zanran: Remove quotes from search query

### DIFF
--- a/lib/DDG/Spice/Zanran.pm
+++ b/lib/DDG/Spice/Zanran.pm
@@ -23,7 +23,8 @@ my @triggers = share('triggers.txt')->slurp;
 triggers any => @triggers;
 
 handle query_lc => sub {
-  return $_ if $_;
+    $_ =~ s/"//g;
+    return $_ if $_;
 };
 
 1;


### PR DESCRIPTION
Quick fix for #102 - remove the `"` quote char from the search query allowing queries like `arabia "oil production"` to work this avoids any internal changes.

See [comment](https://github.com/duckduckgo/zeroclickinfo-spice/issues/102#issue-7845400) for more detail.