### PR TITLE
Remove background color override for recipes mobile detail panes

### DIFF
--- a/share/spice/recipes/recipes.css
+++ b/share/spice/recipes/recipes.css
@@ -56,10 +56,6 @@
     text-align: center;
 }
 
-.is-mobile .detail--recipes {
-    background-color: #f2f2f2;
-}
-
 .detail__body--recipe .recipe__title {
     padding: 0;
 }


### PR DESCRIPTION
This style seems unnecessary and is breaking the mobile detail pane in dark theme:
![screen shot 2016-01-14 at 3 42 04 pm](https://cloud.githubusercontent.com/assets/126358/12646703/a02cac6c-c59f-11e5-86f1-aae64d0a52fc.png)

@moollaza 