### PR TITLE
Public Holidays: Add signal property to IA

### DIFF
--- a/share/spice/public_holidays/public_holidays.js
+++ b/share/spice/public_holidays/public_holidays.js
@@ -44,6 +44,7 @@
             Spice.add({
                 id: "public_holidays",            
                 name: "Answer",
+                signal: "high",
                 data: data,
 
                 meta: {


### PR DESCRIPTION
As per https://github.com/duckduckgo/zeroclickinfo-spice/pull/2536#discussion_r55580445 I've added the `signal` property to this IA

---
https://duck.co/ia/view/public_holidays