### PR TITLE
MLB Games: Fix location for preseason games

### DIFF
--- a/share/spice/sports/mlb/games/mlb_score.handlebars
+++ b/share/spice/sports/mlb/games/mlb_score.handlebars
@@ -52,7 +52,7 @@
 	</div>
 	<div class="c-score__foot">
 		<div class="c-score__foot__main">
-			<div class="c-score__venue">@ {{venue.market}}<span class="c-score__venue__name"> - {{venue.name}}</span></div>
+			<div class="c-score__venue">@ {{#if venue.market}}{{venue.market}}{{else}}{{venue.city}}{{/if}} <span class="c-score__venue__name"> - {{venue.name}}</span></div>
 			<div class="c-score__foot__more  c-score__opt">
 			{{#if has_ended}}
 				{{#if pitchers}}


### PR DESCRIPTION
Preseason MLB games are often missing a location, as shown here for:
https://duckduckgo.com/?q=mets

![preseason games are missing cities](https://cloud.githubusercontent.com/assets/8975/14256375/c778a4f0-fa66-11e5-9ea5-e81859e4cf90.png)

This PR fixes the issue by falling back to `venue.city` when `venue.market` is blank, which seems to often be the case for preseason games (maybe an idiosyncrasy of the API provider).

Here's the MLB IA page:
https://duck.co/ia/view/sports_mlb_games

cc @moollaza @bsstoner @andrey-p 