### PR TITLE
Aqi - Added term 'local' instead of having to use zip codes

### DIFF
--- a/lib/DDG/Spice/Aqi.pm
+++ b/lib/DDG/Spice/Aqi.pm
@@ -20,9 +20,15 @@ spice to => 'http://www.airnowapi.org/aq/observation/zipCode/current/?format=app
 spice wrap_jsonp_callback => 1;
 
 handle remainder => sub {
-    my $query = shift;
+    my $query = lc(shift);
 
-    if($query eq 'local') {
+    if($query eq '' || $query eq 'local' || $query eq 'current') {
+
+        if($query eq '') {
+            # We don't want to trigger on empty strings with AQI as the
+            # trigger.
+            return if $req->{query_raw} =~ /\baqi\b/i;
+        }
 
         # Set $query to failed return value. This way we can keep `else`
         # statements limited.

--- a/lib/DDG/Spice/Aqi.pm
+++ b/lib/DDG/Spice/Aqi.pm
@@ -23,8 +23,21 @@ handle remainder => sub {
     my $query = shift;
 
     if($query eq 'local') {
-        return unless ($loc && $loc->{postal_code});
-        $query = $loc->{postal_code};
+
+        # Set $query to failed return value. This way we can keep `else`
+        # statements limited.
+        $query = '';
+
+        if(defined($loc) && exists($loc->{postal_code}) && exists($loc->{country_code})) {
+            # The current API only supports USA postal codes.
+            if($loc->{country_code} eq 'US') {
+                $query = $loc->{postal_code};
+            }
+        }
+
+        # At this point $query can either be an empty string that we
+        # set before the location checks, or it can be a valid zipcode.
+        return unless $query;
     }else{
         #check if the entire remainder string is a 5 digits number;
         return unless $query =~ qr/^\d{5}$/;

--- a/lib/DDG/Spice/Aqi.pm
+++ b/lib/DDG/Spice/Aqi.pm
@@ -20,9 +20,18 @@ spice to => 'http://www.airnowapi.org/aq/observation/zipCode/current/?format=app
 spice wrap_jsonp_callback => 1;
 
 handle remainder => sub {
-     my $query = shift;
-     return unless $query =~ qr/^\d{5}$/; #check if the entire remainder string is a 5 digits number;
-     return $query; # we know it exists, it's a number and it has 5 digits;
+    my $query = shift;
+
+    if($query eq 'local') {
+        return unless ($loc && $loc->{postal_code});
+        $query = $loc->{postal_code};
+    }else{
+        #check if the entire remainder string is a 5 digits number;
+        return unless $query =~ qr/^\d{5}$/;
+    }
+
+    # we know it exists, it's a number and it has 5 digits;
+    return $query;
 };
 
 1;

--- a/t/Aqi.t
+++ b/t/Aqi.t
@@ -5,6 +5,8 @@ use warnings;
 
 use Test::More;
 use DDG::Test::Spice;
+use DDG::Test::Location;
+use DDG::Request;
 
 ddg_spice_test(
     [
@@ -35,6 +37,25 @@ ddg_spice_test(
         call_type => 'include',
         caller => 'DDG::Spice::Aqi',
     ),
+
+    # Test user location
+    DDG::Request->new(
+        query_raw => 'local air quality',
+        location => test_location('us')
+    ) => test_spice(
+        '/js/spice/aqi/19460',
+        call_type => 'include',
+        caller => 'DDG::Spice::Aqi'
+    ),
+    DDG::Request->new(
+        query_raw => 'local air quality',
+        location => test_location('de')
+    ) => undef,
+
+    # test additional queries that include "local"
+    'local news air quality' => undef,
+    'air quality affects locals' => undef,
+
     # wrong ZIP formatting
     'aqi 1' => undef,
     'aqi 12' => undef,

--- a/t/Aqi.t
+++ b/t/Aqi.t
@@ -8,45 +8,52 @@ use DDG::Test::Spice;
 use DDG::Test::Location;
 use DDG::Request;
 
+my @test_20002 = (
+    '/js/spice/aqi/20002',
+    call_type => 'include',
+    caller => 'DDG::Spice::Aqi',
+);
+
+my @test_19460 = (
+    '/js/spice/aqi/19460',
+    call_type => 'include',
+    caller => 'DDG::Spice::Aqi',
+);
+
 ddg_spice_test(
     [
         'DDG::Spice::Aqi'
     ],
-    'aqi 20002' => test_spice(
-        '/js/spice/aqi/20002',
-        call_type => 'include',
-        caller => 'DDG::Spice::Aqi',
-    ),
-    '20002 aqi' => test_spice(
-        '/js/spice/aqi/20002',
-        call_type => 'include',
-        caller => 'DDG::Spice::Aqi',
-    ),
-    'air quality 20002' => test_spice(
-        '/js/spice/aqi/20002',
-        call_type => 'include',
-        caller => 'DDG::Spice::Aqi',
-    ),
-    'air quality index 20002' => test_spice(
-        '/js/spice/aqi/20002',
-        call_type => 'include',
-        caller => 'DDG::Spice::Aqi',
-    ),
-    'air pollution 20002' => test_spice(
-        '/js/spice/aqi/20002',
-        call_type => 'include',
-        caller => 'DDG::Spice::Aqi',
-    ),
+
+    # zip code testing
+    'aqi 20002' => test_spice(@test_20002),
+    '20002 aqi' => test_spice(@test_20002),
+    'air quality 20002' => test_spice(@test_20002),
+    'air quality index 20002' => test_spice(@test_20002),
+    'air pollution 20002' => test_spice(@test_20002),
 
     # Test user location
     DDG::Request->new(
         query_raw => 'local air quality',
         location => test_location('us')
-    ) => test_spice(
-        '/js/spice/aqi/19460',
-        call_type => 'include',
-        caller => 'DDG::Spice::Aqi'
-    ),
+    ) => test_spice(@test_19460),
+
+    DDG::Request->new(
+        query_raw => 'local aqi',
+        location => test_location('us')
+    ) => test_spice(@test_19460),
+
+    DDG::Request->new(
+        query_raw => 'current air pollution',
+        location => test_location('us')
+    ) => test_spice(@test_19460),
+
+    DDG::Request->new(
+        query_raw => 'air quality',
+        location => test_location('us')
+    ) => test_spice(@test_19460),
+
+    # invalid location (non-us)
     DDG::Request->new(
         query_raw => 'local air quality',
         location => test_location('de')
@@ -55,6 +62,9 @@ ddg_spice_test(
     # test additional queries that include "local"
     'local news air quality' => undef,
     'air quality affects locals' => undef,
+
+    # aqi alone shouldn't detect loction. Trigger is too generic.
+    'aqi' => undef,
 
     # wrong ZIP formatting
     'aqi 1' => undef,


### PR DESCRIPTION
Hello,
In this update to Aqi (Air Quality Index), I added a new option to provide the word "local" instead of a zip code. This could be very useful if you are traveling to a different city and don't know the local zip code.

**A few questions...**
I'm not sure if I validate the location property correctly (I'm not a Perl developer). Is it sufficient enough to check if the `$loc` and `$loc->{postal_code}` return `true`, and to assume a valid postal code is present? Is there a more preferred way?

In the test file, I'm not sure if the `DDG::Request->new` method can be used along side the method of testing strings by themselves. In all the test files I've seen, they either use one or the other.

I was considering having this Instant Answer trigger without any additional content for the more specific trigger words, such as "air quality" and "air quality index". These queries would then request the postal code from the location variable. I would leave out the trigger "aqi" since that could end up over triggering. What are your opinions on this type of trigger to be added also?

---
Aqi Instant Answer
https://duck.co/ia/view/aqi