### PR TITLE
Increases snippet length to 150 chars - #2547

### DIFF
--- a/share/spice/dogo_news/dogo_news.js
+++ b/share/spice/dogo_news/dogo_news.js
@@ -24,7 +24,7 @@
                     sourceName: 'DOGOnews',
                     sourceUrl: 'http://www.dogonews.com/search?query=' + encodeURIComponent(query),
                     itemType: 'Kids News Articles',
-                    snippetChars: 110
+                    snippetChars: 150
                 },
                 normalize: function(item) {
                     var thumb = item.hi_res_thumb || item.thumb;


### PR DESCRIPTION
Fixes #2547 . This commit increase the snippet text length to 150 chars.

IA Page: https://duck.co/ia/view/dogo_news