### PR TITLE
Last.fm: Don't show the IA if there is no biography

### DIFF
--- a/share/spice/lastfm/artist/lastfm_artist.js
+++ b/share/spice/lastfm/artist/lastfm_artist.js
@@ -2,7 +2,7 @@
     "use strict";
 
     env.ddg_spice_lastfm_artist_all = function(api_result) {
-        if (!api_result || !api_result.artist || !api_result.artist.url) { return; }
+        if (!api_result || !api_result.artist || !api_result.artist.url || api_result.artist.bio.content == '') { return; }
 
         Spice.add({
             id: 'lastfm_artist',


### PR DESCRIPTION
**Fixes #2571**
Sometimes authors don't have biography so the IA don't give useful info. Now the IA don't show itself.

---

IA page: https://duck.co/ia/view/lastfm_artist
Maintainer: @jagtalon
