### PR TITLE
Show only one player for audio in dictionary definition

### DIFF
--- a/share/spice/dictionary/definition/dictionary_definition.js
+++ b/share/spice/dictionary/definition/dictionary_definition.js
@@ -184,10 +184,14 @@ var ddg_spice_dictionary = {
         // Audio URL should go to DDG's proxy server for privacy reasons.
         url = '/audio/?u=' + url;
 
-        this.playBtn = new DDG.Views.PlayButton({
-            url: url,
-            after: this.$el.find('.zci__def__pronunciation')
-        });
+        var pronunciationEl = this.$el.find('.zci__def__pronunciation');
+
+        if (pronunciationEl.siblings('[data-url="' + url + '"]').length == 0) {
+            this.playBtn = new DDG.Views.PlayButton({
+                url: url,
+                after: pronunciationEl
+            });
+        }
     }
 }
 


### PR DESCRIPTION
If a player for the same audio file is already present, do not show a new one

This was discussed with @moollaza in #2609, but I feel this is a hacky fix more than an actual one. Shouldn't we find out why the audio is being tried to be added twice instead?

IA Page: https://duck.co/ia/view/dictionary_definition