### PR TITLE
XKCD IA: Override title for 1137

### DIFF
--- a/share/spice/xkcd/display/xkcd_display.js
+++ b/share/spice/xkcd/display/xkcd_display.js
@@ -17,6 +17,11 @@
                 api_result.img = 'http://imgs.xkcd.com/comics/now/12h30m.png';
             }
             
+            // #1137 returns â®LTR from the API (http://xkcd.com/1137/info.0.json), where it should really be the right-to-left override character (&#8238)
+            if (api_result.num === 1137) {
+                api_result.title = 'RTL';
+            }
+
             var months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
             api_result.month = months[parseInt(api_result.month)-1];
     


### PR DESCRIPTION
Fixes #2663 

Unfortunately http://xkcd.com/1137/info.0.json is giving us back `â®LTR` as the title. There is no programmatic way of knowing there was a specific unicode character in the title, so I went with a hardcoded override here. This seems a bit kludgey, but it is a way forward. If more overrides like this come to be necessary we might think of a better framework than a bunch of if-statments in the code.

https://duck.co/ia/view/xkcd