### PR TITLE
Public Holidays: Add Local Holidays to the list of holiday types retrieved

### DIFF
--- a/lib/DDG/Spice/PublicHolidays.pm
+++ b/lib/DDG/Spice/PublicHolidays.pm
@@ -11,7 +11,7 @@ spice proxy_cache_valid => "200 30d";
 spice wrap_jsonp_callback => 0;
 
 spice from => "(.+)\/(.+)\/.+";
-spice to => 'https://api.xmltime.com/holidays?accesskey={{ENV{DDG_SPICE_TIME_AND_DATE_ACCESSKEY}}}&secretkey={{ENV{DDG_SPICE_TIME_AND_DATE_SECRETKEY}}}&version=2&callback={{callback}}&types=federal%2Cfederallocal&country=$1&year=$2';
+spice to => 'https://api.xmltime.com/holidays?accesskey={{ENV{DDG_SPICE_TIME_AND_DATE_ACCESSKEY}}}&secretkey={{ENV{DDG_SPICE_TIME_AND_DATE_SECRETKEY}}}&version=2&callback={{callback}}&types=federal%2Cfederallocal%2Clocal&country=$1&year=$2';
 
 my @triggers  = ('public holidays', 'national holidays', 'bank holidays', 'federal holidays');
 my $triggers  = join('|', @triggers);


### PR DESCRIPTION
This change extends the types of holiday retrieved from the API to include `Local Holidays`. The reason for this change is because it was noted some holidays in the UK weren't showing up, such as St. Patricks Day (Northern Ireland only) and St. Andrews Day (Scotland only) which are [official holidays](https://www.gov.uk/bank-holidays) in those regions. The list of extra holidays this type includes for the UK can be seen [here](http://www.timeanddate.com/holidays/uk/#!hol=2).

**Note**: this IA caches its results for 30 days thus it will need to be flushed when this change goes live to see the difference (if it doesn't do already).

---
https://duck.co/ia/view/public_holidays