### PR TITLE
Nutrition: Add min_score param

### DIFF
--- a/lib/DDG/Spice/Nutrition.pm
+++ b/lib/DDG/Spice/Nutrition.pm
@@ -11,7 +11,7 @@ triggers any => 'calories';
 
 # brand_id is hard coded to USDA for now. Eventually could support searches across brands (i.e. packaged goods or restaurants, but requires multiple
 # calls to their API so waiting for now):
-spice to => 'http://api.nutritionix.com/v1_1/search/$1?results=0%3A20&min_score=1&brand_id=513fcc648110a4cafb90ca5e&fields=*&appId={{ENV{DDG_SPICE_NUTRITIONIX_APPID}}}&appKey={{ENV{DDG_SPICE_NUTRITIONIX_APIKEY}}}';
+spice to => 'http://api.nutritionix.com/v1_1/search/$1?results=0%3A20&brand_id=513fcc648110a4cafb90ca5e&fields=*&appId={{ENV{DDG_SPICE_NUTRITIONIX_APPID}}}&appKey={{ENV{DDG_SPICE_NUTRITIONIX_APIKEY}}}';
 spice wrap_jsonp_callback => 1;
 
 handle query_lc => sub {

--- a/lib/DDG/Spice/Nutrition.pm
+++ b/lib/DDG/Spice/Nutrition.pm
@@ -11,7 +11,7 @@ triggers any => 'calories';
 
 # brand_id is hard coded to USDA for now. Eventually could support searches across brands (i.e. packaged goods or restaurants, but requires multiple
 # calls to their API so waiting for now):
-spice to => 'http://api.nutritionix.com/v1_1/search/$1?results=0%3A20&brand_id=513fcc648110a4cafb90ca5e&fields=*&appId={{ENV{DDG_SPICE_NUTRITIONIX_APPID}}}&appKey={{ENV{DDG_SPICE_NUTRITIONIX_APIKEY}}}';
+spice to => 'http://api.nutritionix.com/v1_1/search/$1?results=0%3A20&min_score=1&brand_id=513fcc648110a4cafb90ca5e&fields=*&appId={{ENV{DDG_SPICE_NUTRITIONIX_APPID}}}&appKey={{ENV{DDG_SPICE_NUTRITIONIX_APIKEY}}}';
 spice wrap_jsonp_callback => 1;
 
 handle query_lc => sub {

--- a/share/spice/nutrition/nutrition.js
+++ b/share/spice/nutrition/nutrition.js
@@ -2,7 +2,7 @@
     'use strict';
     env.ddg_spice_nutrition = function(api_result) {
 
-        if (!api_result || !api_result.hits || !api_result.hits.length) {
+        if (!api_result || !api_result.hits || !api_result.hits.length || api_result.max_score < 1) {
             return Spice.failed('nutrition');
         }
 


### PR DESCRIPTION
Fixes #2419

The score for results mentioned in #2419 are below 1 - see https://duckduckgo.com/js/spice/nutrition/count

~~Using the `min_score=1` param we can limit results to only return above 1. - documentation https://developer.nutritionix.com/docs/v1_1~~

~~Needs to be deployed to beta for testing as unable to test locally without obtaining new API key.~~


_________

https://duck.co/ia/view/nutrition