### PR TITLE
DogoNews: Stops footer from breaking on smaller screens

### DIFF
--- a/share/spice/dogo_news/dogo_news.js
+++ b/share/spice/dogo_news/dogo_news.js
@@ -30,7 +30,7 @@
                     var thumb = item.hi_res_thumb || item.thumb;
                     return {
                         title: item.name,
-                        source: Handlebars.helpers.ellipsis(getFirstNameLastInitial(item.author), 15),
+                        source: Handlebars.helpers.ellipsis(getFirstNameLastInitial(item.author), 10),
                         url: item.url,
                         excerpt: item.summary,
                         description: item.summary,


### PR DESCRIPTION
"**Fixes #2528.** This commit reduces the number of character in author's name to 10 so that it doesn't look broken on smaller screens."

IA Page: https://duck.co/ia/view/dogo_news