### PR TITLE
Cryptocurrency conversion: Fixes #2453

### DIFF
--- a/lib/DDG/Spice/Cryptocurrency.pm
+++ b/lib/DDG/Spice/Cryptocurrency.pm
@@ -66,7 +66,7 @@ my @topCurrencies = (
 #Define regexes
 my $currency_qr = join('|', @currTriggers);
 my $question_prefix = qr/(?:convert|what (?:is|are|does)|how (?:much|many) (?:is|are))?\s?/;
-my $rate_qr = qr/\s(?:rate|exchange|exchange rate|conversion)/i;
+my $rate_qr = qr/\s(?:rate|exchange|exchange rate|conversion|price)/i;
 my $into_qr = qr/\s(?:en|in|to|in ?to|to|from)\s/i;
 my $vs_qr = qr/\sv(?:ersu|)s\.?\s/i;
 my $number_re = number_style_regex();


### PR DESCRIPTION
For issue #2453 . Query now matches on the word 'price'.
![issue2453](https://cloud.githubusercontent.com/assets/7718370/12906199/f71249be-ceab-11e5-89b1-930ee6f3af75.PNG)

The following queries will now trigger:
`'20 ltc price'`
`'dogecoin price'`