### PR TITLE
Public Holidays: Ensure cell data is wrapped on small screens

### DIFF
--- a/share/spice/public_holidays/record.handlebars
+++ b/share/spice/public_holidays/record.handlebars
@@ -1,7 +1,7 @@
-<div class="record  {{#if meta.options.keySpacing}}record--keyspacing{{/if}}  {{#if meta.options.rowHighlight}}record--highlight{{/if}}">
+<div class="record">
     <table class="record__body">
         {{#each holidays}}
-            <tr class="record__row  {{#if ../meta.options.rowHighlight}}record__row--highlight{{/if}}">
+            <tr class="record__row">
                 <td class="record__cell  record__cell--key">{{date}}</td>                
                 <td class="record__cell  record__cell--value">{{name}}</td>
                 <td class="record__cell  record__cell--value">{{notes}}</td>

--- a/share/spice/public_holidays/record.handlebars
+++ b/share/spice/public_holidays/record.handlebars
@@ -3,8 +3,8 @@
         {{#each holidays}}
             <tr class="record__row  {{#if ../meta.options.rowHighlight}}record__row--highlight{{/if}}">
                 <td class="record__cell  record__cell--key">{{date}}</td>                
-                <td class="record__cell  record__cell--key">{{name}}</td>                
-                <td class="record__cell  record__cell--key">{{notes}}</td>                
+                <td class="record__cell  record__cell--value">{{name}}</td>
+                <td class="record__cell  record__cell--value">{{notes}}</td>
             </tr>
         {{/each}}
     </table>


### PR DESCRIPTION
Some holidays only apply to certain regions within a country, in these instances the IA displays a third column clarifying where it is observed. On small screens (ie: mobile devices) this third column can appear clipped, I've attached some before/after screenshots below from an iPhone 5. The end result isn't an ideal layout, but is an improvement.

#### Before (Collapsed)
![before_collapsed](https://cloud.githubusercontent.com/assets/16732873/13795149/5d088316-eaf7-11e5-9bf2-6e9a91cec8fb.png)

#### After (Collapsed)
![after_collapsed](https://cloud.githubusercontent.com/assets/16732873/13795152/603e7842-eaf7-11e5-9a4e-9965e9e12241.png)

#### Before (Expanded)
![before_expanded](https://cloud.githubusercontent.com/assets/16732873/13795154/6390237e-eaf7-11e5-869f-598c0f76f549.png)

#### After (Expanded)
![after_expanded](https://cloud.githubusercontent.com/assets/16732873/13795159/675cad9c-eaf7-11e5-8a65-9511b0b6f91e.png)


---
https://duck.co/ia/view/public_holidays