### PR TITLE
New Grunt Spice

### DIFF
--- a/lib/DDG/Spice/Grunt.pm
+++ b/lib/DDG/Spice/Grunt.pm
@@ -6,11 +6,11 @@ spice is_cached => 1;
 spice wrap_jsonp_callback => 1;
 spice to => 'http://gruntjs.com/plugin-list.json';
 
-triggers any => 'grunt plugin', 'grunt plugins', 'gruntjs', 'gruntjs plugin', 'gruntjs plugins';
+triggers any => 'grunt plugin', 'grunt plugins', 'gruntjs', 'gruntjs plugin', 'gruntjs plugins', 'grunt.js plugin', 'grunt.js plugins';
 
 handle remainder => sub {
     return $_ if length $_;
-    return $_;
+    return;
 };
 
 1;

--- a/lib/DDG/Spice/Grunt.pm
+++ b/lib/DDG/Spice/Grunt.pm
@@ -6,7 +6,7 @@ spice is_cached => 1;
 spice wrap_jsonp_callback => 1;
 spice to => 'http://gruntjs.com/plugin-list.json';
 
-triggers any => 'grunt plugin', 'grunt plugins', 'gruntjs', 'gruntjs plugin', 'gruntjs plugins', 'grunt.js plugin', 'grunt.js plugins';
+triggers startend => 'grunt plugin', 'grunt plugins', 'gruntjs', 'gruntjs plugin', 'gruntjs plugins', 'grunt.js plugin', 'grunt.js plugins';
 
 handle remainder => sub {
     return $_ if length $_;

--- a/lib/DDG/Spice/Grunt.pm
+++ b/lib/DDG/Spice/Grunt.pm
@@ -1,0 +1,16 @@
+package DDG::Spice::Grunt;
+
+use DDG::Spice;
+
+spice is_cached => 1;
+spice wrap_jsonp_callback => 1;
+spice to => 'http://gruntjs.com/plugin-list.json';
+
+triggers any => 'grunt plugin', 'grunt plugins', 'gruntjs', 'gruntjs plugin', 'gruntjs plugins';
+
+handle remainder => sub {
+    return $_ if length $_;
+    return $_;
+};
+
+1;

--- a/share/spice/grunt/footer.handlebars
+++ b/share/spice/grunt/footer.handlebars
@@ -1,0 +1,6 @@
+{{#if licenses}}
+<div>{{licenses}} Licence</div>
+{{else}}
+<div>&nbsp;</div>
+{{/if}}
+<div class="tx-clr--grey-light">{{download_count}} downloads</div>

--- a/share/spice/grunt/grunt.js
+++ b/share/spice/grunt/grunt.js
@@ -1,0 +1,101 @@
+(function (env) {
+    "use strict";
+    
+    // From http://stackoverflow.com/a/34064434/1546577
+    // This is used to decode entities that is often found in the descriptions.
+    function htmlDecode(input) {
+        var doc = new DOMParser().parseFromString(input, "text/html");
+        return doc.documentElement.textContent;
+    }
+    
+    // Add a star beside the name if it's an official plugin.
+    function officialPlugin(author) {
+        if(author === 'Grunt Team') {
+            return '★';
+        }
+        return '';
+    }
+    
+    env.ddg_spice_grunt = function(api_result) {
+        
+        if (!api_result || !api_result.aaData || !api_result.aaData.length) {
+            return Spice.failed('grunt');
+        }
+        
+        // Get the original query sans the trigger words.
+        var script = $('[src*="/js/spice/grunt/"]')[0],
+            source = $(script).attr("src"),
+            query = source.match(/grunt\/([^\/]*)/)[1];
+        
+        // Return immediately if there is no query.
+        // I don't think we'd like to display all the available plugins.
+        // Although, I could be wrong.
+        if(!query) {
+            return Spice.failed('grunt');
+        }
+        
+        // Generate a regexp out of the query.
+        // We're going to use this to look for relevant items to display.
+        var query_re = new RegExp(query, 'i');
+        
+        // Cache the regexp for removing the "grunt-" at the beginning of all the names.
+        var grunt_re = /^grunt\-/;
+
+        Spice.add({
+            id: "grunt",
+            name: "Grunt Plugins",
+            data: api_result.aaData,
+            meta: {
+                sourceName: 'Grunt',
+                // We can't link to the actual query since filtering is all done on 
+                // the front-end as well.
+                sourceUrl: 'http://gruntjs.com/plugins'
+            },
+            normalize: function(item) {
+                // Check if the name or description has the query.
+                // We do this because we get all of the plugins available,
+                // and we have to filter the things we need for ourselves.
+                if(!query_re.test(item.name) && !query_re.test(item.ds)) {
+                    return;
+                }
+                
+                return {
+                    // Remove the "grunt-" at the beginning of plugins.
+                    // That's how they're displayed in http://gruntjs.com/plugins
+                    title: item.name.replace(grunt_re, '') +  ' ' + officialPlugin(item.a),
+                    subtitle: item.a || ' ',
+                    description: htmlDecode(item.ds),
+                    download_count: DDG.commifyNumber(item.dl),
+                    url: 'https://www.npmjs.com/package/' + item.name
+                };
+            },
+            templates: {
+                group: 'text',
+                detail: false,
+                item_detail: false,
+                variants: {
+                    tile: 'basic1',
+                    tileTitle: '1line',
+                    tileFooter: '2line',
+                    tileSnippet: 'large'
+                },
+                options: {
+                    content: Spice.grunt.content,
+                    moreAt: true,
+                    footer: Spice.grunt.footer
+                }
+            },
+            sort_fields: {
+                'official': function(a, b) {
+                    // Make sure the official plugins and the ones that have the highest download
+                    // go first. This is useful if you want to find reputable plugins.
+                    if(a.a === 'Grunt Team' || a.dl > b.dl) {
+                        return -1;
+                    }
+                    return 1;
+                }
+            },
+            sort_default: 'official'
+        });
+    };
+}(this));

--- a/share/spice/grunt/grunt.js
+++ b/share/spice/grunt/grunt.js
@@ -1,12 +1,16 @@
 (function (env) {
     "use strict";
     
-    // From http://stackoverflow.com/a/34064434/1546577
-    // This is used to decode entities that is often found in the descriptions.
-    function htmlDecode(input) {
-        var doc = new DOMParser().parseFromString(input, "text/html");
-        return doc.documentElement.textContent;
-    }
+    // From https://developer.mozilla.org/en-US/Add-ons/Code_snippets/HTML_to_DOM
+    // Used to decode entities.
+    var htmlDecode = (function() {
+        var doc = document.implementation.createHTMLDocument('div');
+        
+        return function(input) {
+            doc.documentElement.innerHTML = input;
+            return doc.body.textContent;
+        };
+    }());
     
     // Add a star beside the name if it's an official plugin.
     function officialPlugin(author) {
@@ -43,7 +47,7 @@
 
         Spice.add({
             id: "grunt",
-            name: "Grunt Plugins",
+            name: "Software",
             data: api_result.aaData,
             meta: {
                 sourceName: 'Grunt',
@@ -62,7 +66,7 @@
                 return {
                     // Remove the "grunt-" at the beginning of plugins.
                     // That's how they're displayed in http://gruntjs.com/plugins
-                    title: item.name.replace(grunt_re, '') +  ' ' + officialPlugin(item.a),
+                    title: officialPlugin(item.a) + ' ' + item.name.replace(grunt_re, ''),
                     subtitle: item.a || ' ',
                     description: htmlDecode(item.ds),
                     download_count: DDG.commifyNumber(item.dl),
@@ -74,10 +78,9 @@
                 detail: false,
                 item_detail: false,
                 variants: {
-                    tile: 'basic1',
                     tileTitle: '1line',
                     tileFooter: '2line',
-                    tileSnippet: 'large'
+                    tileSnippet: 'small'
                 },
                 options: {
                     content: Spice.grunt.content,

--- a/t/Grunt.t
+++ b/t/Grunt.t
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+spice is_cached => 1;
+
+ddg_spice_test(
+    [qw( DDG::Spice::Grunt)],
+    'grunt plugin sass' => test_spice(
+        '/js/spice/grunt/sass',
+        call_type => 'include',
+        caller => 'DDG::Spice::Grunt'
+    ),
+    'grunting' => undef,
+);
+
+done_testing;
+


### PR DESCRIPTION
This plugin gets its data from http://gruntjs.com/plugin-list.json which I admit is a bit big at around 200kb. I think this is ok though since the triggering is limited to "grunt plugins" and "gruntjs plugins". I think anyone searching with those kind of queries have a high signal that they are actually looking for grunt plugins so I think it's worth loading those 200kb (some IAs even load more data--look at recipes. It makes the page 2MB big with the query "cake")

Hope this is ok!

It's modeled after the rubygems spice:

<img width="985" alt="screen shot 2016-01-15 at 3 59 39 am" src="https://cloud.githubusercontent.com/assets/81969/12349289/77a84f3e-bb3c-11e5-89f0-d17295ef71d7.png">

---

https://duck.co/ia/view/grunt