### PR TITLE
Currency: Add support for / slash format in triggers

### DIFF
--- a/lib/DDG/Spice/Currency.pm
+++ b/lib/DDG/Spice/Currency.pm
@@ -30,7 +30,7 @@ my $question_prefix = qr/(?:convert|what (?:is|are|does)|how (?:much|many) (?:is
 my $number_re = number_style_regex();
 my $cardinal_re = join('|', qw(hundred thousand k million m billion b trillion));
 
-my $guard = qr/^$question_prefix(\p{Currency_Symbol})?\s?($number_re*)\s?(\p{Currency_Symbol})?\s?($cardinal_re)?\s?($currency_qr)?(?:s)?(?:$into_qr|$vs_qr|\s)?($number_re*)\s?($currency_qr)?(\p{Currency_Symbol})?(?:s)?\??$/i;
+my $guard = qr/^$question_prefix(\p{Currency_Symbol})?\s?($number_re*)\s?(\p{Currency_Symbol})?\s?($cardinal_re)?\s?($currency_qr)?(?:s)?(?:$into_qr|$vs_qr|\/|\s)?($number_re*)\s?($currency_qr)?(\p{Currency_Symbol})?(?:s)?\??$/i;
 
 triggers query_lc => qr/\p{Currency_Symbol}|$currency_qr/;
 

--- a/t/Currency.t
+++ b/t/Currency.t
@@ -242,7 +242,27 @@ ddg_spice_test(
         caller => 'DDG::Spice::Currency',
         is_cached => 0
     ),
+    
+    # Support slash format e.g AUD/USD
+    'aud/usd' => test_spice(
+        '/js/spice/currency/1/aud/usd',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
+    'convert AUD/USD' => test_spice(
+        '/js/spice/currency/1/aud/usd',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
 
+    'convert 5 USD/AUD' => test_spice(
+        '/js/spice/currency/5/usd/aud',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
 
     # Numbers with with ambiguous formatting.
     'convert 2,000.1.9 cad into usd' => undef,


### PR DESCRIPTION
Fixes #2398 

Adds support for queries like GBP/ZAR - See [test file](https://github.com/MrChrisW/zeroclickinfo-spice/blob/7d3276f20941145523b0b2b47f156419d854d564/t/Currency.t) for other examples

CC// @Ntrails


------
IA Page:  http://duck.co/ia/view/currency