### PR TITLE
MissingKids: Set signal high

### DIFF
--- a/share/spice/missing_kids/missing_kids.js
+++ b/share/spice/missing_kids/missing_kids.js
@@ -63,6 +63,7 @@
             Spice.add({
                 id: 'missing_kids',
                 name: 'Missing Kids',
+                signal: "high",
                 data: articles,
                 meta: {
                     primaryText: 'Missing children in ' + decodedQuery,


### PR DESCRIPTION
This ensures that when the query is "missing kids" if the IA triggers and shows, it's tab will open.

-----
IA Page: https://duck.co/ia/view/missing_kids