### PR TITLE
New VRCTeams Spice

### DIFF
--- a/lib/DDG/Spice/VRC/Teams.pm
+++ b/lib/DDG/Spice/VRC/Teams.pm
@@ -1,0 +1,32 @@
+package DDG::Spice::VRC::Teams;
+
+# ABSTRACT: Get information for registered teams of the current season of the VEX Robotics Competition
+
+use DDG::Spice;
+
+spice is_cached => 1;
+spice proxy_cache_valid => "200 1d";
+spice to => 'http://api.vexdb.io/v1/get_teams?team=$1';
+spice wrap_jsonp_callback => 1;
+
+spice alt_to => {
+    skills => {
+        is_cached => 1,
+        proxy_cache_valid => "200 6h",
+        to => 'http://api.vexdb.io/v1/get_skills?team=$1&season=current'
+    },
+    rankings => {
+        is_cached => 1,
+        proxy_cache_valid => "200 1h",
+        to => 'http://api.vexdb.io/v1/get_rankings?team=$1&season=current'
+    }
+};
+
+triggers any => 'vex team', 'vex', 'vrc team', 'vrc';
+
+handle remainder => sub {
+    return unless $_ =~ /^(\d{1,5}[A-Z]?|[A-Z]{1,5}\d?)$/i;
+    return $1;
+};
+
+1;

--- a/share/spice/vrc/teams/vrc_teams.js
+++ b/share/spice/vrc/teams/vrc_teams.js
@@ -53,7 +53,6 @@
                 l.push({label: 'Programming', value: best_programming});
             }
 
-            console.log(l);
             return l.length ? l : undefined;
         }
 
@@ -64,42 +63,41 @@
 
         var team = team_data.result[0], ranking_data, skills_data;
 
-        Spice.add({
-            id: "vrc_teams",
-            name: "VRC Team",
-            data: team,
-            meta: {
-                sourceName: "VexDB.io",
-                sourceUrl: 'http://vexdb.io/teams/view/' + team.number,
-                rerender: ['infoboxData']
-            },
-            normalize: function(item) {
-                return {
-                    title: item.team_name,
-                    subtitle: item.program + ' Team ' + item.number + ' — ' + item.organisation,
-                    description: description(item)
-                    //infoboxData: infobox(ranking_data, skills_data)
-                };
-            },
-            templates: {
-                group: 'info',
-                options: {
-                    moreAt: true
+        //the api splits the data up into multiple endpoints, fire them simultaneously
+        $.when(
+            $.getJSON('/js/spice/vrc/rankings/' + team.number, function(res){
+                ranking_data = res;
+            }),
+            $.getJSON('/js/spice/vrc/skills/' + team.number, function(res){
+                skills_data = res;
+            })
+        ).then(function(){
+            Spice.add({
+                id: "vrc_teams",
+                name: "VRC Team",
+                data: team,
+                meta: {
+                    sourceName: "VexDB.io",
+                    sourceUrl: 'http://vexdb.io/teams/view/' + team.number
+                },
+                normalize: function(item) {
+                    return {
+                        title: item.team_name,
+                        subtitle: item.program + ' Team ' + item.number + ' — ' + item.organisation,
+                        description: description(item),
+                        infoboxData: infobox(ranking_data, skills_data)
+                    };
+                },
+                templates: {
+                    group: 'info',
+                    options: {
+                        moreAt: true
+                    }
                 }
-            },
-            onItemShown: function(item){
-                //the api splits the data up into multiple endpoints, fire them simultaneously
-                $.when(
-                    $.getJSON('/js/spice/vrc/rankings/' + team.number, function(res){
-                        ranking_data = res;
-                    }),
-                    $.getJSON('/js/spice/vrc/skills/' + team.number, function(res){
-                        skills_data = res;
-                    })
-                ).then(function(){
-                    item.set({infoboxData: infobox(ranking_data, skills_data)});
-                });
-            }
+            });
+        }, function(){
+            //one of these requests failed
+            Spice.failed('vrc_teams');
         });
     };
 }(this));

--- a/share/spice/vrc/teams/vrc_teams.js
+++ b/share/spice/vrc/teams/vrc_teams.js
@@ -63,41 +63,41 @@
 
         var team = team_data.result[0], ranking_data, skills_data;
 
