### PR TITLE
Pwned: reduce snippet size to 140 chars, currently overflowing tile

### DIFF
--- a/share/spice/pwned/pwned.js
+++ b/share/spice/pwned/pwned.js
@@ -19,7 +19,7 @@
                     sourceName: "Have I Been Pwned",
                     sourceUrl: url,
                     primaryText: email + " is compromised:",
-                    snippetChars: 170
+                    snippetChars: 140
                 },
                 normalize: function(item) {
 


### PR DESCRIPTION
I noticed today that the content in the snippet was overflowing and being hidden. This reduces the length of the snippet so you see the ellipses at the end, indicating it's been truncated.

---
IA Page: https://duck.co/ia/view/pwned