### PR TITLE
Remove premium/free badge, move date to left side

### DIFF
--- a/share/spice/statista/footer.handlebars
+++ b/share/spice/statista/footer.handlebars
@@ -1,4 +1,3 @@
 <div class="tx-clr--lt2 statista__footer">
-	<div class="pull-left"><span class="statista__badge statista__{{footerpremiumcssclass}}"></span> {{footerpremiumtext}}</div>
-	<div class="pull-right"><span class="">{{footerdate}}</span></div>
+	<div class="pull-left"><span class="">{{footerdate}}</span></div>
 </div>

--- a/share/spice/statista/statista.css
+++ b/share/spice/statista/statista.css
@@ -6,14 +6,6 @@
     margin-right: .25em;
 }
 
-.tile--statista .statista__premium {
-    background-color: #f1a031;
-}
-
-.tile--statista .statista__free {
-    background-color: #589e4d;
-}
-
 .tile--statista .statista__footer {
     padding-top: 16px;
 }
@@ -24,4 +16,4 @@
 
 .tile--statista .tile__body.has-foot {
     padding-bottom: 2.8em;
-} 
+}

--- a/share/spice/statista/statista.js
+++ b/share/spice/statista/statista.js
@@ -1,78 +1,78 @@
-(function (env) {
-	"use strict";
+(function(env) {
+    "use strict";
 
-	function getImage(item, size, blank) {
-	   if (item.teaserImageUrls[size]) {
-			var img = item.teaserImageUrls[size].src;
-			if (blank == 1) {
-				img = img + '?blank=blank';
-			}
-			return img;
-		} else if (size == 1) {
-			return 'http://statistacloudfront.s3.amazonaws.com/Statistic/table/table-355-1.png';
-		} else if (size == 2) {
-			return 'https://static1.statista.com/Statistic/table/table-100-1.png';
-		}
-	}
+    function getImage(item, size, blank) {
+        if (item.teaserImageUrls[size]) {
+            var img = item.teaserImageUrls[size].src;
+            if (blank == 1) {
+                img = img + '?blank=blank';
+            }
+            return img;
+        } else if (size == 1) {
+            return 'http://statistacloudfront.s3.amazonaws.com/Statistic/table/table-355-1.png';
+        } else if (size == 2) {
+            return 'https://static1.statista.com/Statistic/table/table-100-1.png';
+        }
+    }
 
-	function getTitle(title) {
-		return title.replace(/\ \|\ .+?$/, "");
-	}
+    function getTitle(title) {
+        return title.replace(/\ \|\ .+?$/, "");
+    }
 
-	function formatDate(date) {
-		moment.locale('de');
-		var tstamp = moment(date, "DD.MM.YYYY");
-		moment.locale('en');
-		return moment(tstamp).format('MMM YYYY');
-	}
+    function formatDate(date) {
+        moment.locale('de');
+        var tstamp = moment(date, "DD.MM.YYYY");
+        moment.locale('en');
+        return moment(tstamp).format('MMM YYYY');
+    }
 
-	env.ddg_spice_statista = function(api_result){
+    env.ddg_spice_statista = function(api_result) {
 
-		if (!api_result || api_result.error) {
-			return Spice.failed('statista');
-		}
+        if (!api_result || api_result.error) {
+            return Spice.failed('statista');
+        }
 
-		// Get original query.
-	   var script = $('[src*="/js/spice/statista/"]')[0],
-		   source = $(script).attr("src"),
-		   query = decodeURIComponent(source.match(/statista\/([^\/]+)/)[1]);
+        // Get original query.
+        var script = $('[src*="/js/spice/statista/"]')[0],
+            source = $(script).attr("src"),
+            query = decodeURIComponent(source.match(/statista\/([^\/]+)/)[1]);
 
-		DDG.require('moment.js', function(){
-			Spice.add({
-				id: "statista",
-				name: "Statistics",
-				data: api_result.data,
-				meta: {
-					searchTerm: query,
-					sourceName: "Statista",
-					sourceUrl: 'https://www.statista.com/search/?q='+api_result.q
-				},
-				normalize: function(item) {
-					return {
-						title: getTitle(item.title),
-						url: item.Link,
-						description: item.subject ,
-						image: getImage(item, 1, 1),
-						img_m: getImage(item, 1, 0),
-						heading: item.subject,
-						abstract: item.description,
-						footerdate: formatDate(item.date, moment)
-					}
-				},
-				templates: {
-					group: 'media',
-					item_detail: 'products_item_detail',
-					wrap_detail: 'base_detail',
+        DDG.require('moment.js', function() {
+            Spice.add({
+                id: "statista",
+                name: "Statistics",
+                data: api_result.data,
+                meta: {
+                    searchTerm: query,
+                    sourceName: "Statista",
+                    sourceUrl: 'https://www.statista.com/search/?q=' + api_result.q
+                },
+                normalize: function(item) {
+                    return {
+                        title: getTitle(item.title),
+                        url: item.Link,
+                        description: item.subject,
+                        image: getImage(item, 1, 1),
+                        img_m: getImage(item, 1, 0),
+                        heading: item.subject,
+                        abstract: item.description,
+                        footerdate: formatDate(item.date, moment)
+                    }
+                },
+                templates: {
+                    group: 'media',
+                    item_detail: 'products_item_detail',
+                    wrap_detail: 'base_detail',
 
-					options: {
-						moreAt: true,
-						rating: false,
-						price: false,
-						brand: false,
-						footer: Spice.statista.footer
-					}
-				},
-			});
-		});
-	};
+                    options: {
+                        moreAt: true,
+                        rating: false,
+                        price: false,
+                        brand: false,
+                        footer: Spice.statista.footer
+                    }
+                },
+            });
+        });
+    };
 }(this));

--- a/share/spice/statista/statista.js
+++ b/share/spice/statista/statista.js
@@ -1,98 +1,78 @@
 (function (env) {
-    "use strict";
+	"use strict";
 
-     // Get original query.
-    var script = $('[src*="/js/spice/statista/"]')[0],
-        source = $(script).attr("src"),
-        query = decodeURIComponent(source.match(/statista\/([^\/]+)/)[1]);
+	function getImage(item, size, blank) {
+	   if (item.teaserImageUrls[size]) {
+			var img = item.teaserImageUrls[size].src;
+			if (blank == 1) {
+				img = img + '?blank=blank';
+			}
+			return img;
+		} else if (size == 1) {
+			return 'http://statistacloudfront.s3.amazonaws.com/Statistic/table/table-355-1.png';
+		} else if (size == 2) {
+			return 'https://static1.statista.com/Statistic/table/table-100-1.png';
+		}
+	}
 
-   
-    function getImage(item, size, blank) {  
-       if (item.teaserImageUrls[size]) {
-            var img = item.teaserImageUrls[size].src;
-            if (blank == 1) {
-                img = img + '?blank=blank';
-            }
-            return img;
-        } else if (size == 1) {
-            return 'http://statistacloudfront.s3.amazonaws.com/Statistic/table/table-355-1.png';
-        } else if (size == 2) {
-            return 'https://static1.statista.com/Statistic/table/table-100-1.png';
-        }
-    }
-    
-    function getTitle(title) {
-        return title.replace(/\ \|\ .+?$/, "");
-    }
-    
-    function formatDate(date) {
-        moment.locale('de');
-        var tstamp = moment(date, "DD.MM.YYYY");
-        moment.locale('en');
-        return moment(tstamp).format('MMM YYYY');
-    }
-    
-    function getPremiumText(item) {
-        if (item.Premium == 1) {
-            return 'Premium';
-        } else {
-            return 'Free';
-        }
-    }
-    
-    function getPremiumCssClass(item) {
-        if (item.Premium == 1) {
-            return 'premium';
-        } else {
-            return 'free';
-        }
-    }
-    
-    env.ddg_spice_statista = function(api_result){
+	function getTitle(title) {
+		return title.replace(/\ \|\ .+?$/, "");
+	}
 
-        if (!api_result || api_result.error) {
-            return Spice.failed('statista');
-        }
+	function formatDate(date) {
+		moment.locale('de');
+		var tstamp = moment(date, "DD.MM.YYYY");
+		moment.locale('en');
+		return moment(tstamp).format('MMM YYYY');
+	}
 
-        DDG.require('moment.js', function(){ 
-            Spice.add({
-                id: "statista",
-                name: "Statistics",
-                data: api_result.data,
-                meta: {
-                    searchTerm: query,
-                    sourceName: "Statista",
-                    sourceUrl: 'https://www.statista.com/search/?q='+api_result.q
-                },
-                normalize: function(item) {
-                    return {
-                        title: getTitle(item.title),
-                        url: item.Link,
-                        description: item.subject ,
-                        image: getImage(item, 1, 1),
-                        img_m: getImage(item, 1, 0),
-                        heading: item.subject,
-                        abstract: item.description,
-                        footerdate: formatDate(item.date, moment),
-                        footerpremiumcssclass: getPremiumCssClass(item),
-                        footerpremiumtext: getPremiumText(item)
+	env.ddg_spice_statista = function(api_result){
 
-                    }  
-                },
-                templates: {
-                    group: 'media',
-                    item_detail: 'products_item_detail',
-                    wrap_detail: 'base_detail',
+		if (!api_result || api_result.error) {
+			return Spice.failed('statista');
+		}
 
-                    options: {
-                        moreAt: true,
-                        rating: false,
-                        price: false,
-                        brand: false,
-                        footer: Spice.statista.footer
-                    }
-                },
-            });
-        });
-    };
+		// Get original query.
+	   var script = $('[src*="/js/spice/statista/"]')[0],
+		   source = $(script).attr("src"),
+		   query = decodeURIComponent(source.match(/statista\/([^\/]+)/)[1]);
+
+		DDG.require('moment.js', function(){
+			Spice.add({
+				id: "statista",
+				name: "Statistics",
+				data: api_result.data,
+				meta: {
+					searchTerm: query,
+					sourceName: "Statista",
+					sourceUrl: 'https://www.statista.com/search/?q='+api_result.q
+				},
+				normalize: function(item) {
+					return {
+						title: getTitle(item.title),
+						url: item.Link,
+						description: item.subject ,
+						image: getImage(item, 1, 1),
+						img_m: getImage(item, 1, 0),
+						heading: item.subject,
+						abstract: item.description,
+						footerdate: formatDate(item.date, moment)
+					}
+				},
+				templates: {
+					group: 'media',
+					item_detail: 'products_item_detail',
+					wrap_detail: 'base_detail',
+
+					options: {
+						moreAt: true,
+						rating: false,
+						price: false,
+						brand: false,
+						footer: Spice.statista.footer
+					}
+				},
+			});
+		});
+	};
 }(this));


### PR DESCRIPTION
The IA no longer displays premium content, so the "Free" and "Premium" badges are no longer needed.

I've also fixed the indentation.

You can see the changes without whitespace here: https://github.com/duckduckgo/zeroclickinfo-spice/pull/2449/files?w=1