### PR TITLE
Switch API URL to HTTPS because it now redirects there

### DIFF
--- a/lib/DDG/Spice/UV.pm
+++ b/lib/DDG/Spice/UV.pm
@@ -1,4 +1,5 @@
 package DDG::Spice::UV;
+
 # ABSTRACT: Use the web service provided by EPA to display the UV Index for locations in the US.
 # The web service is described here: http://www.epa.gov/enviro/facts/services.html#uvindex
 
@@ -7,16 +8,15 @@ use DDG::Spice;
 
 spice is_cached => 1;
 
-# Triggers
 triggers startend => 'uv', 'uv index', 'current uv index';
 
 spice from => '([^/]*)/?([^/]*)';
 
 #hourly data - for the next version...
-#spice to => 'http://iaspub.epa.gov/enviro/efservice/getEnvirofactsUVHOURLY/CITY/$1/STATE/$2/JSON';
+#spice to => 'https://iaspub.epa.gov/enviro/efservice/getEnvirofactsUVHOURLY/CITY/$1/STATE/$2/JSON';
 
 #daily data - just one value for the day...
-spice to => 'http://iaspub.epa.gov/enviro/efservice/getEnvirofactsUVDAILY/CITY/$1/STATE/$2/JSON';
+spice to => 'https://iaspub.epa.gov/enviro/efservice/getEnvirofactsUVDAILY/CITY/$1/STATE/$2/JSON';
 
 #UV Index might change daily, but not in the middle of the night.
 spice proxy_cache_valid => "200 304 4h";


### PR DESCRIPTION
The HTTP API now redirects to HTTPS so this is currently broken.

This forces HTTPS and will correct the bug.

---
https://duck.co/ia/view/uv