### PR TITLE
Coderwall: Update to handle markdown content from API (fixes #2548)

### DIFF
--- a/share/spice/coderwall/coderwall.css
+++ b/share/spice/coderwall/coderwall.css
@@ -1,0 +1,13 @@
+/* Fixes issue with legacy user avatars:
+ * hides 20px white border on 100x100px thumnails
+ */
+.zci--coderwall .c-icon__img {
+  max-height: 122%;
+  max-width: 122%;
+  margin: -11%;
+}
+.zci--coderwall .c-icon__img-wrap {
+  -moz-border-radius: 50%;
+  -webkit-border-radius: 50%;
+  border-radius: 50%;
+}

--- a/share/spice/coderwall/coderwall.js
+++ b/share/spice/coderwall/coderwall.js
@@ -43,9 +43,7 @@
                   subtitles.push(item.title);
                 }
                 return {
-                    // Remove image for now
-                    // cropped photos look bad
-                    // image: item.avatar.url,
+                    image: item.avatar.url,
                     title: item.name,
                     subtitle: subtitles,
                     altSubtitle: item.location,
@@ -54,8 +52,35 @@
             },
 
             templates: {
-                group: 'icon'
+                group: 'icon',
+                variants: {
+                    iconImage: 'large'
+                },
+                options: {
+                    chompContents: true,
+                    content: DDH.coderwall.content
+                }
             }
         });
+
     };
+
+    Handlebars.registerHelper("parseMD", function(content){
+        var contentArr = [];
+        var linkExp = /\[([a-z0-9]+)\]\(([a-z0-9\.\:\/\$-_\+\!\*',]+)\)+/gi;
+        if (!content) return;
+        else content.split(/\n+/).forEach(function(line) {
+            // exclude lines that are only whitespace characters
+            if (/[a-z0-9]/.test(line)) {
+                line = line.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')   // bold
+                  .replace(/(?:_(.+?)_|\*(.+?)\*)/g, '<em>$1$2</em>')          // italicize
+                  .replace(/`(.+?)`/g, '<code>$1</code>')                      // monospace
+                  .replace(/~~(.+?)~~/g, '<del>$1</del>')                      // strikethrough
+                  .replace(linkExp, '<a href="$2" class="tx-clr--dk2">$1</a>');// create links
+                contentArr.push(line);
+            }
+        });
+        return contentArr.join('<br>'); //add linebreaks
+    });
+
 }(this));

--- a/share/spice/coderwall/coderwall.js
+++ b/share/spice/coderwall/coderwall.js
@@ -40,7 +40,7 @@
                     }
                 });
                 if (item.title) {
-                  subtitles.push(item.title);
+                    subtitles.push(item.title);
                 }
                 return {
                     image: item.thumbnail,
@@ -63,7 +63,7 @@
         });
     };
 
-    Handlebars.registerHelper("parseMD", function(value){
+    Spice.registerHelper("coderwall_parse_md", function(value){
         var result = [];
         if (!value) return;
         else {
@@ -73,10 +73,10 @@
                 // exclude lines that are only whitespace characters
                 if (/[a-z0-9]/.test(line)) {
                     line = line.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>') // bold
-                      .replace(/(_(.+?)_|\*(.+?)\*)/g, '<em>$1$2</em>') // italicize
-                      .replace(/`(.+?)`/g, '<code>$1</code>') // monospace
-                      .replace(/~~(.+?)~~/g, '<del>$1</del>') // strikethrough
-                      .replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2" class="tx-clr--dk2">$1</a>'); // create links
+                        .replace(/(?:_(.+?)_|\*(.+?)\*)/g, '<em>$1$2</em>') // italicize
+                        .replace(/`(.+?)`/g, '<code>$1</code>') // monospace
+                        .replace(/~~(.+?)~~/g, '<del>$1</del>') // strikethrough
+                        .replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2" class="tx-clr--dk2">$1</a>'); // create links
                     result.push(line);
                 }
             });

--- a/share/spice/coderwall/coderwall.js
+++ b/share/spice/coderwall/coderwall.js
@@ -77,7 +77,7 @@
                 contentArr.push(line);
             }
         });
-        return contentArr.join('<br>'); //add linebreaks
+        var result = contentArr.join('<br>'); //add linebreaks
+        return new Handlebars.SafeString(result);
     });
-
 }(this));

