### PR TITLE
Couprex: reduce height to 19.5em, remove top-padding from body

### DIFF
--- a/share/spice/couprex/couprex.css
+++ b/share/spice/couprex/couprex.css
@@ -1,6 +1,6 @@
 .zci--couprex .tile--c--n {
     width: 14em;
-    height: 21em;
+    height: 19.5em;
 }
 
 .zci--couprex .tile__media {
@@ -18,7 +18,6 @@
 .zci--couprex .tile--c--n .tile__body {
     margin: 1.5em;
     padding: 0;
-    padding-top: 1.5em;
 }
 
 .zci--couprex .tile--c--n .tile__title {


### PR DESCRIPTION
Result:

![electronics_coupons_at_duckduckgo](https://cloud.githubusercontent.com/assets/873785/12930805/6e589c48-cf48-11e5-9d9f-2f7d0ef2c5b6.png)

-----
IA Page: https://duck.co/ia/view/couprex_coupons