### PR TITLE
Transit IA CSS Fixes

### DIFF
--- a/share/spice/transit/njt/train_item.handlebars
+++ b/share/spice/transit/njt/train_item.handlebars
@@ -1,19 +1,19 @@
-<div class="njt__time text--primary">{{departure_time}}</div>
-<div class="njt__details">
+<div class="transit_njt__time text--primary">{{departure_time}}</div>
+<div class="transit_njt__details">
     {{#if cancelled}}N/A{{else}}Arrives {{arrival_time}}{{/if}}<br/>
     {{line}}<br/>
     Train {{train}}
 </div>
-<div class="njt__status-sep">
-    <div class="njt__sep-line"></div>
-    <div class="njt__badge {{status_class}}"></div>
-    <div class="njt__sep-line"></div>
+<div class="transit_njt__status-sep">
+    <div class="transit_njt__sep-line"></div>
+    <div class="transit_njt__badge {{status_class}}"></div>
+    <div class="transit_njt__sep-line"></div>
 </div>
-<div class="njt__status">
-    <div class="one-line text--secondary {{#if bold_status_text}}njt__bold-status{{/if}}">{{status}}</div>
+<div class="transit_njt__status">
+    <div class="one-line text--secondary {{#if bold_status_text}}transit_njt__bold-status{{/if}}">{{status}}</div>
     {{#if track}}
         <div class="one-line">Track {{track}}</div>
     {{else}}
-        <div class="one-line njt__no-track">Track N/A</div>
+        <div class="one-line transit_njt__no-track">Track N/A</div>
     {{/if}}
 </div>

--- a/share/spice/transit/njt/transit_njt.css
+++ b/share/spice/transit/njt/transit_njt.css
@@ -1,27 +1,27 @@
-.zci--njt .tile--njt {
+.zci--transit_njt .tile--transit_njt {
     text-align: center;
     width: 13em;
 }
 
-.is-mobile .zci--njt .tile--njt {
+.is-mobile .zci--transit_njt .tile--transit_njt {
     width: 12.25em;
 }
 
-.tile--njt .njt__time {
+.tile--transit_njt .transit_njt__time {
     font-size: 2.3em;
     font-weight: 300;
 }
 
-.tile--njt .njt__details {
+.tile--transit_njt .transit_njt__details {
     margin-top: 5px;
     margin-bottom: 10px;
 }
 
-.tile--njt .njt__status-sep {
+.tile--transit_njt .transit_njt__status-sep {
     height: 12px;
 }
 
-.tile--njt .njt__sep-line {
+.tile--transit_njt .transit_njt__sep-line {
     background-color: #e1e1e1;
     height: 1px;
     width: 30px;
@@ -31,12 +31,12 @@
     display: inline-block;
 }
 
-.tile--njt .njt__status {
+.tile--transit_njt .transit_njt__status {
     margin-top: 10px;
     margin-bottom: 2px;
 }
 
-.tile--njt .njt__badge {
+.tile--transit_njt .transit_njt__badge {
     background-color: #e0e0e0;
     height: 12px;
     border-radius: 6px;
@@ -44,33 +44,33 @@
     display: inline-block;
 }
 
-.tile--njt .njt__delayed {
+.tile--transit_njt .transit_njt__delayed {
     background-color: #eea43e;
 }
 
-.tile--njt .njt__boarding {
+.tile--transit_njt .transit_njt__boarding {
     background-color: #60ae50;
 }
 
-.tile--njt .njt__cancelled {
+.tile--transit_njt .transit_njt__cancelled {
     background-color: #e34c2d;
 }
 
-.tile--njt .njt__cancelled-tile {
+.tile--transit_njt .transit_njt__cancelled-tile {
     background-color: #fafafa;
     border-color: #fafafa;
 }
 
-.tile--njt .njt__bold-status {
+.tile--transit_njt .transit_njt__bold-status {
     font-weight: bold;
 }
 
-.tile--njt .njt__cancelled-tile .njt__time,
-.tile--njt .njt__cancelled-tile .njt__details,
-.tile--njt .njt__cancelled-tile .njt__status {
+.tile--transit_njt .transit_njt__cancelled-tile .transit_njt__time,
+.tile--transit_njt .transit_njt__cancelled-tile .transit_njt__details,
+.tile--transit_njt .transit_njt__cancelled-tile .transit_njt__status {
     color: #bbb;
 }
 
-.tile--njt .njt__no-track {
+.tile--transit_njt .transit_njt__no-track {
     color: #aaa;
 }

--- a/share/spice/transit/path/train_item.handlebars
+++ b/share/spice/transit/path/train_item.handlebars
@@ -1,5 +1,5 @@
-<div class="path__time text--primary">{{departure_time}}</div>
-<div class="path__details">
+<div class="transit_path__time text--primary">{{departure_time}}</div>
+<div class="transit_path__details">
     {{#if cancelled}}N/A{{else}}Arrives {{arrival_time}}{{/if}}<br/>
     {{line}}<br/>
 </div>

--- a/share/spice/transit/path/transit_path.css
+++ b/share/spice/transit/path/transit_path.css
@@ -1,20 +1,20 @@
-.zci--path .tile--path {
+.zci--transit_path .tile--transit_path {
     text-align: center;
     width: 13em;
 }
 
 @media screen and (max-device-width: 640px) and (orientation: portrait){
-	.is-mobile .zci--path .tile--path {
+	.is-mobile .zci--transit_path .tile--transit_path {
 	    width: 48%;
 	}
 }
 
-.tile--path .path__time {
+.tile--transit_path .transit_path__time {
     font-size: 2.3em;
     font-weight: 300;
 }
 
-.tile--path .path__details {
+.tile--transit_path .transit_path__details {
     margin-top: 5px;
     margin-bottom: 5px;
 }

--- a/share/spice/transit/septa/train_item.handlebars
+++ b/share/spice/transit/septa/train_item.handlebars
@@ -1,14 +1,14 @@
-<div class="septa__time text--primary">{{departure_time}}</div>
-<div class="septa__details">
+<div class="transit_septa__time text--primary">{{departure_time}}</div>
+<div class="transit_septa__details">
     {{#if cancelled}}N/A{{else}}Arrives {{arrival_time}}{{/if}}<br/>
     {{line}}<br/>
     Train {{orig_train}}
 </div>
-<div class="septa__status-sep">
-    <div class="septa__sep-line"></div>
-    <div class="septa__badge {{status_class}}"></div>
-    <div class="septa__sep-line"></div>
+<div class="transit_septa__status-sep">
+    <div class="transit_septa__sep-line"></div>
+    <div class="transit_septa__badge {{status_class}}"></div>
+    <div class="transit_septa__sep-line"></div>
 </div>
-<div class="septa__status text--secondary">
+<div class="transit_septa__status text--secondary">
     <div class="one-line">{{status}}</div>
 </div>

--- a/share/spice/transit/septa/transit_septa.css
+++ b/share/spice/transit/septa/transit_septa.css
@@ -1,23 +1,23 @@
-.zci--septa .tile--septa {
+.zci--transit_septa .tile--transit_septa {
     text-align: center;
     width: 13em;
 }
 
-.tile--septa .septa__time {
+.tile--transit_septa .septa__time {
     font-size: 2.3em;
     font-weight: 300;
 }
 
-.tile--septa .septa__details {
+.tile--transit_septa .septa__details {
     margin-top: 5px;
     margin-bottom: 10px;
 }
 
-.tile--septa .septa__status-sep {
+.tile--transit_septa .septa__status-sep {
     height: 12px;
 }
 
-.tile--septa .septa__sep-line {
+.tile--transit_septa .septa__sep-line {
     background-color: #e1e1e1;
     height: 1px;
     width: 30px;
@@ -27,12 +27,12 @@
     display: inline-block;
 }
 
-.tile--septa .septa__status {
+.tile--transit_septa .septa__status {
     margin-top: 10px;
     margin-bottom: 2px;
 }
 
-.tile--septa .septa__badge {
+.tile--transit_septa .septa__badge {
     background-color: #60AE50;
     height: 12px;
     border-radius: 6px;
@@ -40,21 +40,21 @@
     display: inline-block;
 }
 
-.tile--septa .septa__delayed {
+.tile--transit_septa .septa__delayed {
     background-color: #eea43e;
 }
 
-.tile--septa .septa__cancelled {
+.tile--transit_septa .septa__cancelled {
     background-color: #e34c2d;
 }
 
-.tile--septa .septa__cancelled-tile {
+.tile--transit_septa .septa__cancelled-tile {
     background-color: #fafafa;
     border-color: #fafafa;
 }
 
-.tile--septa .septa__cancelled-tile .septa__time,
-.tile--septa .septa__cancelled-tile .septa__details,
-.tile--septa .septa__cancelled-tile .septa__status {
+.tile--transit_septa .septa__cancelled-tile .septa__time,
+.tile--transit_septa .septa__cancelled-tile .septa__details,
+.tile--transit_septa .septa__cancelled-tile .septa__status {
     color: #bbb;
 }

--- a/share/spice/transit/septa/transit_septa.css
+++ b/share/spice/transit/septa/transit_septa.css
@@ -3,21 +3,21 @@
     width: 13em;
 }
 
-.tile--transit_septa .septa__time {
+.tile--transit_septa .transit_septa__time {
     font-size: 2.3em;
     font-weight: 300;
 }
 
-.tile--transit_septa .septa__details {
+.tile--transit_septa .transit_septa__details {
     margin-top: 5px;
     margin-bottom: 10px;
 }
 
-.tile--transit_septa .septa__status-sep {
+.tile--transit_septa .transit_septa__status-sep {
     height: 12px;
 }
 
-.tile--transit_septa .septa__sep-line {
+.tile--transit_septa .transit_septa__sep-line {
     background-color: #e1e1e1;
     height: 1px;
     width: 30px;
@@ -27,12 +27,12 @@
     display: inline-block;
 }
 
-.tile--transit_septa .septa__status {
+.tile--transit_septa .transit_septa__status {
     margin-top: 10px;
     margin-bottom: 2px;
 }
 
-.tile--transit_septa .septa__badge {
+.tile--transit_septa .transit_septa__badge {
     background-color: #60AE50;
     height: 12px;
     border-radius: 6px;
@@ -40,21 +40,21 @@
     display: inline-block;
 }
 
-.tile--transit_septa .septa__delayed {
+.tile--transit_septa .transit_septa__delayed {
     background-color: #eea43e;
 }
 
-.tile--transit_septa .septa__cancelled {
+.tile--transit_septa .transit_septa__cancelled {
     background-color: #e34c2d;
 }
 
-.tile--transit_septa .septa__cancelled-tile {
+.tile--transit_septa .transit_septa__cancelled-tile {
     background-color: #fafafa;
     border-color: #fafafa;
 }
 
-.tile--transit_septa .septa__cancelled-tile .septa__time,
-.tile--transit_septa .septa__cancelled-tile .septa__details,
-.tile--transit_septa .septa__cancelled-tile .septa__status {
+.tile--transit_septa .transit_septa__cancelled-tile .transit_septa__time,
+.tile--transit_septa .transit_septa__cancelled-tile .transit_septa__details,
+.tile--transit_septa .transit_septa__cancelled-tile .transit_septa__status {
     color: #bbb;
 }

--- a/share/spice/transit/switzerland/train_item.handlebars
+++ b/share/spice/transit/switzerland/train_item.handlebars
@@ -1,15 +1,15 @@
-<div class="switzerland__time text--primary">{{departure_time}}</div>
-<div class="switzerland__details">
+<div class="transit_switzerland__time text--primary">{{departure_time}}</div>
+<div class="transit_switzerland__details">
     {{#if cancelled}}N/A{{else}}Arrives {{arrival_time}}{{/if}}<br/>
     {{transfers}}<br/>
     Train {{name}}
 </div>
-<div class="switzerland__status-sep">
-    <div class="switzerland__sep-line"></div>
-    <div class="switzerland__badge {{status_class}}"></div>
-    <div class="switzerland__sep-line"></div>
+<div class="transit_switzerland__status-sep">
+    <div class="transit_switzerland__sep-line"></div>
+    <div class="transit_switzerland__badge {{status_class}}"></div>
+    <div class="transit_switzerland__sep-line"></div>
 </div>
-<div class="switzerland__status">
+<div class="transit_switzerland__status">
     <div class="one-line">{{status}}</div>
     {{#if platform}}
         <div class="one-line">Platform {{platform}}</div>
@@ -17,5 +17,3 @@
         <div class="one-line tx-clr--lt2">Platform N/A</div>
     {{/if}}
 </div>
-
-

--- a/share/spice/transit/switzerland/transit_switzerland.css
+++ b/share/spice/transit/switzerland/transit_switzerland.css
@@ -1,29 +1,29 @@
-.zci--switzerland .tile--switzerland {
+.zci--transit_switzerland .tile--transit_switzerland {
     text-align: center;
     width: 13em;
 }
 
 @media screen and (max-device-width: 640px) and (orientation: portrait){
-	.is-mobile .zci--switzerland .tile--switzerland {
+	.is-mobile .zci--transit_switzerland .tile--transit_switzerland {
 	    width: 48%;
 	}
 }
 
-.tile--switzerland .switzerland__time {
+.tile--transit_switzerland .transit_switzerland__time {
     font-size: 2.3em;
     font-weight: 300;
 }
 
-.tile--switzerland .switzerland__details {
+.tile--transit_switzerland .transit_switzerland__details {
     margin-top: 5px;
     margin-bottom: 10px;
 }
 
-.tile--switzerland .switzerland__status-sep {
+.tile--transit_switzerland .transit_switzerland__status-sep {
     height: 12px;
 }
 
-.tile--switzerland .switzerland__sep-line {
+.tile--transit_switzerland .transit_switzerland__sep-line {
     background-color: #e1e1e1;
     height: 1px;
     width: 30px;
@@ -33,12 +33,12 @@
     display: inline-block;
 }
 
-.tile--switzerland .switzerland__status {
+.tile--transit_switzerland .transit_switzerland__status {
     margin-top: 10px;
     margin-bottom: 2px;
 }
 
-.tile--switzerland .switzerland__badge {
+.tile--transit_switzerland .transit_switzerland__badge {
     background-color: #60ae50;
     height: 12px;
     border-radius: 6px;
@@ -46,6 +46,6 @@
     display: inline-block;
 }
 
-.tile--switzerland .switzerland__delayed {
+.tile--transit_switzerland .transit_switzerland__delayed {
     background-color: #eea43e;
 }


### PR DESCRIPTION
I recently changed the ID's of the four Transit IA's to be more canonical as we ran into some internal issues with the current ID's because they didn't follow the standard convention.

I didn't properly test these changes and noticed today that the CSS has been broken since changing the ID's.

This PR updates the CSS and handlebars templates to match the new IDs.

I've tested it locally and everything looks correct again.

---
https://duck.co/ia/view/transit_septa
https://duck.co/ia/view/transit_path
https://duck.co/ia/view/transit_njt
https://duck.co/ia/view/transit_switzerland