### PR TITLE
Movies: Remove old check for image filename path

### DIFF
--- a/share/spice/movie/movie.js
+++ b/share/spice/movie/movie.js
@@ -93,10 +93,6 @@
                 skip_words: ['movie', 'info', 'film', 'rt', 'rotten', 'tomatoes', 'rating', 'ratings', 'rotten'],
                 primary: [{
                     key: 'title'
-                }, {
-                    key: 'posters.detailed',
-                    match: /\.jpg$/,
-                    strict: false
                 }]
             },
             onItemShown: function(item) {


### PR DESCRIPTION
We now use an external API for images anyways so this isn't necessary and is causing problems

Fixes #2591 

---
IA Page: https://duck.co/ia/view/movie
/cc @jagtalon 