### PR TITLE
SeatGeek Events (City): Use moment.js

### DIFF
--- a/share/spice/seat_geek/events_by_city/seat_geek_events_by_city.js
+++ b/share/spice/seat_geek/events_by_city/seat_geek_events_by_city.js
@@ -8,168 +8,140 @@
 
         var script = $('[src*="/js/spice/seat_geek/events_by_city/"]')[0],
             source = $(script).attr("src"),
-            citySlug = source.match(/events_by_city\/([^\/]*)/)[1],
-            months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
-            days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+            citySlug = source.match(/events_by_city\/([^\/]*)/)[1];
 
-        Spice.add({
-            id: "seat_geek_events_by_city",
-            name: "Tickets",
-            data: api_result.events,
-            meta: {
-                sourceName: "SeatGeek",
-                sourceUrl: "https://seatgeek.com/search?search=concerts+" + citySlug.replace(/-/g, "+"),
-                sourceIconUrl: "https://seatgeek.com/favicon.ico",
-                primaryText: "Upcoming Concerts in " + DDG.capitalize(citySlug.replace(/-/g,' '))
-            },
-            normalize: function(item) {
-                var artistName = item.performers[0].short_name,
-                    artistDisplayName = capitalizedAcronym(artistName),
-                    performersWithGenres;
-
-                // sometimes we get false positives from the SeatGeek API
-                // where for example sports games get displayed instead of concerts
-                //
-                // filtering out events whose performers don't have genres
-                // seems to be a way to guard against that
-                performersWithGenres = $.grep(item.performers, function (performer) {
-                  return !!performer.genres;
-                });
-
-                if (performersWithGenres.length === 0) {
-                  return null;
-                }
-
-                // Capitalize the name of the band/artist searched for;
-                // if the name is composed by multiple words, capitalize
-                // all of them; if the name is too long, return the acronym
-
-                function capitalizedAcronym(string) {
-                    var splitted = string.split(" "),
-                        i,
-                        acronym,
-                        upper;
-
-                    if(string.length < 18) {
-                        for(i = 0; i < splitted.length; i++) {
-                            splitted[i] = DDG.capitalize(splitted[i]);
-                        }
-
-                        return splitted.join(" ");
-                    } else {
-                        acronym = '';
-                        for(i = 0; i < splitted.length; i++) {
-                            upper = splitted[i].substr(0, 1).toUpperCase() + '.';
-                            acronym += upper;
-                        }
-
-                        return acronym;
-                    }
-                }
-
-                function getDate(date) {
-                    if(date) {
-                        // IE 8 and Safari don't support the yyyy-mm-dd date format,
-                        // but they support mm/dd/yyyy
-                        date = date.replace(/T.*/, '');
-                        var remix_date = date.split("-");
-                        date = remix_date[1] + "/" + remix_date[2] + "/" + remix_date[0];
-
-                        date = new Date(date);
-                        return date;
-                    }
-
-                    return;
-                }
-
-                function getMonth(date) {
-                    if(date) {
-                        var month = months[parseInt(date.getMonth())];
-                        return month.toUpperCase();
-                    }
-
-                    return;
-                }
-
-                function getDay(date) {
-                    if(date) {
-                        var day = date.getDate();
-                        return day;
-                    }
-
-                    return;
-                }
-
-                // Get number of performers, excluding
-                // the one searched for
-
-                function getNumPerformers(performers) {
-                    var how_many = 0,
-                        slug = artistName.toLowerCase().replace(/\s/g, "-"),
-                        i;
-
-                    for(i = 0; i < performers.length; i++) {
-                        if(performers[i].slug !== slug) {
-                            how_many++;
-                        }
-                    }
-
-                    if(how_many > 1) {
-                        return how_many;
-                    }
-
-                    return 0;
-                }
-
-                function getPrice(lowest, highest) {
-                    var price = "";
-
-                    if(lowest && highest) {
-                        price = "$" + lowest + "+";
-                    }
-
-                    return price;
-                }
-                
-                function getSubtitle(performers) {
-                    var num = getNumPerformers(performers),
-                        str = ' ';
-
-                    if (num > 0) {
-                        str = artistDisplayName + ' and '+ num + ' others';
-                    }
-                    return str;
-                }
-
-                return {
-                    url: item.url,
-                    price: getPrice(item.stats.lowest_price, item.stats.highest_price),
-                    artist: artistDisplayName,
-                    subtitle: getSubtitle(item.performers),
-                    title: item.short_title,
-                    place: item.venue.name,
-                    img: item.performers[0].images.small,
-                    city: item.venue.display_location,
-                    dateBadge: {
-                        month: getMonth(getDate(item.datetime_local)),
-                        day: getDay(getDate(item.datetime_local))
-                    }
-                };
-            },
-            templates: {
-                group: 'text',
-                detail: false,
-                item_detail: false,
-                options: {
-                    moreAt: true,
-                    rating: false,
-                    footer: Spice.seat_geek_events_by_city.footer
+        DDG.require('moment.js', function() {        
+            Spice.add({
+                id: "seat_geek_events_by_city",
+                name: "Tickets",
+                data: api_result.events,
+                meta: {
+                    sourceName: "SeatGeek",
+                    sourceUrl: "https://seatgeek.com/search?search=concerts+" + citySlug.replace(/-/g, "+"),
+                    sourceIconUrl: "https://seatgeek.com/favicon.ico",
+                    primaryText: "Upcoming Concerts in " + DDG.capitalize(citySlug.replace(/-/g,' '))
                 },
-                variants: {
-                    tileTitle: '3line-small',
-                    tileFooter: '4line'
+                normalize: function(item) {
+                    var artistName = item.performers[0].short_name,
+                        artistDisplayName = capitalizedAcronym(artistName),
+                        performersWithGenres;
+
+                    // sometimes we get false positives from the SeatGeek API
+                    // where for example sports games get displayed instead of concerts
+                    //
+                    // filtering out events whose performers don't have genres
+                    // seems to be a way to guard against that
+                    performersWithGenres = $.grep(item.performers, function (performer) {
+                      return !!performer.genres;
+                    });
+
+                    if (performersWithGenres.length === 0) {
+                      return null;
+                    }
+
+                    // Capitalize the name of the band/artist searched for;
+                    // if the name is composed by multiple words, capitalize
+                    // all of them; if the name is too long, return the acronym
+
+                    function capitalizedAcronym(string) {
+                        var splitted = string.split(" "),
+                            i,
+                            acronym,
+                            upper;
+
+                        if(string.length < 18) {
+                            for(i = 0; i < splitted.length; i++) {
+                                splitted[i] = DDG.capitalize(splitted[i]);
+                            }
+
+                            return splitted.join(" ");
+                        } else {
+                            acronym = '';
+                            for(i = 0; i < splitted.length; i++) {
+                                upper = splitted[i].substr(0, 1).toUpperCase() + '.';
+                                acronym += upper;
+                            }
+
+                            return acronym;
+                        }
+                    }
+
+                    // Get number of performers, excluding
+                    // the one searched for
+
+                    function getNumPerformers(performers) {
+                        var how_many = 0,
+                            slug = artistName.toLowerCase().replace(/\s/g, "-"),
+                            i;
+
+                        for(i = 0; i < performers.length; i++) {
+                            if(performers[i].slug !== slug) {
+                                how_many++;
+                            }
+                        }
+
+                        if(how_many > 1) {
+                            return how_many;
+                        }
+
+                        return 0;
+                    }
+
+                    function getPrice(lowest, highest) {
+                        var price = "";
+
+                        if(lowest && highest) {
+                            price = "$" + lowest + "+";
+                        }
+
+                        return price;
+                    }
+
+                    function getSubtitle(performers) {
+                        var num = getNumPerformers(performers),
+                            str = ' ';
+
+                        if (num > 0) {
+                            str = artistDisplayName + ' and '+ num + ' others';
+                        }
+                        return str;
+                    }
+                    
+                    var eventDate = moment(item.datetime_local);
+                    if (!eventDate.isValid()) {
+                        return Spice.failed('seat_geek_events_by_city');
+                    }
+
+                    return {
+                        url: item.url,
+                        price: getPrice(item.stats.lowest_price, item.stats.highest_price),
+                        artist: artistDisplayName,
+                        subtitle: getSubtitle(item.performers),
+                        title: item.short_title,
+                        place: item.venue.name,
+                        img: item.performers[0].images.small,
+                        city: item.venue.display_location,
+                        dateBadge: {
+                            month: eventDate.format("MMM").toUpperCase(),
+                            day: eventDate.date()
+                        }
+                    };
+                },
+                templates: {
+                    group: 'text',
+                    detail: false,
+                    item_detail: false,
+                    options: {
+                        moreAt: true,
+                        rating: false,
+                        footer: Spice.seat_geek_events_by_city.footer
+                    },
+                    variants: {
+                        tileTitle: '3line-small',
+                        tileFooter: '4line'
+                    }
                 }
-            }
+            });
         });
     };
 }(this));


### PR DESCRIPTION
SeatGeek Events (City): Use moment.js

Re: #1554

#### Changes
* Wrapped `Spice.add(...)` with moment.js `DDG.require(...)`
* Replaced use of `Date` with `moment`
* Removed redundant methods/variables
  * `getDate()`
  * `getMonth()`
  * `getDay()`
  * `months[]`
  * `days[]`

**Note:** The majority of changes in the diff are a result of adding the `require()` block which pushed everything down one line and indented it. The core changes occur at lines 110-128.
#### Testing
##### Before
![seat-geek-events-by-city-before](https://cloud.githubusercontent.com/assets/16732873/12828502/27b74d08-cb7d-11e5-9890-f3777cb30722.png)

##### After
![seat-geek-events-by-city-after](https://cloud.githubusercontent.com/assets/16732873/12828503/2a5f954c-cb7d-11e5-93f9-3bc10cf4a9e2.png)

---
IA Page: https://duck.co/ia/view/seat_geek_events_by_city