### PR TITLE
Expatistan: Avoid irrelevant results, restrict triggering #2174

### DIFF
--- a/lib/DDG/Spice/Expatistan.pm
+++ b/lib/DDG/Spice/Expatistan.pm
@@ -15,7 +15,7 @@ topics "economy_and_finance";
 category "facts";
 attribution github => ['https://github.com/hunterlang','Hunter Lang'];
 
-triggers any => "cost of living";
+triggers startend => "cost of living";
 
 spice to => 'https://www.expatistan.com/api/spice?q=$1&api_key={{ENV{DDG_SPICE_EXPATISTAN_APIKEY}}}';
 

--- a/share/spice/expatistan/expatistan.js
+++ b/share/spice/expatistan/expatistan.js
@@ -6,7 +6,6 @@
             return Spice.failed('expatistan');
         }
 
-        console.log(api_result);
         Spice.add({
             id: "expatistan",
             name: "Answer",

--- a/share/spice/expatistan/expatistan.js
+++ b/share/spice/expatistan/expatistan.js
@@ -6,6 +6,7 @@
             return Spice.failed('expatistan');
         }
 
+        console.log(api_result);
         Spice.add({
             id: "expatistan",
             name: "Answer",
@@ -20,7 +21,8 @@
                 var city, cost, subtitle, title;
 
                 // Guard if abstract or source_url don't exist
-                if (!api_result.abstract || !api_result.source_url) {
+                // Check abstract for unrecognized location
+                if (!api_result.abstract || !api_result.source_url || api_result.abstract.match(/could not be recognized/)) {
                     return Spice.failed('expatistan');
                 }
 

--- a/t/Expatistan.t
+++ b/t/Expatistan.t
@@ -43,7 +43,7 @@ ddg_spice_test(
         '/js/spice/expatistan/cost%20of%20living%20difference%20london%20paris',
         caller    => 'DDG::Spice::Expatistan',
     ),
-    'compare cost of living between london and paris' => test_spice(
+    'cost of living between london and paris' => test_spice(
         '/js/spice/expatistan/compare%20cost%20of%20living%20between%20london%20and%20paris',
         caller    => 'DDG::Spice::Expatistan',
     ),

--- a/t/Expatistan.t
+++ b/t/Expatistan.t
@@ -44,7 +44,7 @@ ddg_spice_test(
         caller    => 'DDG::Spice::Expatistan',
     ),
     'cost of living between london and paris' => test_spice(
-        '/js/spice/expatistan/compare%20cost%20of%20living%20between%20london%20and%20paris',
+        '/js/spice/expatistan/cost%20of%20living%20between%20london%20and%20paris',
         caller    => 'DDG::Spice::Expatistan',
     ),
 


### PR DESCRIPTION
Fixing #2174

Restricting triggers to start and end due to the following result, only seems to trigger LA with "relative" keyword
+ https://duckduckgo.com/?q=relative+Cost+of+Living+testing

Checking API for "could not be recognized" string returned if an unknown location is checked 
+ https://duckduckgo.com/?q=cost+of+living+in+hawaii+vs+test
+ https://duckduckgo.com/js/spice/expatistan/cost%20of%20living%20in%20hawaii%20vs%20test

May want to revert that check (`api_result.abstract.match(/could not be recognized/`) as showing only the first location in `vs` searches may be fine?
