### PR TITLE
SeatGeek: Change IA's that use the SeatGeek API to use HTTPS

### DIFF
--- a/lib/DDG/Spice/SeatGeek/EventsByArtist.pm
+++ b/lib/DDG/Spice/SeatGeek/EventsByArtist.pm
@@ -18,7 +18,7 @@ triggers startend =>
 
 spice proxy_cache_valid => "200 304 12h";
 
-spice to => 'http://api.seatgeek.com/2/events?taxonomies.name=concert&per_page=20&performers.slug=$1&callback={{callback}}';
+spice to => 'https://api.seatgeek.com/2/events?taxonomies.name=concert&per_page=20&performers.slug=$1&callback={{callback}}';
 
 handle remainder_lc => sub {
     # in case we've matched for example "upcoming bjork concerts"

--- a/lib/DDG/Spice/SeatGeek/EventsByCity.pm
+++ b/lib/DDG/Spice/SeatGeek/EventsByCity.pm
@@ -15,7 +15,7 @@ triggers start =>
 
 spice proxy_cache_valid => "200 304 12h";
 
-spice to => 'http://api.seatgeek.com/2/events?taxonomies.name=concert&per_page=20&venue.city=$1&callback={{callback}}';
+spice to => 'https://api.seatgeek.com/2/events?taxonomies.name=concert&per_page=20&venue.city=$1&callback={{callback}}';
 
 handle remainder_lc => sub {
     # Return if this is a geolocation search

--- a/lib/DDG/Spice/SeatGeek/EventsByVenue.pm
+++ b/lib/DDG/Spice/SeatGeek/EventsByVenue.pm
@@ -15,7 +15,7 @@ triggers start =>
 
 spice proxy_cache_valid => "200 304 12h";
 
-spice to => 'http://api.seatgeek.com/2/events?taxonomies.name=concert&per_page=20&venue.slug=$1&callback={{callback}}';
+spice to => 'https://api.seatgeek.com/2/events?taxonomies.name=concert&per_page=20&venue.slug=$1&callback={{callback}}';
 
 handle remainder_lc => sub {
     # Replaces spaces between words with dashes, because the API requires it

--- a/lib/DDG/Spice/SeatGeek/EventsNearMe.pm
+++ b/lib/DDG/Spice/SeatGeek/EventsNearMe.pm
@@ -16,7 +16,7 @@ triggers start =>
 spice proxy_cache_valid => "418 1d";
 spice is_cached => 0;
 
-spice to => 'http://api.seatgeek.com/2/events?taxonomies.name=concert&per_page=20&lat=$1&lon=$2&range=50mi&&callback={{callback}}';
+spice to => 'https://api.seatgeek.com/2/events?taxonomies.name=concert&per_page=20&lat=$1&lon=$2&range=50mi&&callback={{callback}}';
 spice from => '([\-0-9.]+)/([\-0-9.]+)';
 
 handle remainder_lc => sub {

--- a/lib/DDG/Spice/SeatGeek/Sports.pm
+++ b/lib/DDG/Spice/SeatGeek/Sports.pm
@@ -5,7 +5,7 @@ use DDG::Spice;
 
 triggers startend => 'upcoming matches', 'events', 'event', 'upcoming match', 'matches', 'sports', 'schedule', 'tickets', 'games';
 
-spice to => 'http://api.seatgeek.com/2/events?q=$1&taxonomies.name=sports&per_page=50&callback={{callback}}';
+spice to => 'https://api.seatgeek.com/2/events?q=$1&taxonomies.name=sports&per_page=50&callback={{callback}}';
 
 handle remainder_lc => sub {
     # Removes spaces from the beginning of the query


### PR DESCRIPTION
As pointed out by @moollaza in #1554, the SeatGeek API has changed to always redirect to HTTPS. As a result all current IAs that use it are broken. This PR fixes them.

---
https://duck.co/ia/view/seat_geek
https://duck.co/ia/view/seat_geek_sports
https://duck.co/ia/view/seat_geek_events_near_me
https://duck.co/ia/view/seat_geek_events_by_venue
https://duck.co/ia/view/seat_geek_events_by_city
https://duck.co/ia/view/seat_geek_events_by_artist