### PR TITLE
Use Git::Tag::IAChangelog in dist.ini

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -38,7 +38,9 @@ sharedir_method = module_share_dir
 version_regexp = ^(.+)$
 [PkgVersion]
 [GithubMeta]
-[@Git]
+[Git::Check]
+[Git::Commit]
+[Git::Tag::IAChangelog]
 tag_format = %v
 [Git::Push]
 push_to = origin master

--- a/dist.ini
+++ b/dist.ini
@@ -12,6 +12,7 @@ module = Dist::Zilla::Plugin::UploadToDuckPAN
 module = Dist::Zilla::Plugin::BuildShareAssets
 module = Dist::Zilla::Plugin::IAChangelog
 module = Dist::Zilla::Plugin::AnnounceRelease
+module = Dist::Zilla::Plugin::Git::Tag::IAChangelog
 
 [AutoPrereqs]
 

--- a/dist.ini
+++ b/dist.ini
@@ -12,7 +12,6 @@ module = Dist::Zilla::Plugin::UploadToDuckPAN
 module = Dist::Zilla::Plugin::BuildShareAssets
 module = Dist::Zilla::Plugin::IAChangelog
 module = Dist::Zilla::Plugin::AnnounceRelease
-module = Dist::Zilla::Plugin::Git::Tag::IAChangelog
 
 [AutoPrereqs]
 


### PR DESCRIPTION
Use our new dzil plugin to update tag message on git.