### PR TITLE
Fix for issue #1529

### DIFF
--- a/share/spice/stocks/stocks.js
+++ b/share/spice/stocks/stocks.js
@@ -13,7 +13,14 @@
                 id: 'stocks',
                 name: 'Stock',
                 data: api_result,
-                signal: (DDG.get_query().search('stock')) ? 'low' : 'high', 
+                signal: function (){
+                   var exceptions = ['irc', 'guid']
+                      for each (var x in exceptions)
+                        if (!DDG.get_query().search(x)){
+                            return 'low';
+                        }
+                            return 'high';
+                        }, 
                 meta: {
                     sourceName: 'NASDAQ',
                     sourceUrl: url

--- a/share/spice/stocks/stocks.js
+++ b/share/spice/stocks/stocks.js
@@ -13,6 +13,7 @@
                 id: 'stocks',
                 name: 'Stock',
                 data: api_result,
+                signal: (DDG.get_query().search('stock')) ? 'low' : 'high', 
                 meta: {
                     sourceName: 'NASDAQ',
                     sourceUrl: url


### PR DESCRIPTION
When the search query doesn't contain the word 'stock' the signal is set to low. This should prevent this Instant Answer to fire when not searching for stock prices.

Fixes #1529

https://duck.co/ia/view/stocks