-        //the api splits the data up into multiple endpoints, fire them simultaneously
-        $.when(
-            $.getJSON('/js/spice/vrc/rankings/' + team.number, function(res){
-                ranking_data = res;
-            }),
-            $.getJSON('/js/spice/vrc/skills/' + team.number, function(res){
-                skills_data = res;
-            })
-        ).then(function(){
-            Spice.add({
-                id: "vrc_teams",
-                name: "VRC Team",
-                data: team,
-                meta: {
-                    sourceName: "VexDB.io",
-                    sourceUrl: 'http://vexdb.io/teams/view/' + team.number
-                },
-                normalize: function(item) {
-                    return {
-                        title: item.team_name,
-                        subtitle: item.program + ' Team ' + item.number + ' — ' + item.organisation,
-                        description: description(item),
-                        infoboxData: infobox(ranking_data, skills_data)
-                    };
-                },
-                templates: {
-                    group: 'info',
-                    options: {
-                        moreAt: true
-                    }
+        Spice.add({
+            id: "vrc_teams",
+            name: "VRC Team",
+            data: team,
+            meta: {
+                sourceName: "VexDB.io",
+                sourceUrl: 'http://vexdb.io/teams/view/' + team.number
+            },
+            normalize: function(item) {
+                return {
+                    title: item.team_name,
+                    subtitle: item.program + ' Team ' + item.number + ' — ' + item.organisation,
+                    description: description(item)
+                    //infoboxData: infobox(ranking_data, skills_data)
+                };
+            },
+            templates: {
+                group: 'info',
+                options: {
+                    moreAt: true
                 }
-            });
-        }, function(){
-            //one of these requests failed
-            Spice.failed('vrc_teams');
+            },
+            onItemShown: function(item){
+                //the api splits the data up into multiple endpoints, fire them simultaneously
+                $.when(
+                    $.getJSON('/js/spice/vrc/rankings/' + team.number, function(res){
+                        ranking_data = res;
+                    }),
+                    $.getJSON('/js/spice/vrc/skills/' + team.number, function(res){
+                        skills_data = res;
+                    })
+                ).then(function(){
+                    item.set({infoboxData: infobox(ranking_data, skills_data)});
+                });
+            }
         });
     };
 }(this));

--- a/share/spice/vrc/teams/vrc_teams.js
+++ b/share/spice/vrc/teams/vrc_teams.js
@@ -1,0 +1,103 @@
+(function (env) {
+    "use strict";
+    env.ddg_spice_vrc_teams = function(team_data) {
+        if (!team_data || team_data.status !== 1 || team_data.size === 0 || team_data.result[0].is_registered === "0") {
+            return Spice.failed('vrc_teams');
+        }
+
+        //infobox data for statistics
+        function infobox(ranking, skills){
+            var l = []
+            if (ranking.status === 1 && ranking.size > 0){
+                l.push({heading: 'Qualifying Matches'});
+                var total_wins = 0,
+                    total_losses = 0,
+                    total_ties = 0,
+                    total_ccwm = 0.0,
+                    max_score = 0,
+                    latest = ranking.result[0];
+
+                $.each(ranking.result, function(ind, i){
+                    total_wins += parseInt(i.wins);
+                    total_losses += parseInt(i.losses);
+                    total_ties += parseInt(i.ties);
+                    total_ccwm += parseFloat(i.ccwm);
+                    max_score = Math.max(max_score, parseInt(i.max_score));
+                });
+
+                var total_wlt = total_wins + '-' + total_losses + '-' + total_ties;
+                var latest_wlt = latest.wins + '-' + latest.losses + '-' + latest.ties;
+                l.push({label: 'Total W-L-T', value: total_wlt});
+                l.push({label: 'Latest W-L-T', value: latest_wlt});
+                l.push({label: 'Greatest Match Score', value: max_score});
+
+                var average_ccwm = total_ccwm / ranking.size;
+                l.push({label: 'Average CCWM', value: average_ccwm.toFixed(2)});
+                l.push({label: 'Latest CCWM', value: parseFloat(latest.ccwm).toFixed(2)});
+            }
+            if (skills.status === 1 && skills.size > 0){
+                l.push({heading: 'Best Skills'});
+                var best_robot = 0,
+                    best_programming = 0;
+
+                $.each(skills.result, function(ind, i){
+                    if (i.type === "0" && parseInt(i.score) > best_robot){
+                        best_robot = parseInt(i.score);
+                    }
+                    if (i.type === "1" && parseInt(i.score) > best_programming){
+                        best_programming = parseInt(i.score);
+                    }
+                });
+
+                l.push({label: 'Robot', value: best_robot});
+                l.push({label: 'Programming', value: best_programming});
+            }
+
+            return l.length ? l : undefined;
+        }
+
+        //description data for team location and grade
+        function description(team){
+            return team.grade + ' team from ' + team.city + ', ' + team.region + ', ' + team.country;
+        }
+
+        var team = team_data.result[0], ranking_data, skills_data;
+
+        //the api splits the data up into multiple endpoints, fire them simultaneously
+        $.when(
+            $.getJSON('/js/spice/vrc/rankings/' + team.number, function(res){
+                ranking_data = res;
+            }),
+            $.getJSON('/js/spice/vrc/skills/' + team.number, function(res){
+                skills_data = res;
+            })
+        ).then(function(){
+            Spice.add({
+                id: "vrc_teams",
+                name: "VRC Team",
+                data: team,
+                meta: {
+                    sourceName: "VexDB.io",
+                    sourceUrl: 'http://vexdb.io/teams/view/' + team.number
+                },
+                normalize: function(item) {
+                    return {
+                        title: item.team_name,
+                        subtitle: item.program + ' Team ' + item.number + ' — ' + item.organisation,
+                        description: description(item),
+                        infoboxData: infobox(ranking_data, skills_data)
+                    };
+                },
+                templates: {
+                    group: 'info',
+                    options: {
+                        moreAt: true
+                    }
+                }
+            });
+        }, function(){
+            //one of these requests failed
+            Spice.failed('vrc_teams');
+        });
+    };
+}(this));

