### PR TITLE
Reduce API result limit to 20 in accordance with Quixey API changes

### DIFF
--- a/lib/DDG/Spice/Quixey.pm
+++ b/lib/DDG/Spice/Quixey.pm
@@ -41,7 +41,7 @@ triggers any => @triggers;
 
 spice from => '([^/]+)/([^/]+)/?([^/]+)?/?([^/]+)?';
 
-spice to => 'https://api.quixey.com/1.0/search?partner_id=2073823582&partner_secret={{ENV{DDG_SPICE_QUIXEY_APIKEY}}}&q=$1&platform_ids=$2&max_cents=$3&custom_id=$4&limit=50&skip=0&format=json';
+spice to => 'https://api.quixey.com/1.0/search?partner_id=2073823582&partner_secret={{ENV{DDG_SPICE_QUIXEY_APIKEY}}}&q=$1&platform_ids=$2&max_cents=$3&custom_id=$4&limit=20&skip=0&format=json';
 
 spice proxy_ssl_session_reuse => "off";
 


### PR DESCRIPTION
The Quixey API now has a maximum of 20 results for an API call. This updates our API call to the max of 20 from 50.

The IA is currently producing errors on Beta because of this. 

https://beta.duckduckgo.com/js/spice/quixey/flight%20tracking/%5B2004%2C2005%2C2008%2C2015%2C8556073%5D/999999/2414062669

/cc @bsstoner 

IA Page: https://duck.co/ia/view/apps