### PR TITLE
Currency: Fixes large flag img sizing issue for mobile.

### DIFF
--- a/share/spice/currency/currency.css
+++ b/share/spice/currency/currency.css
@@ -207,7 +207,7 @@
 
 @media only screen and (max-width: 600px) {
     .flag_img {
-        width: 40px;
+        width: 30px;
     }
 }
 

--- a/share/spice/currency/currency.css
+++ b/share/spice/currency/currency.css
@@ -205,6 +205,12 @@
     }
 }
 
+@media only screen and (max-width: 600px) {
+    .flag_img {
+        width: 40px;
+    }
+}
+
 /* Mobile view */
 
 .is-mobile .tile--s {

--- a/share/spice/currency/currency.css
+++ b/share/spice/currency/currency.css
@@ -205,10 +205,8 @@
     }
 }
 
-@media only screen and (max-width: 600px) {
-    .flag_img {
-        width: 30px;
-    }
+.is-mobile .flag-img {
+    width: 30px;
 }
 
 /* Mobile view */

--- a/share/spice/currency/detail.handlebars
+++ b/share/spice/currency/detail.handlebars
@@ -6,7 +6,7 @@
             <div class="zci--currency-result" data-link="{{xeUrl}}">
                 <div class="zci--currency-group">
                     <section class="zci--currency-first-part">
-                        <img src="{{fromFlag}}" alt="Flag of {{fromCurrencySymbol}}">
+                        <img src="{{fromFlag}}" class="flag-img" alt="Flag of {{fromCurrencySymbol}}">
                         <span class="zci--currency-amount text--primary" data-original="{{from-amount}}" data-processed="{{amount}}">{{amount}}</span>
                         <span class="zci--currency-symbol">{{fromCurrencySymbol}}</span>
                     </section>
@@ -15,7 +15,7 @@
                 </div>
 
                 <section class="zci--currency-second-part">
-                    <img src="{{toFlag}}" class="flag" alt="Flag of {{toCurrencySymbol}}">
+                    <img src="{{toFlag}}" class="flag-img" alt="Flag of {{toCurrencySymbol}}">
                     <span class="zci--currency-amount text--primary" data-original="{{converted-amount}}" data-processed="{{convertedAmount}}">{{convertedAmount}}</span>
                     <span class="zci--currency-symbol">{{toCurrencySymbol}}</span>
                 </section>

--- a/share/spice/currency/detail_mobile.handlebars
+++ b/share/spice/currency/detail_mobile.handlebars
@@ -9,7 +9,7 @@
 
 <a class="tile tile--s small" href="http://www.xe.com/currencycharts/?from={{fromCurrencySymbol}}&to={{toCurrencySymbol}}">
     <div class="zci--currency-first-part tx-clr--dk">
-        <img class="flag_img" src="{{fromFlag}}" alt="Flag of {{fromCurrencySymbol}}">
+        <img class="flag-img" src="{{fromFlag}}" alt="Flag of {{fromCurrencySymbol}}">
         <span class="zci--currency-symbol-large">{{fromCurrencySymbol}}</span>
         <span class="zci--currency-amount" data-original="{{from-amount}}" data-processed="{{amount}}">{{amount}}</span>
         <span class="zci--currency-symbol-small">{{fromCurrencySymbol}}</span>
@@ -22,7 +22,7 @@
     </div>
     
     <div class="zci--currency-second-part tx-clr--dk">
-        <img class="flag_img" src="{{toFlag}}" alt="Flag of {{toCurrencySymbol}}">
+        <img class="flag-img" src="{{toFlag}}" alt="Flag of {{toCurrencySymbol}}">
         <span class="zci--currency-symbol-large">{{toCurrencySymbol}}</span>
         <span class="zci--currency-amount" data-original="{{converted-amount}}" data-processed="{{convertedAmount}}">{{convertedAmount}}</span>
         <span class="zci--currency-symbol-small">{{toCurrencySymbol}}</span>

--- a/share/spice/currency/detail_mobile.handlebars
+++ b/share/spice/currency/detail_mobile.handlebars
@@ -9,7 +9,7 @@
 
 <a class="tile tile--s small" href="http://www.xe.com/currencycharts/?from={{fromCurrencySymbol}}&to={{toCurrencySymbol}}">
     <div class="zci--currency-first-part tx-clr--dk">
-        <img src="{{fromFlag}}" alt="Flag of {{fromCurrencySymbol}}">
+        <img class="flag_img" src="{{fromFlag}}" alt="Flag of {{fromCurrencySymbol}}">
         <span class="zci--currency-symbol-large">{{fromCurrencySymbol}}</span>
         <span class="zci--currency-amount" data-original="{{from-amount}}" data-processed="{{amount}}">{{amount}}</span>
         <span class="zci--currency-symbol-small">{{fromCurrencySymbol}}</span>
@@ -22,7 +22,7 @@
     </div>
     
     <div class="zci--currency-second-part tx-clr--dk">
-        <img src="{{toFlag}}" alt="Flag of {{toCurrencySymbol}}">
+        <img class="flag_img" src="{{toFlag}}" alt="Flag of {{toCurrencySymbol}}">
         <span class="zci--currency-symbol-large">{{toCurrencySymbol}}</span>
         <span class="zci--currency-amount" data-original="{{converted-amount}}" data-processed="{{convertedAmount}}">{{convertedAmount}}</span>
         <span class="zci--currency-symbol-small">{{toCurrencySymbol}}</span>


### PR DESCRIPTION
IA URL: https://duck.co/ia/view/currency
Fixes Issue: #2603

Images of the country flags were being rendered too large on mobile devices. This fix sets a fixed size for the flags on mobile screens. Here is an example of output for small and large input values (on iPhone 5):

<img width="320" alt="screen shot 2016-03-26 at 16 17 47" src="https://cloud.githubusercontent.com/assets/3945744/14062256/c9cd4322-f36e-11e5-877e-91b8eae0ba64.png"><br />
<img width="322" alt="screen shot 2016-03-26 at 16 12 15" src="https://cloud.githubusercontent.com/assets/3945744/14062255/c8595260-f36e-11e5-98f9-cb21d77dd3e0.png">
