### PR TITLE
Currency: Require space after unit abbreviation

### DIFF
--- a/lib/DDG/Spice/Currency.pm
+++ b/lib/DDG/Spice/Currency.pm
@@ -28,7 +28,7 @@ my $into_qr = qr/\s(?:en|in|to|in ?to|to)\s/i;
 my $vs_qr = qr/\sv(?:ersu|)s\.?\s/i;
 my $question_prefix = qr/(?:convert|what (?:is|are|does)|how (?:much|many) (?:is|are))?\s?/;
 my $number_re = number_style_regex();
-my $cardinal_re = join(' |', qw(hundred thousand k million m billion b trillion));
+my $cardinal_re = join(' |', qw(hundred thousand k million m billion b trillion)).' ';
 
 
 my $guard = qr/^$question_prefix(\p{Currency_Symbol})?\s?($number_re*)\s?(\p{Currency_Symbol})?\s?($cardinal_re)?\s?($currency_qr)?(?:s)?(?:$into_qr|$vs_qr|\/|\s)?($number_re*)\s?($currency_qr)?(\p{Currency_Symbol})?(?:s)?\??$/i;

--- a/lib/DDG/Spice/Currency.pm
+++ b/lib/DDG/Spice/Currency.pm
@@ -28,7 +28,7 @@ my $into_qr = qr/\s(?:en|in|to|in ?to|to)\s/i;
 my $vs_qr = qr/\sv(?:ersu|)s\.?\s/i;
 my $question_prefix = qr/(?:convert|what (?:is|are|does)|how (?:much|many) (?:is|are))?\s?/;
 my $number_re = number_style_regex();
-my $cardinal_re = qr/hundred |thousand |k |million |m |billion |b |trillion /;
+my $cardinal_re = join(' |', qw(hundred thousand k million m billion b trillion));
 
 
 my $guard = qr/^$question_prefix(\p{Currency_Symbol})?\s?($number_re*)\s?(\p{Currency_Symbol})?\s?($cardinal_re)?\s?($currency_qr)?(?:s)?(?:$into_qr|$vs_qr|\/|\s)?($number_re*)\s?($currency_qr)?(\p{Currency_Symbol})?(?:s)?\??$/i;
@@ -131,10 +131,10 @@ handle query_lc => sub {
             $amount = $styler->for_computation($amount);
 
             if ($cardinal =~ /(hundred )/i)  { $amount *= 100 }
-            elsif ($cardinal =~ /(thousand |k )/i) { $amount *= 1000 }
-            elsif ($cardinal =~ /(million |m )/i)  { $amount *= 1000000 }
-            elsif ($cardinal =~ /(billion |b )/i)  { $amount *= 1000000000 }
-            elsif ($cardinal =~ /(trillion |t )/i) { $amount *= 1000000000000 }
+            elsif ($cardinal =~ /(thousand |k )/i) { $amount *= 1_000 }
+            elsif ($cardinal =~ /(million |m )/i)  { $amount *= 1_000_000 }
+            elsif ($cardinal =~ /(billion |b )/i)  { $amount *= 1_000_000_000 }
+            elsif ($cardinal =~ /(trillion |t )/i) { $amount *= 1_000_000_000_000 }
         } elsif($cardinal && $amount eq '') {
             return; # if cardinal provided but no amount return
         }

--- a/lib/DDG/Spice/Currency.pm
+++ b/lib/DDG/Spice/Currency.pm
@@ -28,7 +28,8 @@ my $into_qr = qr/\s(?:en|in|to|in ?to|to)\s/i;
 my $vs_qr = qr/\sv(?:ersu|)s\.?\s/i;
 my $question_prefix = qr/(?:convert|what (?:is|are|does)|how (?:much|many) (?:is|are))?\s?/;
 my $number_re = number_style_regex();
-my $cardinal_re = join('|', qw(hundred thousand k million m billion b trillion));
+my $cardinal_re = qr/hundred |thousand |k |million |m |billion |b |trillion /;
+
 
 my $guard = qr/^$question_prefix(\p{Currency_Symbol})?\s?($number_re*)\s?(\p{Currency_Symbol})?\s?($cardinal_re)?\s?($currency_qr)?(?:s)?(?:$into_qr|$vs_qr|\/|\s)?($number_re*)\s?($currency_qr)?(\p{Currency_Symbol})?(?:s)?\??$/i;
 
@@ -124,15 +125,18 @@ handle query_lc => sub {
 
         my $styler = number_style_for($amount);
         return unless $styler;
-
-        if ($cardinal ne '') {
+        
+        # only convert $amount if exists
+        if ($cardinal ne '' && $amount ne '') { 
             $amount = $styler->for_computation($amount);
 
-            if ($cardinal eq 'hundred')  { $amount *= 100 }
-            elsif ($cardinal =~ /(thousand|k)/i) { $amount *= 1000 }
-            elsif ($cardinal =~ /(million|m)/i)  { $amount *= 1000000 }
-            elsif ($cardinal =~ /(billion|b)/i)  { $amount *= 1000000000 }
-            elsif ($cardinal =~ /(trillion|t)/i) { $amount *= 1000000000000 }
+            if ($cardinal =~ /(hundred )/i)  { $amount *= 100 }
+            elsif ($cardinal =~ /(thousand |k )/i) { $amount *= 1000 }
+            elsif ($cardinal =~ /(million |m )/i)  { $amount *= 1000000 }
+            elsif ($cardinal =~ /(billion |b )/i)  { $amount *= 1000000000 }
+            elsif ($cardinal =~ /(trillion |t )/i) { $amount *= 1000000000000 }
+        } elsif($cardinal && $amount eq '') {
+            return; # if cardinal provided but no amount return
         }
 
         # If two amounts are available, exit early. It's ambiguous.

--- a/t/Currency.t
+++ b/t/Currency.t
@@ -107,7 +107,7 @@ ddg_spice_test(
         is_cached => 0
     ),
     # Query with everything smushed together, with k for thousand.
-    '2kcadusd' => test_spice(
+    '2k cadusd' => test_spice(
         '/js/spice/currency/2000/cad/usd',
         call_type => 'include',
         caller => 'DDG::Spice::Currency',
@@ -271,6 +271,17 @@ ddg_spice_test(
     # Ambiguous queries.
     '100cny 40usd' => undef,
     '10 euro to 10 jpy' => undef,
+    '1mars' => undef,
+    '1baud' => undef,
+    'mars' => undef,
+    'kaud' => undef,
+    'baud' => undef,
+    
+    'k aud' => undef,
+    'm aud' => undef,
+    'b aud' => undef,
+    't aud' => undef,
+    
     # Things that should probably work but it doesn't at the moment.
     'cny jpy 400' => undef,
     '499 cny = ? usd' => undef,

--- a/t/Currency.t
+++ b/t/Currency.t
@@ -263,6 +263,21 @@ ddg_spice_test(
         caller => 'DDG::Spice::Currency',
         is_cached => 0
     ),
+    
+    # Requirement for space between unit and currency
+    '5m usd to aud' => test_spice(
+        '/js/spice/currency/5000000/usd/aud',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
+    '1k ars to eur' => test_spice(
+        '/js/spice/currency/1000/ars/eur',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
+
 
     # Numbers with with ambiguous formatting.
     'convert 2,000.1.9 cad into usd' => undef,


### PR DESCRIPTION
Fixes #2533 

//CC @moollaza 


------
IA Page:  http://duck.co/ia/view/currency