### PR TITLE
Fix Equaldex API call to address redirect

### DIFF
--- a/lib/DDG/Spice/Equaldex.pm
+++ b/lib/DDG/Spice/Equaldex.pm
@@ -1,12 +1,13 @@
 package DDG::Spice::Equaldex;
+
 # ABSTRACT: LGBT rights by region
 
 use DDG::Spice;
-use Locale::Country; 
+use Locale::Country;
 
 spice is_cached => 1;
 
-spice to => 'http://equaldex.com/api/region?format=json&region=$1&callback={{callback}}';
+spice to => 'http://www.equaldex.com/api/region?format=json&region=$1&callback={{callback}}';
 
 triggers startend => "lgbt", "lesbian", "gay", "bisexual", "transgender";
 my $guardRe = qr/(rights?|laws?) (in)?\s?/;
@@ -15,9 +16,9 @@ handle remainder => sub {
     if(m/$guardRe/) {
         my $country = $';
         # Workaround for Locale::Country returning ISO 3166-1 alpha-2 code when using country2code("us(a)")
-        $country = "united states" if $country =~ /\busa?\b/; 
+        $country = "united states" if $country =~ /\busa?\b/;
         # Return full country name if valid
-        return $country if defined country2code($country); 
+        return $country if defined country2code($country);
         # Return country name from ISO 3166-1 alpha-2 code
         if(code2country($country, LOCALE_CODE_ALPHA_2)) {
             return lc code2country($country, LOCALE_CODE_ALPHA_2);


### PR DESCRIPTION
API currently redirects causing the IA to break in production. This fixes the issue.

Live on Moollaza: https://moollaza.duckduckgo.com/?q=lgbt+rights+in+china&ia=equaldex

IA Page: https://duck.co/ia/view/equaldex
/cc @MrChrisW 