### PR TITLE
Restrict similar to to allow only one word for 2681

### DIFF
--- a/lib/DDG/Spice/WordMap.pm
+++ b/lib/DDG/Spice/WordMap.pm
@@ -37,10 +37,8 @@ triggers start => (
     "more words like"
 );
 
-my $regex = qr/^similar to (\w+)$/;
-triggers query_raw => $regex;
-
 handle remainder => sub {
+    return unless /^(.*) (like|to) (\w+)$/
     return lc $_ if $_;
     return;
 };

--- a/lib/DDG/Spice/WordMap.pm
+++ b/lib/DDG/Spice/WordMap.pm
@@ -38,7 +38,7 @@ triggers start => (
 );
 
 handle remainder => sub {
-    return unless /^(.*) (like|to) (\w+)$/
+    return unless /^(.*) (like|to) (\w+)$/;
     return lc $_ if $_;
     return;
 };

--- a/lib/DDG/Spice/WordMap.pm
+++ b/lib/DDG/Spice/WordMap.pm
@@ -37,6 +37,9 @@ triggers start => (
     "more words like"
 );
 
+my $regex = qr/^similar to (\w+)$/;
+triggers query_raw => $regex;
+
 handle remainder => sub {
     return lc $_ if $_;
     return;

--- a/lib/DDG/Spice/WordMap.pm
+++ b/lib/DDG/Spice/WordMap.pm
@@ -38,7 +38,7 @@ triggers start => (
 );
 
 handle remainder => sub {
-    return unless /^(.*) (like|to) (\w+)$/;
+    return unless /^(\w+)$/;
     return lc $_ if $_;
     return;
 };

--- a/t/WordMap.t
+++ b/t/WordMap.t
@@ -20,6 +20,7 @@ ddg_spice_test(
         '/js/spice/word_map/sound',
         caller    => 'DDG::Spice::WordMap',
     ),
+    'similar to multi word query' => undef,
 );
 
 done_testing;


### PR DESCRIPTION
Issue: https://github.com/duckduckgo/zeroclickinfo-spice/issues/2681

This fix adds a regex trigger to allow one word after similar to per the issue description.  Other rules may need to be added such as "words like"

---
https://duck.co/ia/view/word_map
Maintainer: @twinword 