### PR TITLE
Switch API to HTTPS

### DIFF
--- a/lib/DDG/Spice/MinecraftStatus.pm
+++ b/lib/DDG/Spice/MinecraftStatus.pm
@@ -6,7 +6,7 @@ use DDG::Spice;
 
 triggers any => 'minecraft', 'mcstatus', 'mc', 'mine craft';
 
-spice to => 'http://mcstatusraw.thedestruc7i0n.ca/';
+spice to => 'https://mcstatusraw.thedestruc7i0n.ca/';
 spice wrap_jsonp_callback => 1;
 
 spice is_cached => 1;


### PR DESCRIPTION
The API switched to HTTPS and so the Spice is currently failing.

This updates the code to use the HTTPS API endpoint.

---
https://duck.co/ia/view/minecraft_status