### PR TITLE
SeatGeek Sports Tickets: Use moment.js

### DIFF
--- a/share/spice/seat_geek/sports/seat_geek_sports.js
+++ b/share/spice/seat_geek/sports/seat_geek_sports.js
@@ -9,137 +9,100 @@
         var query = DDG.get_query();
         var clean_query = $.trim(query.replace(/((upcoming\s)?(match(es)?))|(events?)|(schedule)|(sports)|(tickets)|(games)/, '').toLowerCase());
 
-        var months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-
-        Spice.add({
-            id: "seat_geek_sports",
-            name: "Tickets",
-            data: api_result.events,
-            meta: {
-                searchTerm: clean_query,
-                sourceName: "SeatGeek",
-                sourceUrl: "https://seatgeek.com/search?search=" + clean_query,
-                sourceIconUrl: "https://seatgeek.com/favicon.ico",
-                itemType: "Upcoming Events"
-            },
-            normalize: function(item) {
-                // Check relevancy of the item.
-                // First check if the query matches one of the performers names;
-                // if it doesn't, and it's not even relevant to the event title,
-                // check relevancy on the taxonomies. If this fails too, return null
-                var relevant = false;
-                var performer = item.performers[0];
-                var both_performers = [];
-                var title;
-                for(var i = 0; i < item.performers.length; i++) {
-                    if(DDG.stringsRelevant(item.performers[i].name.toLowerCase(), clean_query, [], 3, true) || DDG.stringsRelevant(item.performers[i].short_name.toLowerCase(), clean_query, [], 3, true)) {
-                        relevant = true;
-                    } else {
-                        performer = item.performers[i];
-                    }
-
-                    both_performers.push(item.performers[i].name);
-                }
-
-                if(!relevant) {
-                    if(DDG.stringsRelevant(item.short_title, clean_query, [], 3, true)) {
-                        relevant = true;
-                    } else {
-                        for(var i = 0; i < item.taxonomies.length; i++) {
-                            if(DDG.stringsRelevant(item.taxonomies[i].name.toLowerCase(), clean_query, [], 3, true)) {
-                                relevant = true;
-                            }
+        DDG.require('moment.js', function() {
+            Spice.add({
+                id: "seat_geek_sports",
+                name: "Tickets",
+                data: api_result.events,
+                meta: {
+                    searchTerm: clean_query,
+                    sourceName: "SeatGeek",
+                    sourceUrl: "https://seatgeek.com/search?search=" + clean_query,
+                    sourceIconUrl: "https://seatgeek.com/favicon.ico",
+                    itemType: "Upcoming Events"
+                },
+                normalize: function(item) {
+                    // Check relevancy of the item.
+                    // First check if the query matches one of the performers names;
+                    // if it doesn't, and it's not even relevant to the event title,
+                    // check relevancy on the taxonomies. If this fails too, return null
+                    var relevant = false;
+                    var performer = item.performers[0];
+                    var both_performers = [];
+                    var title;
+                    for(var i = 0; i < item.performers.length; i++) {
+                        if(DDG.stringsRelevant(item.performers[i].name.toLowerCase(), clean_query, [], 3, true) || DDG.stringsRelevant(item.performers[i].short_name.toLowerCase(), clean_query, [], 3, true)) {
+                            relevant = true;
+                        } else {
+                            performer = item.performers[i];
                         }
+
+                        both_performers.push(item.performers[i].name);
                     }
 
                     if(!relevant) {
-                        return null;
+                        if(DDG.stringsRelevant(item.short_title, clean_query, [], 3, true)) {
+                            relevant = true;
+                        } else {
+                            for(var i = 0; i < item.taxonomies.length; i++) {
+                                if(DDG.stringsRelevant(item.taxonomies[i].name.toLowerCase(), clean_query, [], 3, true)) {
+                                    relevant = true;
+                                }
+                            }
+                        }
+
+                        if(!relevant) {
+                            return null;
+                        } else {
+                            title = both_performers.join(" vs ");
+                        }
                     } else {
-                        title = both_performers.join(" vs ");
-                    }
-                } else {
-                    title = performer.name;
-                }
-
-                function getDate(date) {
-                    if(date) {
-                        // IE 8 and Safari don't support the yyyy-mm-dd date format,
-                        // but they support mm/dd/yyyy
-                        date = date.replace(/T.*/, '');
-                        var remix_date = date.split("-");
-                        date = remix_date[1] + "/" + remix_date[2] + "/" + remix_date[0];
-
-                        date = new Date(date);
-                        return date;
+                        title = performer.name;
                     }
 
-                    return;
-                }
+                    function getPrice(lowest, highest) {
+                        var price = "";
 
-                function getYear(date) {
-                    if(date) {
-                        var year = date.getFullYear();
-                        return year;
+                        if(lowest && highest) {
+                            price = "$" + lowest + "+";
+                        }
+
+                        return price;
                     }
 
-                    return;
-                }
-
-                function getMonth(date) {
-                    if(date) {
-                        var month = months[parseInt(date.getMonth())];
-                        return month;
+                    var eventDate = moment(item.datetime_local);
+                    if (!eventDate.isValid()) {
+                        return Spice.failed('seat_geek_sports');
                     }
 
-                    return;
-                }
-
-                function getDay(date) {
-                    if(date) {
-                        var day = date.getDate();
-                        return day;
-                    }
-
-                    return;
-                }
-
-                function getPrice(lowest, highest) {
-                    var price = "";
-
-                    if(lowest && highest) {
-                        price = "$" + lowest + "+";
-                    }
-
-                    return price;
-                }
-
-                return {
-                    url: item.url,
-                    price: getPrice(item.stats.lowest_price, item.stats.highest_price),
-                    title: title,
-                    place: item.venue.name,
-                    city: item.venue.display_location,
-                    year: getYear(getDate(item.datetime_local)),
-                    dateBadge: {
-                        day: getDay(getDate(item.datetime_local)),
-                        month: getMonth(getDate(item.datetime_local))
-                    }
-                };
-            },
-            templates: {
-                group: 'text',
-                detail: false,
-                item_detail: false,
-                options: {
-                    footer: Spice.seat_geek_sports.footer,
-                    moreAt: true,
-                    rating: false
+                    return {
+                        url: item.url,
+                        price: getPrice(item.stats.lowest_price, item.stats.highest_price),
+                        title: title,
+                        place: item.venue.name,
+                        city: item.venue.display_location,
+                        year: eventDate.year(),
+                        dateBadge: {
+                            day: eventDate.date(),
+                            month: eventDate.format("MMM")
+                        }
+                    };
                 },
-                variants: {
-                    tileTitle: '3line-small',
-                    tileFooter: '4line'
+                templates: {
+                    group: 'text',
+                    detail: false,
+                    item_detail: false,
+                    options: {
+                        footer: Spice.seat_geek_sports.footer,
+                        moreAt: true,
+                        rating: false
+                    },
+                    variants: {
+                        tileTitle: '3line-small',
+                        tileFooter: '4line'
+                    }
                 }
-            }
-        });
+            });
+        });        
     };
 }(this));

--- a/share/spice/seat_geek/sports/seat_geek_sports.js
+++ b/share/spice/seat_geek/sports/seat_geek_sports.js
@@ -84,7 +84,7 @@
                         year: eventDate.year(),
                         dateBadge: {
                             day: eventDate.date(),
-                            month: eventDate.format("MMM")
+                            month: eventDate.format("MMM").toUpperCase()
                         }
                     };
                 },


### PR DESCRIPTION
SeatGeek Sports Tickets: Use moment.js

Re: #1554

#### Changes
* Wrapped `Spice.add(...)` with moment.js `DDG.require(...)`
* Replaced use of `Date` with `moment`
* Removed redundant methods/variables
  * `getDate()`
  * `getYear()`
  * `getMonth()`
  * `getDay()`
  * `months[]`
* Letters of the month are now uppercase to be consistent with the other SeatGeek IAs

**Note:** The majority of changes in the diff are a result of adding the `require()` block which pushed everything down one line and indented it. The core changes occur at lines 73-89.
#### Testing
##### Before
![seat-geek-sports-before](https://cloud.githubusercontent.com/assets/16732873/12766270/cf1c8bc8-c9fa-11e5-8981-d35064dafdd8.png)

##### After
![seat-geek-sports-after](https://cloud.githubusercontent.com/assets/16732873/12796537/3630167e-cab7-11e5-9e86-80006bc97084.png)


---
IA Page: https://duck.co/ia/view/seat_geek_sports