### PR TITLE
Hotfix: Forecast: Event handlers aren't attached

### DIFF
--- a/share/spice/forecast/forecast.js
+++ b/share/spice/forecast/forecast.js
@@ -244,7 +244,6 @@
               detail_mobile: Spice.forecast.forecast_detail_mobile
           }
       });
-    });
 
     //convert temperature to specified unit
     var convertTemp = function(unit, d){
@@ -350,6 +349,7 @@
         // update the setting so we remember this choice going forward:
         DDG.settings.set('kaj', uom === 'C' ? 'm' : 'u', { saveToCloud: true });
     });
+  });
   };
 
 }(this));


### PR DESCRIPTION
With the addition of moment.js in https://github.com/duckduckgo/zeroclickinfo-spice/pull/2432, the event handler for switching between C and F isn't being attached to the DOM element, because that element won't exist until moment.js is loaded.