### PR TITLE
expand_url: fixed spice failing on every query

### DIFF
--- a/share/spice/expand_url/expand_url.js
+++ b/share/spice/expand_url/expand_url.js
@@ -8,7 +8,7 @@
             query = source.match(/expand_url\/([^\/]+)/)[1];
 
         // Check if there are any errors.
-        if (!api_response || api_response["long-url"] || api_response["long-url"] === query) {
+        if (!api_response || !api_response["long-url"] || api_response["long-url"] === query) {
             return Spice.failed('expand_url');
         }
 


### PR DESCRIPTION
* added exclamation mark, which ensures that
  if there's not a long-url key, it will fail

Signed-off-by: Adrian Matejov <a.matejov@centrum.sk>

@bsstoner probably removed that exclamation mark here -> https://github.com/duckduckgo/zeroclickinfo-spice/commit/c790c2392994136f0891c842bc1d4a810f8edf0a