### PR TITLE
Time: Remove .replace for time offset, display raw offset

### DIFF
--- a/share/spice/time/time.js
+++ b/share/spice/time/time.js
@@ -98,7 +98,7 @@
             monthName: months[dateObj.getMonth()],
             year: dateObj.getFullYear(),
             placeName: placeName,
-            offset: chosen.time.timezone.offset.replace(/0|:/g, ""),
+            offset: chosen.time.timezone.offset,
             zone: chosen.time.timezone.zonename,
             country: chosen.geo.country.name
         };


### PR DESCRIPTION
Fixes #2404

Display raw offset, don't use replace to remove `0`

![2016-01-13-37-what is the time in dublin at duckduckgo](https://cloud.githubusercontent.com/assets/5282264/12282077/4cd8af54-b9d6-11e5-96f8-bbd64ed8481a.png)
![2016-01-13-29-what is the time in finland at duckduckgo](https://cloud.githubusercontent.com/assets/5282264/12282076/4cc9e438-b9d6-11e5-9013-f8c5bf3f78b8.png)

https://duck.co/ia/view/time