### PR TITLE
Make sure r and r.stars exist in amazon/isbn callback

### DIFF
--- a/share/spice/amazon/amazon.js
+++ b/share/spice/amazon/amazon.js
@@ -46,7 +46,9 @@
                 arg = arg.replace('http://www.amazon/reviews/iframe?', '');
 
                 $.getJSON(url + encodeURIComponent(arg), function(r) {
-                    if (r.stars.match(/stars-(\d)-(\d)/)) {
+                    if (!r) { return; }
+
+                    if (r.stars && r.stars.match(/stars-(\d)-(\d)/)) {
                         item.set({ rating:  RegExp.$1 + "." + RegExp.$2 });
                     }
                     item.set({ reviewCount:  r.reviews });

--- a/share/spice/isbn/isbn.js
+++ b/share/spice/isbn/isbn.js
@@ -38,7 +38,9 @@
                 arg = arg.replace('http://www.amazon/reviews/iframe?', '');
 
                 $.getJSON(url + encodeURIComponent(arg), function(r) {
-                    if (r.stars.match(/stars-(\d)-(\d)/)) {
+                    if (!r) { return; }
+
+                    if (r.stars && r.stars.match(/stars-(\d)-(\d)/)) {
                         item.set({ rating: RegExp.$1 + "." + RegExp.$2 });
                     }
                     item.set({ reviewCount:  r.reviews });


### PR DESCRIPTION
Added more guards in the Amazon/ISBN review callback. It's currently causing errors in some cases where no stars are returned.

cc @b2ddg 