--- a/share/spice/coderwall/coderwall.js
+++ b/share/spice/coderwall/coderwall.js
@@ -65,16 +65,17 @@
 
     Spice.registerHelper("coderwall_parse_md", function(value){
         var result = [];
-        if (!value) return;
-        else {
+        if (!value) {
+            return;
+        } else {
             // no cross site scripting
             value = Handlebars.Utils.escapeExpression(value);
             value.split(/\n+/).forEach(function(line) {
                 // exclude lines that are only whitespace characters
-                if (/[a-z0-9]/.test(line)) {
-                    line = line.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>') // bold
-                        .replace(/(?:_(.+?)_|\*(.+?)\*)/g, '<em>$1$2</em>') // italicize
-                        .replace(/`(.+?)`/g, '<code>$1</code>') // monospace
+                if (/[a-z0-9]/.test(line)) { // Github flavored MD
+                    line = line.replace(/(__(.+?)__|\*\*(.+?)\*\*)/g, '<strong>$2$3</strong>') // bold
+                        .replace(/(_(.+?)_|\*(.+?)\*)/g, '<em>$2$3</em>') // italicize
+                        .replace(/&#x60;(.+?)&#x60;/g, '<code>$1</code>') // monospace (unicode for ` grave accent)
                         .replace(/~~(.+?)~~/g, '<del>$1</del>') // strikethrough
                         .replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2" class="tx-clr--dk2">$1</a>'); // create links
                     result.push(line);

--- a/share/spice/coderwall/coderwall.js
+++ b/share/spice/coderwall/coderwall.js
@@ -27,7 +27,7 @@
                     twitter: '@{{}}'
                 };
                 var subtitles = [];
-                $.each(item.accounts, function(service, name) {
+                $.each(item, function(service, name) {
                     // Check that we have a profile url template and
                     // coderwall actually provided a name instead null
                     if (account_url[service] && name) {
@@ -45,11 +45,7 @@
                 return {
                     // Remove image for now
                     // cropped photos look bad
-
-                    // some thumbnail URIs are relative to coderwall.com
-                    // image: /^\//.test(item.thumbnail)
-                    //     ? 'https://coderwall.com/' + item.thumbnail
-                    //     : item.thumbnail,
+                    // image: item.avatar.url,
                     title: item.name,
                     subtitle: subtitles,
                     altSubtitle: item.location,

--- a/share/spice/coderwall/coderwall.js
+++ b/share/spice/coderwall/coderwall.js
@@ -63,21 +63,26 @@
         });
     };
 
-    Handlebars.registerHelper("parseMD", function(content){
-        var contentArr = [];
-        if (!content) return;
-        else content.split(/\n+/).forEach(function(line) {
-            // exclude lines that are only whitespace characters
-            if (/[a-z0-9]/.test(line)) {
-                line = line.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>') // bold
-                  .replace(/(?:_(.+?)_|\*(.+?)\*)/g, '<em>$1$2</em>') // italicize
-                  .replace(/`(.+?)`/g, '<code>$1</code>') // monospace
-                  .replace(/~~(.+?)~~/g, '<del>$1</del>') // strikethrough
-                  .replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2" class="tx-clr--dk2">$1</a>'); // create links
-                contentArr.push(line);
-            }
-        });
-        var result = contentArr.join('<br>'); //add linebreaks
-        return new Handlebars.SafeString(result);
+    Handlebars.registerHelper("parseMD", function(value){
+        var result = [];
+        if (!value) return;
+        else {
+            // no cross site scripting
+            value = Handlebars.Utils.escapeExpression(value);
+            value.split(/\n+/).forEach(function(line) {
+                // exclude lines that are only whitespace characters
+                if (/[a-z0-9]/.test(line)) {
+                    line = line.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>') // bold
+                      .replace(/(?:_(.+?)_|\*(.+?)\*)/g, '<em>$1$2</em>') // italicize
+                      .replace(/`(.+?)`/g, '<code>$1</code>') // monospace
+                      .replace(/~~(.+?)~~/g, '<del>$1</del>') // strikethrough
+                      .replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2" class="tx-clr--dk2">$1</a>'); // create links
+                    result.push(line);
+                }
+            });
+            result = result.join('<br>'); //add linebreaks
+            return new Handlebars.SafeString(result);
+        }
     });
+
 }(this));

--- a/share/spice/coderwall/coderwall.js
+++ b/share/spice/coderwall/coderwall.js
@@ -57,12 +57,10 @@
                     iconImage: 'large'
                 },
                 options: {
-                    chompContents: true,
                     content: DDH.coderwall.content
                 }
             }
         });
-
     };
 
     Handlebars.registerHelper("parseMD", function(content){

--- a/share/spice/coderwall/coderwall.js
+++ b/share/spice/coderwall/coderwall.js
@@ -72,11 +72,11 @@
         else content.split(/\n+/).forEach(function(line) {
             // exclude lines that are only whitespace characters
             if (/[a-z0-9]/.test(line)) {
-                line = line.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')   // bold
-                  .replace(/(?:_(.+?)_|\*(.+?)\*)/g, '<em>$1$2</em>')          // italicize
-                  .replace(/`(.+?)`/g, '<code>$1</code>')                      // monospace
-                  .replace(/~~(.+?)~~/g, '<del>$1</del>')                      // strikethrough
-                  .replace(linkExp, '<a href="$2" class="tx-clr--dk2">$1</a>');// create links
+                line = line.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>') // bold
+                  .replace(/(?:_(.+?)_|\*(.+?)\*)/g, '<em>$1$2</em>') // italicize
+                  .replace(/`(.+?)`/g, '<code>$1</code>') // monospace
+                  .replace(/~~(.+?)~~/g, '<del>$1</del>') // strikethrough
+                  .replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2" class="tx-clr--dk2">$1</a>'); // create links
                 contentArr.push(line);
             }
         });

--- a/share/spice/coderwall/coderwall.js
+++ b/share/spice/coderwall/coderwall.js
@@ -3,17 +3,17 @@
     env.ddg_spice_coderwall = function(api_result){
 
         // Check if API provided information
-        if ($.isEmptyObject(api_result.data)) {
+        if ($.isEmptyObject(api_result.user)) {
             return Spice.failed('coderwall');
         }
 
         Spice.add({
             id: "coderwall",
             name: "Social",
-            data: api_result.data,
+            data: api_result.user,
             meta: {
                 sourceName: "Coderwall",
-                sourceUrl: 'https://coderwall.com/' + api_result.data.username
+                sourceUrl: 'https://coderwall.com/' + api_result.user.username
             },
 
             normalize: function(item) {
@@ -43,7 +43,7 @@
                   subtitles.push(item.title);
                 }
                 return {
-                    image: item.avatar.url,
+                    image: item.thumbnail,
                     title: item.name,
                     subtitle: subtitles,
                     altSubtitle: item.location,
@@ -73,7 +73,7 @@
                 // exclude lines that are only whitespace characters
                 if (/[a-z0-9]/.test(line)) {
                     line = line.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>') // bold
-                      .replace(/(?:_(.+?)_|\*(.+?)\*)/g, '<em>$1$2</em>') // italicize
+                      .replace(/(_(.+?)_|\*(.+?)\*)/g, '<em>$1$2</em>') // italicize
                       .replace(/`(.+?)`/g, '<code>$1</code>') // monospace
                       .replace(/~~(.+?)~~/g, '<del>$1</del>') // strikethrough
                       .replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2" class="tx-clr--dk2">$1</a>'); // create links

--- a/share/spice/coderwall/coderwall.js
+++ b/share/spice/coderwall/coderwall.js
@@ -65,7 +65,6 @@
 
     Handlebars.registerHelper("parseMD", function(content){
         var contentArr = [];
-        var linkExp = /\[([a-z0-9]+)\]\(([a-z0-9\.\:\/\$-_\+\!\*',]+)\)+/gi;
         if (!content) return;
         else content.split(/\n+/).forEach(function(line) {
             // exclude lines that are only whitespace characters

--- a/share/spice/coderwall/content.handlebars
+++ b/share/spice/coderwall/content.handlebars
@@ -1,2 +1,1 @@
-{{parseMD description}}
-
+{{coderwall_parse_md description}}

--- a/share/spice/coderwall/content.handlebars
+++ b/share/spice/coderwall/content.handlebars
@@ -1,2 +1,2 @@
-{{ellipsis (parseMD description) '300'}}
+{{parseMD description}}
 

--- a/share/spice/coderwall/content.handlebars
+++ b/share/spice/coderwall/content.handlebars
@@ -1,1 +1,2 @@
-{{{ellipsis (parseMD description) 300}}}
+{{ellipsis (parseMD description) '300'}}
+

--- a/share/spice/coderwall/content.handlebars
+++ b/share/spice/coderwall/content.handlebars
@@ -1,1 +1,3 @@
-{{coderwall_parse_md description}}
+{{#coderwall_substr_html this 250}}
+    {{coderwall_parse_md description}}
+{{/coderwall_substr_html}}

--- a/share/spice/coderwall/content.handlebars
+++ b/share/spice/coderwall/content.handlebars
@@ -1,1 +1,1 @@
-{{{parseMD description}}}
+{{{ellipsis (parseMD description) 300}}}

--- a/share/spice/coderwall/content.handlebars
+++ b/share/spice/coderwall/content.handlebars
@@ -1,0 +1,1 @@
+{{{parseMD description}}}


### PR DESCRIPTION
This PR fixes the issue described in #2548 

Fixes include: 
* Changing the object passed to `normalize` to match the new Coderwall API response
* A custom handlebars helper to parse any markdown in `description`
* Profile avatar images included in `iconImage`

@moollaza suggested also using `chompContent` to hide descriptions that are too long, but I am not sure how to implement it.

CC: @GuiltyDolphin

---
IA Page: https://duck.co/ia/view/coderwall