### PR TITLE
New Public Holidays Spice

### DIFF
--- a/lib/DDG/Spice/PublicHolidays.pm
+++ b/lib/DDG/Spice/PublicHolidays.pm
@@ -5,7 +5,6 @@ package DDG::Spice::PublicHolidays;
 use strict;
 use DDG::Spice;
 use Locale::Country;
-use Text::Trim;
 
 spice is_cached => 1;
 spice proxy_cache_valid => "200 30d";

--- a/lib/DDG/Spice/PublicHolidays.pm
+++ b/lib/DDG/Spice/PublicHolidays.pm
@@ -11,7 +11,7 @@ spice proxy_cache_valid => "200 30d";
 spice wrap_jsonp_callback => 0;
 
 spice from => "(.+)/(.+)";
-spice to => 'https://api.xmltime.com/holidays?accesskey={{ENV{DDG_SPICE_TIME_AND_DATE_ACCESSKEY}}}&secretkey={{ENV{DDG_SPICE_TIME_AND_DATE_SECRETKEY}}}&version=2&callback={{callback}}&types=federal&country=$1&year=$2';
+spice to => 'https://api.xmltime.com/holidays?accesskey={{ENV{DDG_SPICE_TIME_AND_DATE_ACCESSKEY}}}&secretkey={{ENV{DDG_SPICE_TIME_AND_DATE_SECRETKEY}}}&version=2&callback={{callback}}&types=federal%2Cfederallocal&country=$1&year=$2';
 
 my @triggers  = ('public holidays', 'national holidays', 'bank holidays', 'federal holidays');
 my $triggers  = join('|', @triggers);

--- a/lib/DDG/Spice/PublicHolidays.pm
+++ b/lib/DDG/Spice/PublicHolidays.pm
@@ -1,0 +1,121 @@
+package DDG::Spice::PublicHolidays;
+
+# ABSTRACT: Provides the list of public holidays in a calendar year for a country. 
+
+use strict;
+use DDG::Spice;
+use Locale::Country;
+
+spice is_cached => 1;
+spice proxy_cache_valid => "200 30d";
+spice wrap_jsonp_callback => 0;
+
+spice from => "(.+)/(.+)";
+spice to => 'https://api.xmltime.com/holidays?accesskey={{ENV{DDG_SPICE_TIME_AND_DATE_ACCESSKEY}}}&secretkey={{ENV{DDG_SPICE_TIME_AND_DATE_SECRETKEY}}}&version=2&callback={{callback}}&types=federal&country=$1&year=$2';
+
+my @triggers  = ('public holidays', 'national holidays', 'bank holidays', 'federal holidays');
+my $triggers  = join('|', @triggers);
+my $countries = join('|', share("countries.txt")->slurp(chomp => 1));
+
+triggers any => @triggers;
+    
+handle query_lc => sub {
+    my $query = $_;
+    
+    # Current year and users location are the defaults unless otherwise specified by the query
+    my $defaultYear = (localtime(time))[5] + 1900;
+    my $defaultCountry = $loc->country_name;
+    
+    # Regexes to match components of queries relevant to this IA
+    my $holidays = qr/$triggers/;
+    my $country  = qr/$countries/;
+    my $year     = qr/[1-9]{1}[0-9]{3}/;
+    
+    # Regexes to ignore optional words that can precede the year or country name
+    my $in       = qr/(?:in )?/;
+    my $inThe    = qr/(?:in the |in )?/;
+    
+    my $chosenYear;
+    my $chosenCountry;
+    
+    # Match: <trigger>
+    if ( $query =~ /^$holidays$/ ) {
+        $chosenYear = $defaultYear;
+        $chosenCountry = $defaultCountry;
+    }
+    
+    # Match: <trigger> <country>
+    elsif ( $query =~ /^$holidays $inThe($country)$/ ) {
+        $chosenYear = $defaultYear;
+        $chosenCountry = $1;
+    }
+    
+    # Match: <trigger> <year>
+    elsif ( $query =~ /^$holidays $in($year)$/ ) {
+        $chosenYear = $1;
+        $chosenCountry = $defaultCountry;
+    }
+    
+    # Match: <country> <trigger>
+    elsif ( $query =~ /^($country) $holidays$/ ) {
+        $chosenYear = $defaultYear;
+        $chosenCountry = $1;
+    }
+    
+    # Match: <year> <trigger>
+    elsif ( $query =~ /^($year) $holidays$/ ) {
+        $chosenYear = $1;
+        $chosenCountry = $defaultCountry;
+    }
+    
+    # Match: <trigger> <country> <year>
+    elsif ( $query =~ /^$holidays $inThe($country) $in($year)$/ ) {
+        $chosenYear = $2;
+        $chosenCountry = $1;
+    }
+    
+    # Match: <trigger> <year> <country>
+    elsif ( $query =~ /^$holidays $in($year) $inThe($country)$/ ) {
+        $chosenYear = $1;
+        $chosenCountry = $2;
+    }
+    
+    # Match: <country> <trigger> <year>
+    elsif ( $query =~ /^($country) $holidays $in($year)$/ ) {
+        $chosenYear = $2;
+        $chosenCountry = $1;
+    }
+    
+    # Match: <country> <year> <trigger>
+    elsif ( $query =~ /^($country) ($year) $holidays$/ ) {
+        $chosenYear = $2;
+        $chosenCountry = $1;
+    }
+    
+    # Match: <year> <trigger> <country>
+    elsif ( $query =~ /^($year) $holidays $inThe($country)$/ ) {
+        $chosenYear = $1;
+        $chosenCountry = $2;
+    }
+    
+    # Match: <year> <country> <trigger>
+    elsif ( $query =~ /^($year) ($country) $holidays$/ ) {
+        $chosenYear = $1;
+        $chosenCountry = $2;
+    }
+    
+    # No matches
+    else {
+        return; 
+    }
+    
+    # These are the min/max years available from the API (Feb 2016, API version 2)
+    return unless($chosenYear >= 1600 && $chosenYear <= 2400);
+    
+    my $chosenCountryCode = country2code($chosenCountry);
+    return unless($chosenCountryCode);    
+    
+    return $chosenCountryCode, $chosenYear, code2country($chosenCountryCode);
+};
+
+1;

