### PR TITLE
strip content after TLD in company url, fixes logo images

### DIFF
--- a/share/spice/couprex/couprex.js
+++ b/share/spice/couprex/couprex.js
@@ -42,7 +42,9 @@
                         descriptionText = htmlDecode(item.content);
 
                     // strip protocol, subdomain, and trailing slashes from domain for Clearbit API
-                    company_url = company_url.replace(/^(https?:\/\/)?(www\.)?/i, "").replace(/\/$/, "");
+                    console.log(company_url);
+                    company_url = company_url.replace(/^(https?:\/\/)?(www\.)?/i, "").replace(/\/.+$/, "");
+                    console.log(company_url);
 
                     return {
                         title: htmlDecode(item.title),

--- a/share/spice/couprex/couprex.js
+++ b/share/spice/couprex/couprex.js
@@ -42,9 +42,7 @@
                         descriptionText = htmlDecode(item.content);
 
                     // strip protocol, subdomain, and trailing slashes from domain for Clearbit API
-                    console.log(company_url);
                     company_url = company_url.replace(/^(https?:\/\/)?(www\.)?/i, "").replace(/\/.+$/, "");
-                    console.log(company_url);
 
                     return {
                         title: htmlDecode(item.title),

--- a/share/spice/couprex/couprex.js
+++ b/share/spice/couprex/couprex.js
@@ -42,7 +42,7 @@
                         descriptionText = htmlDecode(item.content);
 
                     // strip protocol, subdomain, and trailing slashes from domain for Clearbit API
-                    company_url = company_url.replace(/^(https?:\/\/)?(www\.)?/i, "").replace(/\/.+$/, "");
+                    company_url = company_url.replace(/^(https?:\/\/)?(www\.)?/i, "").replace(/\/.*$/, "");
 
                     return {
                         title: htmlDecode(item.title),


### PR DESCRIPTION
Several Clearbit Logo API calls were failing. It turns out I wasn't properly stripping the url to just the domain + TLD. This fixes it an now we should have several more correct logos in the results.

/cc @AdamSC1-ddg 

IA: https://duck.co/ia/view/couprex_coupons