### PR TITLE
InTheaters: fixed tomato icon size in retina displays

### DIFF
--- a/share/spice/in_theaters/in_theaters.css
+++ b/share/spice/in_theaters/in_theaters.css
@@ -2,6 +2,7 @@
     padding: 4px;
     position: relative;
     top: 10px;
+    max-width: 26px;
 }
 
 .zci--in_theaters .c-detail__title {


### PR DESCRIPTION
Fixes #2469

A larger image is being served to retina displays, but the CSS needed to have a maximum width property for it to show at the correct size. I've set it to the same size as that of the images served to non-retina displays.

---
IA Page: https://duck.co/ia/view/in_theaters