--- a/lib/DDG/Spice/PublicHolidays.pm
+++ b/lib/DDG/Spice/PublicHolidays.pm
@@ -10,7 +10,7 @@ spice is_cached => 1;
 spice proxy_cache_valid => "200 30d";
 spice wrap_jsonp_callback => 0;
 
-spice from => "(.+)/(.+)";
+spice from => "(.+)\/(.+)\/.+";
 spice to => 'https://api.xmltime.com/holidays?accesskey={{ENV{DDG_SPICE_TIME_AND_DATE_ACCESSKEY}}}&secretkey={{ENV{DDG_SPICE_TIME_AND_DATE_SECRETKEY}}}&version=2&callback={{callback}}&types=federal%2Cfederallocal&country=$1&year=$2';
 
 my @triggers  = ('public holidays', 'national holidays', 'bank holidays', 'federal holidays');
@@ -41,27 +41,27 @@ handle query_lc => sub {
     $query =~ s/$triggers//;
     
     $query =~ s/$in(?<year>$year)//;
-    if ( $+{year} ) {
+    if ($+{year}) {
         $chosenYear = $+{year};
     } else {
         $chosenYear = $defaultYear;
     }
     
     $query =~ s/$inThe(?<country>$country)//;
-    if ( $+{country} ) {
+    if ($+{country}) {
         $chosenCountry = $+{country};
     } else {
         $chosenCountry = $defaultCountry;
     }
    
-    # Nothing should be left in the query by now, if there is bailout   
-    return unless($query =~ /^\s*$/);
+    # If there's anything left in the query we can't be sure its relevant
+    return unless ($query =~ /^\s*$/);
     
     # These are the min/max years available from the API (as of Feb 2016, API version 2)
-    return unless($chosenYear >= 1600 && $chosenYear <= 2400);
+    return unless ($chosenYear >= 1600 && $chosenYear <= 2400);
     
     my $chosenCountryCode = country2code($chosenCountry);
-    return unless($chosenCountryCode);    
+    return unless ($chosenCountryCode);    
     
     return $chosenCountryCode, $chosenYear, code2country($chosenCountryCode);
 };

--- a/lib/DDG/Spice/PublicHolidays.pm
+++ b/lib/DDG/Spice/PublicHolidays.pm
@@ -5,6 +5,7 @@ package DDG::Spice::PublicHolidays;
 use strict;
 use DDG::Spice;
 use Locale::Country;
+use Text::Trim;
 
 spice is_cached => 1;
 spice proxy_cache_valid => "200 30d";
@@ -38,78 +39,26 @@ handle query_lc => sub {
     my $chosenYear;
     my $chosenCountry;
     
-    # Match: <trigger>
-    if ( $query =~ /^$holidays$/ ) {
+    $query =~ s/$triggers//;
+    
+    $query =~ s/$in(?<year>$year)//;
+    if ( $+{year} ) {
+        $chosenYear = $+{year};
+    } else {
         $chosenYear = $defaultYear;
+    }
+    
+    $query =~ s/$inThe(?<country>$country)//;
+    if ( $+{country} ) {
+        $chosenCountry = $+{country};
+    } else {
         $chosenCountry = $defaultCountry;
     }
+   
+    # Nothing should be left in the query by now, if there is bailout   
+    return unless($query =~ /^\s*$/);
     
-    # Match: <trigger> <country>
-    elsif ( $query =~ /^$holidays $inThe($country)$/ ) {
-        $chosenYear = $defaultYear;
-        $chosenCountry = $1;
-    }
-    
-    # Match: <trigger> <year>
-    elsif ( $query =~ /^$holidays $in($year)$/ ) {
-        $chosenYear = $1;
-        $chosenCountry = $defaultCountry;
-    }
-    
-    # Match: <country> <trigger>
-    elsif ( $query =~ /^($country) $holidays$/ ) {
-        $chosenYear = $defaultYear;
-        $chosenCountry = $1;
-    }
-    
-    # Match: <year> <trigger>
-    elsif ( $query =~ /^($year) $holidays$/ ) {
-        $chosenYear = $1;
-        $chosenCountry = $defaultCountry;
-    }
-    
-    # Match: <trigger> <country> <year>
-    elsif ( $query =~ /^$holidays $inThe($country) $in($year)$/ ) {
-        $chosenYear = $2;
-        $chosenCountry = $1;
-    }
-    
-    # Match: <trigger> <year> <country>
-    elsif ( $query =~ /^$holidays $in($year) $inThe($country)$/ ) {
-        $chosenYear = $1;
-        $chosenCountry = $2;
-    }
-    
-    # Match: <country> <trigger> <year>
-    elsif ( $query =~ /^($country) $holidays $in($year)$/ ) {
-        $chosenYear = $2;
-        $chosenCountry = $1;
-    }
-    
-    # Match: <country> <year> <trigger>
-    elsif ( $query =~ /^($country) ($year) $holidays$/ ) {
-        $chosenYear = $2;
-        $chosenCountry = $1;
-    }
-    
-    # Match: <year> <trigger> <country>
-    elsif ( $query =~ /^($year) $holidays $inThe($country)$/ ) {
-        $chosenYear = $1;
-        $chosenCountry = $2;
-    }
-    
-    # Match: <year> <country> <trigger>
-    elsif ( $query =~ /^($year) ($country) $holidays$/ ) {
-        $chosenYear = $1;
-        $chosenCountry = $2;
-    }
-    
-    # No matches
-    else {
-        return; 
-    }
-    
-    # These are the min/max years available from the API (Feb 2016, API version 2)
+    # These are the min/max years available from the API (as of Feb 2016, API version 2)
     return unless($chosenYear >= 1600 && $chosenYear <= 2400);
     
     my $chosenCountryCode = country2code($chosenCountry);

--- a/share/spice/public_holidays/countries.txt
+++ b/share/spice/public_holidays/countries.txt
@@ -179,6 +179,7 @@ qatar
 reunion
 romania
 russian federation
+russia
 rwanda
 saint barthelemy
 saint helena

--- a/share/spice/public_holidays/countries.txt
+++ b/share/spice/public_holidays/countries.txt
@@ -1,0 +1,251 @@
+afghanistan
+aland islands
+albania
+algeria
+american samoa
+andorra
+angola
+anguilla
+antarctica
+antigua and barbuda
+argentina
+armenia
+aruba
+australia
+austria
+azerbaijan
+bahamas
+bahrain
+bangladesh
+barbados
+belarus
+belgium
+belize
+benin
+bermuda
+bhutan
+bolivia
+bonaire
+bosnia and herzegovina
+botswana
+bouvet island
+brazil
+british indian ocean territory
+brunei
+brunei darussalam
+bulgaria
+burkina faso
+burundi
+cambodia
+cameroon
+canada
+cape verde
+cayman islands
+central african republic
+chad
+chile
+china
+christmas island
+cocos islands
+colombia
+comoros
+congo
+cook islands
+costa rica
+cote d'ivoire
+croatia
+cuba
+curacao
+cyprus
+czech republic
+denmark
+djibouti
+dominica
+dominican republic
+ecuador
+egypt
+el salvador
+equatorial guinea
+eritrea
+estonia
+ethiopia
+falkland islands
+faroe islands
+fiji
+finland
+france
+french guiana
+french polynesia
+french southern territories
+gabon
+gambia
+georgia
+germany
+ghana
+gibraltar
+greece
+greenland
+grenada
+guadeloupe
+guam
+guatemala
+guernsey
+guinea
+guinea-bissau
+guyana
+haiti
+holy see
+honduras
+hong kong
+hungary
+iceland
+india
+indonesia
+iran
+iraq
+ireland
+isle of man
+israel
+italy
+jamaica
+japan
+jersey
+jordan
+kazakhstan
+kenya
+kiribati
+kuwait
+kyrgyzstan
+laos
+latvia
+lebanon
+lesotho
+liberia
+libya
+liechtenstein
+lithuania
+luxembourg
+macao
+macedonia
+madagascar
+malawi
+malaysia
+maldives
+mali
+malta
+marshall islands
+martinique
+mauritania
+mauritius
+mayotte
+mexico
+micronesia
+moldova
+monaco
+mongolia
+montenegro
+montserrat
+morocco
+mozambique
+myanmar
+namibia
+nauru
+nepal
+netherlands
+new caledonia
+new zealand
+nicaragua
+niger
+nigeria
+niue
+norfolk island
+north korea
+northern mariana islands
+norway
+oman
+pakistan
+palau
+palestine
+panama
+papua new guinea
+paraguay
+peru
+philippines
+pitcairn
+poland
+portugal
+puerto rico
+qatar
+reunion
+romania
+russian federation
+rwanda
+saint barthelemy
+saint helena
+saint kitts and nevis
+saint lucia
+saint martin
+saint pierre and miquelon
+saint vincent and the grenadines
+samoa
+san marino
+sao tome and principe
+saudi arabia
+senegal
+serbia
+seychelles
+sierra leone
+singapore
+sint maarten
+slovakia
+slovenia
+solomon islands
+somalia
+south africa
+south georgia and the south sandwich islands
+south korea
+south sudan
+spain
+sri lanka
+sudan
+suriname
+svalbard and jan mayen
+swaziland
+sweden
+switzerland
+syria
+taiwan
+tajikistan
+tanzania
+thailand
+timor-leste
+togo
+tokelau
+tonga
+trinidad and tobago
+tunisia
+turkey
+turkmenistan
+turks and caicos islands
+tuvalu
+uganda
+ukraine
+united arab emirates
+uae
+united kingdom
+uk
+united states
+us
+usa
+united states minor outlying islands
+uruguay
+uzbekistan
+vanuatu
+venezuela
+vietnam
+virgin islands
+wallis and futuna
+western sahara
+yemen
+zambia
+zimbabwe

--- a/share/spice/public_holidays/public_holidays.js
+++ b/share/spice/public_holidays/public_holidays.js
@@ -1,0 +1,54 @@
+(function (env) {
+    "use strict";
+    env.ddg_spice_public_holidays = function(api_result) {
+
+        if ( !api_result || api_result.error || api_result.errors || !api_result.holidays || api_result.holidays.length === 0) {
+            return Spice.failed('public_holidays');
+        }
+
+        var script = $('[src*="/js/spice/public_holidays/"]')[0];
+        var source = $(script).attr("src");       
+        var year = decodeURIComponent(source.match(/public_holidays\/[a-z]{2}\/([0-9]{4})\/[^\/]+/)[1]);
+        var country = decodeURIComponent(source.match(/public_holidays\/[a-z]{2}\/[0-9]{4}\/([^\/]+)/)[1]);        
+        
+        if ( !year || !country ) {
+            return Spice.failed('public_holidays');                
+        }
+        
+        DDG.require('moment.js', function() {
+            Spice.add({
+                id: "public_holidays",            
+                name: "Answer",            
+                data: api_result,
+
+                meta: {
+                    sourceName: "timeanddate.com",
+                    sourceUrl: 'http://www.timeanddate.com/holidays/'
+                },
+
+                normalize: function(data) {                
+                    var result = {
+                        title: "Public Holidays " + year,
+                        subtitle: country,
+                        record_data: {}
+                    };
+
+                    $.each(data.holidays, function() {                        
+                        var label = moment(this.date.iso).format('ddd Do MMM');
+                        result.record_data[label] = this.name;                     
+                    });
+
+                    return result;
+                },
+
+                templates: {
+                    group: 'list',
+                    options: {
+                        content: 'record',
+                        moreAt: true
+                    }
+                }
+            });
+        });
+    };
+}(this));

--- a/share/spice/public_holidays/public_holidays.js
+++ b/share/spice/public_holidays/public_holidays.js
@@ -38,6 +38,9 @@
                 });
             });
             
