### PR TITLE
Use string relevance for maps

### DIFF
--- a/share/spice/maps/maps/maps_maps.js
+++ b/share/spice/maps/maps/maps_maps.js
@@ -6,7 +6,7 @@ DDG.require('maps',function(){
         // Mapbox sends back a bunch of places, just want the first one for now
         response = response.features[0];
 
-        if (response.relevance < 0.9) {
+        if ((response.place_name && !DDG.isRelevant(response.place_name.toLowerCase())) && response.relevance < 0.9) {
             return Spice.failed('maps_maps');
         }
 

--- a/share/spice/maps/maps/maps_maps.js
+++ b/share/spice/maps/maps/maps_maps.js
@@ -6,7 +6,9 @@ DDG.require('maps',function(){
         // Mapbox sends back a bunch of places, just want the first one for now
         response = response.features[0];
 
-        if (!DDG.isRelevant(response.place_name.toLowerCase()) && response.relevance < 0.9) {
+        var skipArray = [ "directions", "map", "maps" ];
+
+        if ( response.relevance < 0.9 && !( response.place_name && DDG.isRelevant(response.place_name.toLowerCase(), skipArray)) ) {
             return Spice.failed('maps_maps');
         }
 

--- a/share/spice/maps/maps/maps_maps.js
+++ b/share/spice/maps/maps/maps_maps.js
@@ -6,7 +6,7 @@ DDG.require('maps',function(){
         // Mapbox sends back a bunch of places, just want the first one for now
         response = response.features[0];
 
-        if ((response.place_name && !DDG.isRelevant(response.place_name.toLowerCase())) && response.relevance < 0.9) {
+        if (!DDG.isRelevant(response.place_name.toLowerCase()) && response.relevance < 0.9) {
             return Spice.failed('maps_maps');
         }
 


### PR DESCRIPTION
Adding back string based relevancy check for maps. This used to be the relevancy metric before the single point cutoff was put in place.

@bsstoner @andrey-p 