### PR TITLE
People In Space: Use cloudinary platform to resize bio images on-the-fly

### DIFF
--- a/share/spice/people_in_space/people_in_space.js
+++ b/share/spice/people_in_space/people_in_space.js
@@ -12,7 +12,8 @@
                     launchdate: moment(item.launchdate).format("MMM DD, YYYY"),
                     icon: DDG.settings.region.getLargeIconURL(codes[item.country.toLowerCase()]),
                     twitter: item.twitter.replace(/https?:\/\/twitter.com\//,''),
-                    url: item.biolink
+                    url: item.biolink,
+                    biophoto: "http://res.cloudinary.com/duckduckgo/image/fetch/w_100,h_130,f_auto/" + item.biophoto
                 };
             };
             obj.templates.item = 'base_item';


### PR DESCRIPTION
The large image size delivered by the howmanypeopleinspace.com website has caused slow loading of the astronaut images for the IA. (sorry mobile users :grimacing: )

The astronaut images are only displayed with a size of 100x130 however they're delivered at 640x800 (see [example image](http://www.howmanypeopleareinspacerightnow.com/app/biophotos/mikhail-kornienko.jpg)) using the cloudinary.com free service we can reduce page loading considerably by resizing the images on-the-fly.

The free account offers the following - I've signed up and am using the account with the url name **duckduckgo**

![2016-01-06-09-cloudinary management console - dashboard](https://cloud.githubusercontent.com/assets/5282264/12135465/1aa4752c-b477-11e5-8e20-40333822bb52.png)

This would allow all 6 astronaut images to be pulled around 40 times a day within one month - I'm not sure what the traffic to this IA is, so this may not be feasible. 

**Speed improvements** - 70% load improvement.

#### Before
![2016-01-06-23-](https://cloud.githubusercontent.com/assets/5282264/12135502/96e6afa6-b477-11e5-8002-bc3b1c41d50a.png)

#### After

![2016-01-06-59](https://cloud.githubusercontent.com/assets/5282264/12135507/9dc84b54-b477-11e5-9d66-84732a2c3377.png)

cc// @moollaza @jagtalon
