### PR TITLE
Enable image/flag of ShadowCash [cryptocurrency]

### DIFF
--- a/share/spice/cryptocurrency/cryptocurrency.js
+++ b/share/spice/cryptocurrency/cryptocurrency.js
@@ -39,6 +39,7 @@
         "pot": true,
         "ppc": true,
         "qrk": true,
+        "sdc": true,
         "utc": true,
         "wdc": true,
         "xpm": true,

--- a/share/spice/cryptocurrency/cryptocurrencylist.txt
+++ b/share/spice/cryptocurrency/cryptocurrencylist.txt
@@ -530,8 +530,7 @@ xsx,servx,
 sxc,sexcoin,sex coin,
 sha,shacoin,sha coin,
 shade,shadecoin,shade coin,
-sdc,shadowcoin,shadow coin,
-sdc, shadowcash, shadow cash
+sdc,shadowcoin,shadow coin,shadowcash,shadow cash
 shi,shi,
 shibe,shibecoin,shibe coin,
 shld,shieldcoin,shield coin,


### PR DESCRIPTION
Hi,

The flag for ShadowCash is already present in the files on DuckDuckGo
https://duckduckgo.com/share/spice/cryptocurrency/1178/assets/svg/SDC.svg

But not enabled in the cryptocurrency.js file.

I've set it to "true" and added it to the list of cryptocurrencies.

https://duck.co/ia/view/cryptocurrency