+            // holiday.urlid is of the form "<country>/<holiday>"
+            var countryUrlId = api_result.holidays[0].urlid.match(/(.+)\/.*/)[1];            
+            
             Spice.add({
                 id: "public_holidays",            
                 name: "Answer",
@@ -45,7 +48,7 @@
 
                 meta: {
                     sourceName: "timeanddate.com",
-                    sourceUrl: 'http://www.timeanddate.com/holidays/'
+                    sourceUrl: 'http://www.timeanddate.com/holidays/' + countryUrlId + "/" + year
                 },
 
                 templates: {

--- a/share/spice/public_holidays/public_holidays.js
+++ b/share/spice/public_holidays/public_holidays.js
@@ -14,37 +14,44 @@
         if (!year || !country) {
             return Spice.failed('public_holidays');                
         }
-        
+
         DDG.require('moment.js', function() {
+            var data = {
+                title: "Public Holidays " + year, 
+                subtitle: country,
+                holidays: []
+            };
+            
+            $.each(api_result.holidays, function(index, holiday) {
+                // Some holidays only apply to certain provinces
+                var provinces = [];
+                if (holiday.states) {                    
+                    for (var i=0; i<holiday.states.length; ++i) {
+                        provinces.push(holiday.states[i].name);
+                    }
+                }
+                
+                data.holidays.push({
+                    name:  holiday.name,
+                    date:  moment(holiday.date.iso).format('ddd Do MMM'),
+                    notes: provinces.join(", ")
+                });
+            });
+            
             Spice.add({
                 id: "public_holidays",            
-                name: "Answer",            
-                data: api_result,
+                name: "Answer",
+                data: data,
 
                 meta: {
                     sourceName: "timeanddate.com",
                     sourceUrl: 'http://www.timeanddate.com/holidays/'
                 },
 
-                normalize: function(data) {                
-                    var result = {
-                        title: "Public Holidays " + year,
-                        subtitle: country,
-                        record_data: {}
-                    };
-
-                    $.each(data.holidays, function() {                        
-                        var label = moment(this.date.iso).format('ddd Do MMM');
-                        result.record_data[label] = this.name;                     
-                    });
-
-                    return result;
-                },
-
                 templates: {
                     group: 'list',
                     options: {
-                        content: 'record',
+                        content: DDH.public_holidays.record,
                         moreAt: true
                     }
                 }

--- a/share/spice/public_holidays/public_holidays.js
+++ b/share/spice/public_holidays/public_holidays.js
@@ -2,7 +2,7 @@
     "use strict";
     env.ddg_spice_public_holidays = function(api_result) {
 
-        if ( !api_result || api_result.error || api_result.errors || !api_result.holidays || api_result.holidays.length === 0) {
+        if (!api_result || api_result.error || api_result.errors || !api_result.holidays || api_result.holidays.length === 0) {
             return Spice.failed('public_holidays');
         }
 
@@ -11,7 +11,7 @@
         var year = decodeURIComponent(source.match(/public_holidays\/[a-z]{2}\/([0-9]{4})\/[^\/]+/)[1]);
         var country = decodeURIComponent(source.match(/public_holidays\/[a-z]{2}\/[0-9]{4}\/([^\/]+)/)[1]);        
         
-        if ( !year || !country ) {
+        if (!year || !country) {
             return Spice.failed('public_holidays');                
         }
         

--- a/share/spice/public_holidays/record.handlebars
+++ b/share/spice/public_holidays/record.handlebars
@@ -1,0 +1,11 @@
+<div class="record  {{#if meta.options.keySpacing}}record--keyspacing{{/if}}  {{#if meta.options.rowHighlight}}record--highlight{{/if}}">
+    <table class="record__body">
+        {{#each holidays}}
+            <tr class="record__row  {{#if ../meta.options.rowHighlight}}record__row--highlight{{/if}}">
+                <td class="record__cell  record__cell--key">{{date}}</td>                
+                <td class="record__cell  record__cell--key">{{name}}</td>                
+                <td class="record__cell  record__cell--key">{{notes}}</td>                
+            </tr>
+        {{/each}}
+    </table>
+</div>

--- a/t/PublicHolidays.t
+++ b/t/PublicHolidays.t
@@ -112,6 +112,7 @@ ddg_spice_test(
     'national park holidays'                => undef,    
     'riverbank holidays'                    => undef,
     'confederal holidays'                   => undef,
+    'public holidays are great'             => undef,
 );
 
 done_testing;

--- a/t/PublicHolidays.t
+++ b/t/PublicHolidays.t
@@ -1,0 +1,116 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Request;
+use DDG::Test::Spice;
+use DDG::Test::Location;
+
+spice is_cached => 1;
+
+my $currentYear = (localtime(time))[5] + 1900;
+
+my @germanyPresent = (
+    "/js/spice/public_holidays/de/$currentYear/Germany",
+    call_type => 'include',
+    caller    => 'DDG::Spice::PublicHolidays'
+);
+
+my @australia2018 = (
+    '/js/spice/public_holidays/au/2018/Australia',
+    call_type => 'include',
+    caller    => 'DDG::Spice::PublicHolidays'
+);
+
+my @uk2020 = (
+    '/js/spice/public_holidays/gb/2020/The%20United%20Kingdom',
+    call_type => 'include',
+    caller    => 'DDG::Spice::PublicHolidays'
+);
+
+my @japan2020 = (
+    '/js/spice/public_holidays/jp/2020/Japan',
+    call_type => 'include',
+    caller    => 'DDG::Spice::PublicHolidays'
+);
+
+ddg_spice_test(
+    [qw( DDG::Spice::PublicHolidays)],
+       
+    # Match: <trigger>
+    DDG::Request->new(
+        query_raw => "public holidays",
+        location => test_location("de")
+    ) => test_spice(@germanyPresent),
+    
+    # Match: <trigger> <year>
+    DDG::Request->new(
+        query_raw => "public holidays 2018",
+        location => test_location("au")
+    ) => test_spice(@australia2018),   
+    DDG::Request->new(
+        query_raw => "public holidays in 2018",
+        location => test_location("au")
+    ) => test_spice(@australia2018),    
+    
+    # Match: <year> <trigger>
+    DDG::Request->new(
+        query_raw => "2018 public holidays",
+        location => test_location("au")
+    ) => test_spice(@australia2018),
+    
+    # Match: <trigger> <country>
+    'public holidays germany'               => test_spice(@germanyPresent),
+    'public holidays in germany'            => test_spice(@germanyPresent),
+    
+    # Match: <country> <trigger>
+    'germany national holidays'             => test_spice(@germanyPresent),
+    'germany national holidays'             => test_spice(@germanyPresent),
+    
+    # Match: <trigger> <country> <year>
+    'public holidays uk 2020'               => test_spice(@uk2020),
+    'public holidays in the uk 2020'        => test_spice(@uk2020),
+    'public holidays in the uk in 2020'     => test_spice(@uk2020),
+    'public holidays japan 2020'            => test_spice(@japan2020),
+    'public holidays in japan 2020'         => test_spice(@japan2020),
+    'public holidays in japan in 2020'      => test_spice(@japan2020),
+    
+    # Match: <trigger> <year> <country>
+    'national holidays 2020 uk'             => test_spice(@uk2020),
+    'national holidays in 2020 uk'          => test_spice(@uk2020),
+    'national holidays in 2020 in the uk'   => test_spice(@uk2020),
+    'national holidays 2020 japan'          => test_spice(@japan2020),
+    'national holidays in 2020 japan'       => test_spice(@japan2020),
+    'national holidays in 2020 in japan'    => test_spice(@japan2020),
+    
+    # Match: <country> <trigger> <year>
+    'uk bank holidays 2020'                 => test_spice(@uk2020),
+    'uk bank holidays in 2020'              => test_spice(@uk2020),
+    'japan bank holidays 2020'              => test_spice(@japan2020),
+    'japan bank holidays in 2020'           => test_spice(@japan2020),
+    
+    # Match: <country> <year> <trigger>
+    'uk 2020 federal holidays'              => test_spice(@uk2020),
+    'japan 2020 federal holidays'           => test_spice(@japan2020),
+    
+    # Match: <year> <trigger> <country>
+    '2020 public holidays uk'               => test_spice(@uk2020),
+    '2020 public holidays in the uk'        => test_spice(@uk2020),
+    '2020 public holidays japan'            => test_spice(@japan2020),
+    '2020 public holidays in japan'         => test_spice(@japan2020),
+    
+    # Match: <year> <country> <trigger>
+    '2020 uk national holidays'             => test_spice(@uk2020),
+    '2020 japan national holidays'          => test_spice(@japan2020),   
+      
+    'holidays 2016'                         => undef,    
+    'uk public holiday 2016'                => undef,    
+    'yuk public holidays 2016'              => undef,    
+    'uk usa public holidays 2016'           => undef,    
+    'national park holidays'                => undef,    
+    'riverbank holidays'                    => undef,
+    'confederal holidays'                   => undef,
+);
+
+done_testing;

--- a/t/PublicHolidays.t
+++ b/t/PublicHolidays.t
@@ -108,6 +108,7 @@ ddg_spice_test(
     'uk public holiday 2016'                => undef,    
     'yuk public holidays 2016'              => undef,    
     'uk usa public holidays 2016'           => undef,    
+    'uk public holidays 2016 2017'          => undef,    
     'national park holidays'                => undef,    
     'riverbank holidays'                    => undef,
     'confederal holidays'                   => undef,


### PR DESCRIPTION
_(Work in progress - see limitations)_

# Overview
This is a new IA that provides the list of public holidays in a calendar year for a country.

# Preview
For now I'm using the `List` template but I'd welcome input from the design team.

![preview](https://cloud.githubusercontent.com/assets/16732873/13338664/c6cd3f44-dc1a-11e5-93d6-30b10dbf7cae.png)

# Triggers
The following words are triggers for this IA:
- `public holidays`
- `national holidays`
- `bank holidays`
- `federal holidays`

The trigger words can appear anywhere in the query but are carefully inspected to ensure they are matched in the right context before triggering the IA. Queries are inspected for the following components:

Component| Description| Required | Default | Optional Prefix
--------------|----------------|-------------|----------|---------------------
 `trigger`    | one of the keywords listed above | Yes |  - | -
`country`   |  the country for which holidays to retrieve | No | `$loc` | `in | in the`
`year`       | the year for which the holidays should be retrieved | No | Current Year | `in`

The components can be combined in various ways to form a query that this IA responds to, for example:

`trigger` `country` `year` => `public holidays` `uk` `2016`
`country` `trigger` `year` => `uk` `public holidays` `2016`
`country` `trigger` => `uk` `public holidays`
etc...

The IA will not trigger unless one of the possible variations is matched exactly (start to end of the query).

# Outstanding Issues

1. The UI layout doesn't fit on mobile devices
2. Some public holidays are not listed, for example St.Patricks day in Northern Ireland. We need to request an additional holiday type from the API but first some more investigation is required to ensure this extra set only includes genuine public holidays for _all_ countries

# Future Improvements
These are some ideas for how I might improve the IA in the future:

- Only show holidays that have yet to come by default; clicking `Show More` would display holidays that have passed
- The API response includes a URL to a page containing details about each specific holiday, what's it for, what do people do traditionally etc. It could be useful/interesting to include links to these pages

---
https://duck.co/ia/view/public_holidays