### PR TITLE
InTheaters: Support for cinemas trigger word

### DIFF
--- a/lib/DDG/Spice/InTheaters.pm
+++ b/lib/DDG/Spice/InTheaters.pm
@@ -5,7 +5,7 @@ use strict;
 use DDG::Spice;
 
 my $rating = '(?:g\s*|pg\s*|r\s*)?';
-triggers any => 'movie', 'movies', 'theaters', 'theatres', 'cinemas', 'cinema' ,'showing', 'something', 'watch', 'opening', 'see';
+triggers any => 'movie', 'movies', 'theaters', 'theatres', 'cinemas', 'showing', 'something', 'watch', 'opening', 'see';
 spice from => '(.*?)/(.*)';
 spice to => 'http://api.rottentomatoes.com/api/public/v1.0/lists/movies/$1.json?country=$2&apikey={{ENV{DDG_SPICE_ROTTEN_APIKEY}}}&callback={{callback}}&page_limit=30&limit=30';
 

--- a/lib/DDG/Spice/InTheaters.pm
+++ b/lib/DDG/Spice/InTheaters.pm
@@ -5,7 +5,7 @@ use strict;
 use DDG::Spice;
 
 my $rating = '(?:g\s*|pg\s*|r\s*)?';
-triggers any => 'movie', 'movies', 'theaters', 'theatres', 'showing', 'something', 'watch', 'opening', 'see';
+triggers any => 'movie', 'movies', 'theaters', 'theatres', 'cinemas', 'cinema' ,'showing', 'something', 'watch', 'opening', 'see';
 spice from => '(.*?)/(.*)';
 spice to => 'http://api.rottentomatoes.com/api/public/v1.0/lists/movies/$1.json?country=$2&apikey={{ENV{DDG_SPICE_ROTTEN_APIKEY}}}&callback={{callback}}&page_limit=30&limit=30';
 
@@ -82,6 +82,7 @@ my %movies = (
     'pg13 movies' => 1,
     'unrated movies' => 1,
     'movies in theaters' => 1,
+    'movies in cinemas' => 1,
     'r movies in theaters' => 1,
     'pg movies in theaters' => 1,
     'pg-13 movies in theaters' => 1,
@@ -91,8 +92,10 @@ my %movies = (
     'unrated movies in theaters' => 1,
     'movies currently in theaters' => 1,
     'movies currently in theatres' => 1,
+    'movies currently in cinemas' => 1,
     'currently in theaters' => 1,
     'currently in theatres' => 1,
+    'currently in cinemas' => 1,
     );
 
 handle query_lc => sub {

--- a/t/InTheaters.t
+++ b/t/InTheaters.t
@@ -53,12 +53,12 @@ ddg_spice_test(
         caller    => 'DDG::Spice::InTheaters',
         is_cached => 0,
     ),
-    'opening soon in cinemas' => test_spice(
+    'movies currently in cinemas' => test_spice(
         "/js/spice/in_theaters/in_theaters/US",
         caller    => 'DDG::Spice::InTheaters',
         is_cached => 0,
     ),
-    'movies currently in cinemas' => test_spice(
+    'movies in cinemas' => test_spice(
         "/js/spice/in_theaters/in_theaters/US",
         caller    => 'DDG::Spice::InTheaters',
         is_cached => 0,

--- a/t/InTheaters.t
+++ b/t/InTheaters.t
@@ -48,6 +48,21 @@ ddg_spice_test(
         caller    => 'DDG::Spice::InTheaters',
         is_cached => 0,
     ),
+    'currently in cinemas' => test_spice(
+        "/js/spice/in_theaters/in_theaters/US",
+        caller    => 'DDG::Spice::InTheaters',
+        is_cached => 0,
+    ),
+    'opening soon in cinemas' => test_spice(
+        "/js/spice/in_theaters/in_theaters/US",
+        caller    => 'DDG::Spice::InTheaters',
+        is_cached => 0,
+    ),
+    'movies currently in cinemas' => test_spice(
+        "/js/spice/in_theaters/in_theaters/US",
+        caller    => 'DDG::Spice::InTheaters',
+        is_cached => 0,
+    ),
 );
 
 done_testing;


### PR DESCRIPTION
Fixes #2321 

Support for "cinemas" trigger word -  [see test file](https://github.com/duckduckgo/zeroclickinfo-spice/blob/fb14a961c3830fd4143a5fa3c4fcd5569deed7d2/t/InTheaters.t#L51-L64)

"theatres" triggers already exist. 