### PR TITLE
Parking: Update test to support to Australia timezone

### DIFF
--- a/t/Parking.t
+++ b/t/Parking.t
@@ -25,7 +25,7 @@ ddg_spice_test(
         query_raw =>  'parking 21230',
         location => test_location('au')
     ) => test_spice(
-        '/js/spice/parking/21230',
+        '/js/spice/parking/21230/Australia%2FAdelaide',
         call_type => 'include',
         caller => 'DDG::Spice::Parking'
     ),
@@ -101,4 +101,3 @@ ddg_spice_test(
 );
 
 done_testing;
-


### PR DESCRIPTION
The DuckDuckGo package was recently updated and now the Parking test is failing.

This updates the test to pass again.

/cc @zachthompson @GuiltyDolphin 

---
IA PAge: https://duck.co/ia/view/parking