### PR TITLE
Thesaurus: Fixes #412

### DIFF
--- a/lib/DDG/Spice/Thesaurus.pm
+++ b/lib/DDG/Spice/Thesaurus.pm
@@ -21,8 +21,7 @@ handle remainder_lc => sub {
     # Abort if we're left with more than one word to lookup
     return if ($query =~ /\s+/);
   
-    #return $query;
-    return $query, "todo-remove-this-var";
+    return $query;
 };
 
 1;

--- a/lib/DDG/Spice/Thesaurus.pm
+++ b/lib/DDG/Spice/Thesaurus.pm
@@ -3,32 +3,26 @@ package DDG::Spice::Thesaurus;
 
 use strict;
 use DDG::Spice;
+use Text::Trim;
 
-spice from => '([^/]+)/([^/]+)';
 spice to => 'http://words.bighugelabs.com/api/2/{{ENV{DDG_SPICE_BIGHUGE_APIKEY}}}/$1/json?callback={{callback}}';
 
-triggers startend => "synonyms", "synonym", "antonyms", "antonym", "related", "similar", "thesaurus";
+triggers startend => "synonyms", "synonym", "antonyms", "antonym", "thesaurus";
 
-handle query_lc => sub {
-  /^
-      (?:(synonym|antonym|related|similar|thesaurus)s?) \s+
-      (?:(?:terms?|words?)\s+)? (?:(?:of|to|for)\s+)?
-      (\w+) \s*
-      |
-      (\w+) \s+
-      ((synonym|antonym|thesaurus)s?)? \s*
-  $/x;
-
-  my $type = $1 || $4;
-  my $word = $2 || $3;
-
-  return unless $word and $type;
-
-  $type = 'synonym' if $type eq 'thesaurus';
-
-  return $word, $type;
-
-  return;
+handle remainder_lc => sub {
+    my $query = $_;
+    return unless $query;
+    
+    # Remove words that have no bearing on the lookup
+    $query =~ s/\b(of|for)+\b//g;
+    trim $query;    
+    return unless $query;
+    
+    # Abort if we're left with more than one word to lookup
+    return if ($query =~ /\s+/);
+  
+    #return $query;
+    return $query, "todo-remove-this-var";
 };
 
 1;

--- a/share/spice/thesaurus/content.handlebars
+++ b/share/spice/thesaurus/content.handlebars
@@ -1,7 +1,0 @@
-<ul>
-{{#each results}}
-    <li>
-        <span class='thesaurus--part'>{{heading}}</span>: {{words}}.
-    </li>
-{{/each}}
-</ul>

--- a/share/spice/thesaurus/thesaurus.css
+++ b/share/spice/thesaurus/thesaurus.css
@@ -1,0 +1,3 @@
+.zci--thesaurus .record__cell {
+    white-space: normal;
+}

--- a/share/spice/thesaurus/thesaurus.css
+++ b/share/spice/thesaurus/thesaurus.css
@@ -1,7 +1,0 @@
-.zci--thesaurus .thesaurus--part {
-    color: #777;
-}
-
-.zci--thesaurus h1 {
-    font-weight: 400;
-}

--- a/share/spice/thesaurus/thesaurus.js
+++ b/share/spice/thesaurus/thesaurus.js
@@ -59,8 +59,8 @@
                 };
                 
                 var result = {
-                    title: query,
-                    subtitle: wordTypeWithMostEntries,                    
+                    title: DDG.capitalize(query),
+                    subtitle: DDG.capitalize(wordTypeWithMostEntries),
                     record_keys : [],
                     record_data : {}
                 };

--- a/share/spice/thesaurus/thesaurus.js
+++ b/share/spice/thesaurus/thesaurus.js
@@ -14,17 +14,17 @@
         
         // Search the results for the word type (noun, adjective etc) with the most entries
         var wordTypeWithMostEntries;
-        var largestWordTypeEntryTotal = 0;
-        
-        Object.keys(api_result).forEach(function(wordType) { // wordType = ajective, noun etc...
-            var wordTypeEntryTotal = 0;
+        var highestEntryCount = 0;
 
-            Object.keys(api_result[wordType]).forEach(function(relationshipType) { // relationshipType = synonym, antonym etc...
-                wordTypeEntryTotal += Object.keys(api_result[wordType][relationshipType]).length;
+        $.each(api_result, function(wordType, words) { // wordType = ajective, noun etc... 
+            var wordTypeEntryCount = 0;
+            
+            $.each(words, function(relationshipType) { // relationshipType = synonym, antonym etc...
+                wordTypeEntryCount += words[relationshipType].length;
             });
-
-            if (wordTypeEntryTotal > largestWordTypeEntryTotal) {
-                largestWordTypeEntryTotal = wordTypeEntryTotal;
+            
+            if (wordTypeEntryCount > highestEntryCount) {
+                highestEntryCount = wordTypeEntryCount;
                 wordTypeWithMostEntries = wordType;
             }
         });
@@ -40,18 +40,17 @@
             templates: {
                 group: 'list',
                 options:{
-                    content: 'record', 
-                    rowHighlight : true,
+                    content: 'record',
                     moreAt: true
                 }
             },
             
             meta: {
-                sourceName:  'Big Huge Thesaurus',
+                sourceName: 'Big Huge Thesaurus',
                 sourceUrl:  'http://words.bighugelabs.com/' + query,
             },
             
-            normalize: function(item) {
+            normalize: function(words) {
                 var RELATIONSHIP_TYPE = {
                     SYNONYMS : "syn",
                     SIMILAR  : "sim",                    
@@ -62,27 +61,32 @@
                 var result = {
                     title: query,
                     subtitle: wordTypeWithMostEntries,                    
+                    record_keys : [],
                     record_data : {}
                 };
-
+                
                 // Display any synonyms if present
-                if(item.hasOwnProperty(RELATIONSHIP_TYPE.SYNONYMS)) {                    
-                    result.record_data["Synonyms"] = item[RELATIONSHIP_TYPE.SYNONYMS].join(', ');                    
+                if (words.hasOwnProperty(RELATIONSHIP_TYPE.SYNONYMS)) {
+                    result.record_keys.push("Synonyms");
+                    result.record_data["Synonyms"] = words[RELATIONSHIP_TYPE.SYNONYMS].join(', ');
                 }
                 
                 // Display any similar words if present
-                if(item.hasOwnProperty(RELATIONSHIP_TYPE.SIMILAR)) {                    
-                    result.record_data["Similar"] = item[RELATIONSHIP_TYPE.SIMILAR].join(', ');                    
+                if (words.hasOwnProperty(RELATIONSHIP_TYPE.SIMILAR)) {
+                    result.record_keys.push("Similar");
+                    result.record_data["Similar"] = words[RELATIONSHIP_TYPE.SIMILAR].join(', ');
                 }
                 
                 // Display any related words if present
-                if(item.hasOwnProperty(RELATIONSHIP_TYPE.RELATED)) {                    
-                    result.record_data["Related"] = item[RELATIONSHIP_TYPE.RELATED].join(', ');                    
+                if (words.hasOwnProperty(RELATIONSHIP_TYPE.RELATED)) {
+                    result.record_keys.push("Related");
+                    result.record_data["Related"] = words[RELATIONSHIP_TYPE.RELATED].join(', ');                    
                 }
                 
                 // Display any antonyms if present
-                if(item.hasOwnProperty(RELATIONSHIP_TYPE.ANTONYMS)) {                    
-                    result.record_data["Antonyms"] = item[RELATIONSHIP_TYPE.ANTONYMS].join(', ');                    
+                if (words.hasOwnProperty(RELATIONSHIP_TYPE.ANTONYMS)) {
+                    result.record_keys.push("Antonyms");
+                    result.record_data["Antonyms"] = words[RELATIONSHIP_TYPE.ANTONYMS].join(', ');
                 }
              
                 return result;

--- a/share/spice/thesaurus/thesaurus.js
+++ b/share/spice/thesaurus/thesaurus.js
@@ -38,7 +38,7 @@
             name: 'Thesaurus',
             data:  api_result[wordTypeWithMostEntries],
             templates: {
-                group: 'list',
+                group: 'text',
                 options:{
                     content: 'record',
                     moreAt: true

--- a/share/spice/thesaurus/title_content.handlebars
+++ b/share/spice/thesaurus/title_content.handlebars
@@ -1,1 +1,0 @@
-<h1 class="zci__header">{{headerText}} <b>{{query}}</b>:</h1>

--- a/t/Thesaurus.t
+++ b/t/Thesaurus.t
@@ -7,53 +7,144 @@ use DDG::Test::Spice;
 
 ddg_spice_test(
     [qw( DDG::Spice::Thesaurus )],
-    'synonym for search' => test_spice(
-        '/js/spice/thesaurus/search/synonym',
-        call_type => 'include',
-        caller => 'DDG::Spice::Thesaurus'
-    ),
+    
+    # Tests for trigger word 'synonym[s]'
+    
     'synonym forget' => test_spice(
-        '/js/spice/thesaurus/forget/synonym',
+        '/js/spice/thesaurus/forget',
         call_type => 'include',
         caller => 'DDG::Spice::Thesaurus'
     ),
-    'synonyms for forget' => test_spice(
-        '/js/spice/thesaurus/forget/synonym',
+    'synonym for search' => test_spice(
+        '/js/spice/thesaurus/search',
         call_type => 'include',
         caller => 'DDG::Spice::Thesaurus'
-    ),
-    'antonyms for forget' => test_spice(
-        '/js/spice/thesaurus/forget/antonym',
-        call_type => 'include',
-        caller => 'DDG::Spice::Thesaurus'
-    ),
-    'similar words to expose' => test_spice(
-        '/js/spice/thesaurus/expose/similar',
-        call_type => 'include',
-        caller => 'DDG::Spice::Thesaurus'
-    ),
-    'related words to corruption' => test_spice(
-        '/js/spice/thesaurus/corruption/related',
-        call_type => 'include',
-        caller => 'DDG::Spice::Thesaurus'
-    ),
-    'beautiful thesaurus' => test_spice(
-        '/js/spice/thesaurus/beautiful/synonym',
-        call_type => 'include',
-        caller => 'DDG::Spice::Thesaurus'
-    ),
-    'synonyms for person' => test_spice(
-        '/js/spice/thesaurus/person/synonym',
+    ),   
+    'synonym of happy' => test_spice(
+        '/js/spice/thesaurus/happy',
         caller    => 'DDG::Spice::Thesaurus',
     ),
-    'thesaurus awesome' => test_spice(
-        '/js/spice/thesaurus/awesome/synonym',
+    'synonyms forget' => test_spice(
+        '/js/spice/thesaurus/forget',
+        call_type => 'include',
+        caller => 'DDG::Spice::Thesaurus'
+    ),
+    'synonyms for search' => test_spice(
+        '/js/spice/thesaurus/search',
+        call_type => 'include',
+        caller => 'DDG::Spice::Thesaurus'
+    ),   
+    'synonyms of happy' => test_spice(
+        '/js/spice/thesaurus/happy',
         caller    => 'DDG::Spice::Thesaurus',
     ),
-    'similar words to miniature' => test_spice(
-        '/js/spice/thesaurus/miniature/similar',
+    'forget synonym' => test_spice(
+        '/js/spice/thesaurus/forget',
+        call_type => 'include',
+        caller => 'DDG::Spice::Thesaurus'
+    ),
+    'happy synonyms' => test_spice(
+        '/js/spice/thesaurus/happy',
+        call_type => 'include',
+        caller => 'DDG::Spice::Thesaurus'
+    ),
+    
+    # Tests for trigger word 'antonym[s]'
+    
+    'antonym forget' => test_spice(
+        '/js/spice/thesaurus/forget',
+        call_type => 'include',
+        caller => 'DDG::Spice::Thesaurus'
+    ),    
+    'antonym for search' => test_spice(
+        '/js/spice/thesaurus/search',
+        call_type => 'include',
+        caller => 'DDG::Spice::Thesaurus'
+    ),
+    'antonym of happy' => test_spice(
+        '/js/spice/thesaurus/happy',
+        caller    => 'DDG::Spice::Thesaurus',
+    ),    
+    'antonyms forget' => test_spice(
+        '/js/spice/thesaurus/forget',
+        call_type => 'include',
+        caller => 'DDG::Spice::Thesaurus'
+    ),
+    'antonyms for search' => test_spice(
+        '/js/spice/thesaurus/search',
+        call_type => 'include',
+        caller => 'DDG::Spice::Thesaurus'
+    ),   
+    'antonyms of happy' => test_spice(
+        '/js/spice/thesaurus/happy',
         caller    => 'DDG::Spice::Thesaurus',
     ),
+    'forget antonym' => test_spice(
+        '/js/spice/thesaurus/forget',
+        call_type => 'include',
+        caller => 'DDG::Spice::Thesaurus'
+    ),
+    'happy antonyms' => test_spice(
+        '/js/spice/thesaurus/happy',
+        call_type => 'include',
+        caller => 'DDG::Spice::Thesaurus'
+    ),
+    
+    # Tests for trigger word 'thesaurus'
+    
+    'thesaurus forget' => test_spice(
+        '/js/spice/thesaurus/forget',
+        caller    => 'DDG::Spice::Thesaurus',
+    ),
+    
+    'happy thesaurus' => test_spice(
+        '/js/spice/thesaurus/happy',
+        caller    => 'DDG::Spice::Thesaurus',
+    ),
+    
+    # Tests that shouldn't trigger the IA
+
+    'synonym firstword secondword' => undef,
+    'firstword synonym secondword' => undef,
+    'firstword secondword synonym ' => undef,
+    
+    'synonyms firstword secondword' => undef,
+    'firstword synonyms secondword' => undef,
+    'firstword secondword synonyms' => undef,
+    
+    'antonym firstword secondword' => undef,
+    'firstword antonym secondword' => undef,
+    'firstword secondword antonym' => undef,
+    
+    'antonyms firstword secondword' => undef,
+    'firstword antonyms secondword' => undef, 
+    'firstword secondword antonyms' => undef,
+    
+    'thesaurus firstword secondword' => undef,
+    'firstword thesaurus secondword' => undef, 
+    'firstword secondword thesaurus' => undef,
+    
+    'synonym' => undef,
+    'synonyms' => undef,
+    'antonym' => undef,
+    'antonyms' => undef,
+    'thesaurus' => undef,
+    
+    'synonym of' => undef,
+    'synonyms of' => undef,
+    'antonym of' => undef,
+    'antonyms of' => undef,
+    'thesaurus of' => undef,
+    
+    'synonym for' => undef,
+    'synonyms for' => undef,
+    'antonym for' => undef,
+    'antonyms for' => undef,
+    'thesaurus for' => undef,
+    
+    'similar words to expose' => undef,    
+    'related words to corruption' => undef,
+    'similar words to miniature' => undef,
 );
 
 done_testing;


### PR DESCRIPTION
Fixes #412

This PR improves the results displayed by the Thesaurus IA. It also changes the layout. As highlighted in #412 the results displayed were somewhat questionable at times. Below I've listed the changes made to address this and the work that is still outstanding. 

I'd also like to look for a better source of data, perhaps [Wordnik](https://www.wordnik.com/), which is what we use for the Dictionary IA. However that goes beyond the scope of this fix.

### Preview
![new-look](https://cloud.githubusercontent.com/assets/16732873/12690324/850ade68-c6da-11e5-82dd-b3301b6af2a5.PNG)

### Changes
1. The results returned from the API are now searched and the word type (noun, adjective etc) with the most entries is selected and displayed on the basis that it's likely to be the most common use case for that particular word
2. The results are now displayed using the `list` template group
3. Regardless of the trigger word used (see below) we display all word entries (synonyms, antonyms, related words etc)
3. Deleted redundant Handlebars and CSS files
4. The trigger handling has been simplified to only fire when queries of the following format are submitted:

`<trigger-word> [of|for] <search-word>` or `<search-word> [of|for] <trigger-word>`

where:
`<trigger-word>` is one of `synonym|synonyms|thesaurus|antonym|antonyms`
`<search-word>` is a single word

### Outstanding Issues
1. ~~For reasons unknown to me, unless I return two variables from `Thesaurus.pm` the IA fails to trigger~~
2. ~~`Thesaurus.t` needs to be updated but can't until (1) is addressed~~
3. ~~Is it possible to fix the order of the rows with the `list` template group? (I haven't found a way)~~
4. ~~Lastly, during testing I could only make the _Show More/Less_ button appear by making the width of my window extremely narrow. I'd like it to be present whenever one of the rows has more data than it can display (as is the case above). Is this just a quirk with local servers and it'll be automatically fixed in production or is this something I need to programmatically enforce?~~

![show-more](https://cloud.githubusercontent.com/assets/16732873/12690689/359cbb46-c6dd-11e5-8bf3-f62f6c391ba9.png)

---
IA Page: https://duck.co/ia/view/thesaurus