### PR TITLE
do not strip DJ from artist names on triggering lastfm

### DIFF
--- a/lib/DDG/Spice/Lastfm/Artist.pm
+++ b/lib/DDG/Spice/Lastfm/Artist.pm
@@ -21,6 +21,10 @@ handle query_lc => sub {
     if(m{watch\ bands?}) {
         return;
     }
+    #Special case for DJs (or artists/bands named DJ)
+    if(m{^(?:djs?)\s+(\S+(?:\s+\S+)*)}) {
+        return "dj $1", 'all';
+    }
     #Queries like "weezer band"
     if(m{(\S+(?:\s+\S+)*)\s+(?:$synonyms)$}) {
         return $1, 'all';

--- a/t/LastfmArtist.t
+++ b/t/LastfmArtist.t
@@ -14,6 +14,16 @@ ddg_spice_test(
         call_type => 'include',
         caller => 'DDG::Spice::Lastfm::Artist',
     ),
+    'DJ Khaled' => test_spice(
+        '/js/spice/lastfm/artist/dj%20khaled/all',
+        call_type => 'include',
+        caller => 'DDG::Spice::Lastfm::Artist',
+    ),
+    'musicians Pink Floyd' => test_spice(
+        '/js/spice/lastfm/artist/pink%20floyd/all',
+        call_type => 'include',
+        caller => 'DDG::Spice::Lastfm::Artist',
+    ),
 
     # have to implement the front-end method for these to work
     # needed method - ddg_spice_lastfm_artist_similar


### PR DESCRIPTION
As some artists can be named DJ (or DJ can be part of their DJ - as in Disc Jockey - name), stripping it resulted in some false positives.

This implementation is NOT perfect either, and I don't think there's an easy way to get the best of both worlds. Namely:
- Searching for "DJ Khaled" returns the right person (named DJ Khaled)
- Searching for "DJ Paul Oakenfold" returns the right person (he is a DJ, and his name is Paul Oakenfold... Last.fm figures out that "DJ" can be dropped)
- Searching for "DJ Gammer" in current implementation works fine (returning Gammer: http://www.last.fm/music/Gammer), but this fix returns a somehow less ideal profile DJ Gammer http://www.last.fm/music/DJ+GAMMER), which seems to refer to the same person, but not merged in their side.

fixes #2572

BTW: Also added a new test for a case not covered by existing ones

---

IA Page: https://duck.co/ia/view/lastfm_artist
Maintainer: @jagtalon 
