### PR TITLE
Timer - Fixes issue #2380

### DIFF
--- a/share/spice/timer/timer.js
+++ b/share/spice/timer/timer.js
@@ -457,11 +457,13 @@ License: CC BY-NC 3.0 http://creativecommons.org/licenses/by-nc/3.0/
             var timer = new Timer(timers.length + 1, startingTime);
             timer.$element.insertBefore($addTimerBtn.parent());
             timers.push(timer);
-            // start first timer automatically
-            if (timers.length === 1)
+            // start first timer automatically, but only when the user
+            // specified a time.
+            if (startingTime !== 0 && timers.length === 1) {
                 timer.start();
+			}
         }
-        
+
         function onShow() {
             // make sure this runs only once
             if (hasShown) {
@@ -532,7 +534,7 @@ License: CC BY-NC 3.0 http://creativecommons.org/licenses/by-nc/3.0/
             //this makes sure the divs display at the right time so the layout doesn't break
             onShow: onShow
         });
-        
+
 
     };
 }(this));

--- a/share/spice/timer/timer.js
+++ b/share/spice/timer/timer.js
@@ -461,7 +461,7 @@ License: CC BY-NC 3.0 http://creativecommons.org/licenses/by-nc/3.0/
             // specified a time.
             if (startingTime !== 0 && timers.length === 1) {
                 timer.start();
-			}
+            }
         }
 
         function onShow() {


### PR DESCRIPTION
Good evening.

This branch fixes issue #2380 

We check to see if the variable `startingTime` is a value larger than 0. When no time is provided in the query, the `startingTime` variable is 0. This can also happen if someone submits "timer 0 minutes". In this case, I still think it's a good idea to have the timer not start but instead show a create timer box.

Due to my editor, some extra white space was also removed with this commit.

---
https://duck.co/ia/view/timer