### PR TITLE
Bitcoin: Unify ID and Tab name

### DIFF
--- a/share/spice/bitcoin/bitcoin.js
+++ b/share/spice/bitcoin/bitcoin.js
@@ -19,6 +19,8 @@
         
         DDG.require('moment.js', function(){
             var spice = {
+                id: "bitcoin",
+                name: "Answer",
                 data: api_result,
                 meta: {
                     sourceName: "Biteasy"
@@ -32,8 +34,6 @@
 
             switch (query) {
                 case "addresses":
-                    spice.id = "bitcoin_address";
-                    spice.name = "Bitcoin Address";
                     spice.templates.group = "info";
                     spice.data = {
                         "record_data": {
@@ -51,10 +51,8 @@
                     };
                     spice.meta.sourceUrl = "https://www.biteasy.com/blockchain/addresses/" + api_result.address;
                     break;
-                    
+
                 case "transactions":
-                    spice.id = "bitcoin_transaction";
-                    spice.name = "Bitcoin Transaction";
                     spice.templates.group = "list";
                     spice.data = {
                         "record_data": {
@@ -69,13 +67,11 @@
                             "BTC Transacted": formatBtc(api_result.transacted_value)
                         }
                     };
-                    
+
                     spice.meta.sourceUrl = "https://www.biteasy.com/blockchain/transactions/" + api_result.address;
                     break;
 
                 case "blocks":
-                    spice.id = "bitcoin_block";
-                    spice.name = "Bitcoin Block";
                     spice.templates.group = "list";
                     var genesisHash = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";
                     spice.data = {

--- a/share/spice/bitcoin/bitcoin.js
+++ b/share/spice/bitcoin/bitcoin.js
@@ -1,22 +1,23 @@
 (function (env) {
     "use strict";
-        
+
     env.ddg_spice_bitcoin = function(api_result) {
-        
+
         if (!api_result || api_result.status !== 200) {
             return Spice.failed('bitcoin');
         }
-        
-        
+
+
         var script = $('[src*="/js/spice/bitcoin/"]')[0],
             source = $(script).attr("src"),
-            query = decodeURIComponent(source.match(/bitcoin\/([a-z]{0,12})/)[1]),
-            api_result = api_result.data;
+            query = decodeURIComponent(source.match(/bitcoin\/([a-z]{0,12})/)[1]);
+
+        api_result = api_result.data;
 
         var formatBtc = function(amount) {
-            return (amount / 100000000.0) + " BTC"
+            return (amount / 100000000.0) + " BTC";
         };
-        
+
         DDG.require('moment.js', function(){
             var spice = {
                 id: "bitcoin",


### PR DESCRIPTION
#This IA was incorrectly using 3 different Tab names and IDs.

Seeing as these all live in Bitcoin.pm and Bitcoin.js the ID should be `bitcoin` whenever this IA triggers and the canonical "Answer" tab name works best here -- The metadata and the JS need to match so we can't have more than one tab name.

Fixes #2584 

---

IA Page: https://duck.co/ia/view/bitcoin