### PR TITLE
Location Sunrise/Sunset: Only trigger when a location is specified

### DIFF
--- a/lib/DDG/Spice/SunRiseSet.pm
+++ b/lib/DDG/Spice/SunRiseSet.pm
@@ -28,15 +28,12 @@ my $capitals = LoadFile(share('capitals.yml'));
 handle remainder_lc => sub {
     my $q = $_;
 
-    if ($q ne '') {
-        $q =~ s/\b(what|is|today|time|in|at)+\b//g;
-        $q =~ s/(\,\s)+/ /g;
-        $q = trim $q;
-        $q = ($q eq '') ? lc $loc->city : $q;
-    } else {
-        $q = lc $loc->city;
-    }
-
+    $q =~ s/\b(what|is|today|time|in|at)+\b//g;
+    $q =~ s/(\,\s)+/ /g;
+    $q = trim $q;
+    
+    return unless $q;
+    
     if (my $caps = $capitals->{$q}) {
         # These are internally sorted by population,
         # so assume they want the big one for now.

--- a/t/SunRiseSet.t
+++ b/t/SunRiseSet.t
@@ -15,12 +15,6 @@ my @oslo_norway = (
     caller    => 'DDG::Spice::SunRiseSet'
 );
 
-my @new_delhi_india = (
-    '/js/spice/sun_rise_set/new%20delhi%20india',
-    call_type => 'include',
-    caller    => 'DDG::Spice::SunRiseSet'
-);
-
 ddg_spice_test(
     [qw( DDG::Spice::SunRiseSet)],
     'sunset oslo'                       => test_spice(@oslo_norway),
@@ -41,77 +35,18 @@ ddg_spice_test(
     'when will sun rise in oslo'        => test_spice(@oslo_norway),
     'when will sun set in oslo'         => test_spice(@oslo_norway),
     
-    # undef because only sunset/sunrise without location returns phoenixville
+    # This IA should only trigger when a location is specified
     'sunrise'                           => undef,
     'what time is sunset'               => undef,
+    'when is the sunrise'               => undef,
+    'when does sun set'                 => undef,
+    'when will the sun rise'            => undef,
 
-    # invalid cases
+    # Invalid cases
     'sunset at'                         => undef,
     'time and space museum'             => undef,
     'time complexity of qsort'          => undef,
     'running time of titanic'           => undef,
-    
-    # location-aware tests   
-    DDG::Request->new(
-        query_raw => "when is the sunrise",
-        location => test_location("in")
-    ) => test_spice(@new_delhi_india),
-    
-    DDG::Request->new(
-        query_raw => "when is the sunset",
-        location => test_location("in")
-    ) => test_spice(@new_delhi_india),
-        
-    DDG::Request->new(
-        query_raw => "when is sunrise",
-        location => test_location("in")
-    ) => test_spice(@new_delhi_india),
-    
-    DDG::Request->new(
-        query_raw => "when is sunset",
-        location => test_location("in")
-    ) => test_spice(@new_delhi_india),
-    
-    DDG::Request->new(
-        query_raw => "when does the sun rise",
-        location => test_location("in")
-    ) => test_spice(@new_delhi_india),
-    
-    DDG::Request->new(
-        query_raw => "when does the sun set",
-        location => test_location("in")
-    ) => test_spice(@new_delhi_india),
-    
-    DDG::Request->new(
-        query_raw => "when does sun rise",
-        location => test_location("in")
-    ) => test_spice(@new_delhi_india),
-    
-    DDG::Request->new(
-        query_raw => "when does sun set",
-        location => test_location("in")
-    ) => test_spice(@new_delhi_india),
-    
-    DDG::Request->new(
-        query_raw => "when will the sun rise",
-        location => test_location("in")
-    ) => test_spice(@new_delhi_india),
-    
-    DDG::Request->new(
-        query_raw => "when will the sun set",
-        location => test_location("in")
-    ) => test_spice(@new_delhi_india),
-    
-    DDG::Request->new(
-        query_raw => "when will sun rise",
-        location => test_location("in")
-    ) => test_spice(@new_delhi_india),
-    
-    DDG::Request->new(
-        query_raw => "when will sun set",
-        location => test_location("in")
-    ) => test_spice(@new_delhi_india),
 );
 
 done_testing;
-


### PR DESCRIPTION
Fixes #2426

* `$loc` is no longer used when a location is not specified
* Removed location aware tests

---
IA Page: https://duck.co/ia/view/sun_rise_set