### PR TITLE
IndeedJobs Design Updates - Fixes #2393

### DIFF
--- a/share/spice/indeed_jobs/indeed_jobs.js
+++ b/share/spice/indeed_jobs/indeed_jobs.js
@@ -24,7 +24,7 @@
                 return {
                     url: item.url,
                     title: item.jobtitle,
-                    subtitle: item.company,
+                    subtitle: item.company || ' ', // has to translate to boolean(true)
                     description: DDG.strip_html(item.snippet)
                 };
             },
@@ -36,7 +36,8 @@
                     footer: Spice.indeed_jobs.footer
                 },
                 variants: {
-                    tileTitle: '2line',
+                    tile: 'wide',
+                    tileTitle: '1line',
                     tileSnippet: 'large',
                     tileFooter: '2line'
                 }


### PR DESCRIPTION
Fixes issue #2393 

I also updated the design slightly to (what I believe) displays the information better. Before some job titles only occupied one line and caused additional white-space between the job description and the job title. 

Switched the tile width to be wide, and set the tileTitle to be 1 line.

![after](https://cloud.githubusercontent.com/assets/14809478/12215978/d6a5ef32-b6a0-11e5-8764-0a9ee976b633.jpg)

---
IA Page: http://duck.co/ia/view/indeed_jobs