### PR TITLE
GitHub Status triggers

### DIFF
--- a/lib/DDG/Spice/GithubStatus.pm
+++ b/lib/DDG/Spice/GithubStatus.pm
@@ -5,7 +5,12 @@ use strict;
 use DDG::Spice;
 use Text::Trim;
 
-triggers startend => 'github';
+triggers start => "github status", "github system status";
+
+handle remainder => sub {
+    return if $_; #
+    return '';
+};
 
 spice to => 'https://status.github.com/api/last-message.json?callback={{callback}}';
 spice proxy_cache_valid => "418 1d";


### PR DESCRIPTION
Changed trigger for github_status so that is not triggered by the query 'github', as of issue #2513.

I am not sure if the issue was already solved by @theaverageguy, if that is the case, just ignore my pull request. :)

https://duck.co/ia/view/github_status
Maintainer: @Feral2k
