### PR TITLE
Octopart: Include relevancy checking against item title

### DIFF
--- a/share/spice/octopart/octopart.js
+++ b/share/spice/octopart/octopart.js
@@ -80,12 +80,18 @@
                 }
             },
             relevancy: {
+                skip_words:  [
+                        "datasheet",
+                        "specs",
+                        "octopart"
+                ],
                 primary: [
                     { required: 'item.short_description' },
                     { required: 'item.octopart_url' },
                     { required: 'item.datasheets' },
                     { required: 'item.imagesets' },
                     { required: 'item.avg_price_v2' },
+                    { key: 'item.mpn' }, //check item title for relevancy
                 ],
             }
         });

--- a/share/spice/octopart/octopart.js
+++ b/share/spice/octopart/octopart.js
@@ -81,9 +81,9 @@
             },
             relevancy: {
                 skip_words:  [
-                        "datasheet",
-                        "specs",
-                        "octopart"
+                    "datasheet",
+                    "specs",
+                    "octopart"
                 ],
                 primary: [
                     { required: 'item.short_description' },


### PR DESCRIPTION
Fixes #2207

This allows queries like the following by checking the query against the item title
+ [atmega datasheet](https://beta.duckduckgo.com/?q=atmega+datasheet&ia=parts)
+ [ne555 specs](https://beta.duckduckgo.com/?q=ne555+specs&ia=parts)

Queries - will not trigger
+ people round specs 
+ apple watch specs

-----
IA Page: https://duck.co/ia/view/octopart