--- a/share/spice/vrc/teams/vrc_teams.js
+++ b/share/spice/vrc/teams/vrc_teams.js
@@ -53,6 +53,7 @@
                 l.push({label: 'Programming', value: best_programming});
             }
 
+            console.log(l);
             return l.length ? l : undefined;
         }
 
@@ -69,7 +70,8 @@
             data: team,
             meta: {
                 sourceName: "VexDB.io",
-                sourceUrl: 'http://vexdb.io/teams/view/' + team.number
+                sourceUrl: 'http://vexdb.io/teams/view/' + team.number,
+                rerender: ['infoboxData']
             },
             normalize: function(item) {
                 return {

--- a/share/spice/vrc/teams/vrc_teams.js
+++ b/share/spice/vrc/teams/vrc_teams.js
@@ -1,7 +1,7 @@
 (function (env) {
     "use strict";
     env.ddg_spice_vrc_teams = function(team_data) {
-        if (!team_data || team_data.status !== 1 || team_data.size === 0 || team_data.result[0].is_registered === "0") {
+        if (!team_data || team_data.status !== 1 || team_data.size === 0) {
             return Spice.failed('vrc_teams');
         }
 

--- a/t/VRCTeams.t
+++ b/t/VRCTeams.t
@@ -1,0 +1,26 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+spice is_cached => 1;
+
+ddg_spice_test(
+    [qw( DDG::Spice::VRC::Teams)],
+    'vex team 765A' => test_spice(
+        '/js/spice/vrc/teams/765A',
+        call_type => 'include',
+        caller => 'DDG::Spice::VRC::Teams'
+    ),
+    'vrc aura' => test_spice(
+        '/js/spice/vrc/teams/aura',
+        call_type => 'include',
+        caller => 'DDG::Spice::VRC::Teams'
+    ),
+    'vex team scores' => undef,
+    'awesome vrc team' => undef
+);
+
+done_testing;


### PR DESCRIPTION
This IA fetches statistics for a given VEX Robotics Competition team. It displays them in the infobox along with information about their division, location, etc.

The data source, VexDB.io, is regarded in the community as a really good data source, as the canonical data is split up into a lot of csv files rather than a nice, consumable JSON api.

Unfortunately, the data is split into multiple endpoints, so I used the `spice alt_to` attribute exhibited in [xkcd](https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/Xkcd/Display.pm#L12-L16) to add these in. I used jQuery's `$.when().then()` to fire the needed requests off simultaneously rather than sequentially. I'm unsure about its compatibility with IE, but I haven't found anything saying that it's incompatible (I'm assuming they're using a polyfill).

https://duck.co/ia/view/vrc_teams