### PR TITLE
Add stopwords to Couprex

### DIFF
--- a/lib/DDG/Spice/Couprex.pm
+++ b/lib/DDG/Spice/Couprex.pm
@@ -7,16 +7,21 @@ use DDG::Spice;
 spice is_cached => 1;
 
 my @triggers = ("coupon", "coupon code", "promo code", "discount coupon", "discount code", "promotional code", "deal", "discount");
+
 push (@triggers, map {$_."s"} @triggers);
 push (@triggers, map {"$_ for"} @triggers);
 
 triggers any => @triggers;
+
+my @stopwords = qw( retailmenot amazon ebay );
+my $stopwords_re = join ('|', @stopwords);
 
 spice to => 'http://couprex.com/?json=get_search_results&search=$1';
 spice wrap_jsonp_callback => 1;
 
 handle remainder => sub {
     s/\bfree\b//;
+    return if m/\b$stopwords_re\b/;
     return $_ if $_;
     return;
 };

--- a/t/Couprex.t
+++ b/t/Couprex.t
@@ -29,7 +29,9 @@ ddg_spice_test(
     ),
 
     'coupons' => undef,
-    'free deals' => undef
+    'free deals' => undef,
+    'retailmenot coupons' => undef,
+    'amazon discount' => undef
 );
 
 done_testing;


### PR DESCRIPTION
Added some stopwords for Amazon, Ebay and Retailmenot -- we shouldn't trigger when those words are in the query.

/cc @AdamSC1-ddg 

---
IA Page: https://duck.co/ia/view/couprex_coupons