### PR TITLE
Holiday: False trigger on "California Primary"

### DIFF
--- a/lib/DDG/Spice/Holiday.pm
+++ b/lib/DDG/Spice/Holiday.pm
@@ -38,6 +38,9 @@ handle query_lc => sub {
 
     # Block queries like "a day"
     return if $q =~ /^[a-z1-9]?\ ?day$/;
+    
+    # Block queries like "california primary"
+    return if $q =~ /primary/;
 
     if ($q =~ /([\d]{4})/) {
         $y = $1;

--- a/t/Holiday.t
+++ b/t/Holiday.t
@@ -72,7 +72,9 @@ ddg_spice_test(
     ),
 
     'when is day' => undef,
-    'when is a day' => undef
+    'when is a day' => undef,
+    'when is california primary' => undef,
+    'when is the june primary' => undef
 );
 
 done_testing;


### PR DESCRIPTION
Fixes #2651. This is a crude fix that simply addresses the issue mentioned. Any query with the word "primary" no longer triggers this IA, so this should cover other `<state> primary` searches too.

---
IA Page: http://duck.co/ia/view/holiday