### PR TITLE
Hex IA: Limit the string length for the subtitle, contributor and maintainer sections

### DIFF
--- a/share/spice/hex/hex.js
+++ b/share/spice/hex/hex.js
@@ -1,4 +1,4 @@
-/* globals Spice, DDG, moment */
+/* globals Spice, DDG, moment, Handlebars */
 (function(env) {
     'use strict';
 
@@ -24,21 +24,21 @@
 
                     if (Array.isArray(item.meta.maintainers) && item.meta.maintainers.length > 0) {
                         infoboxData.push({
-                            label: (item.meta.maintainers.length > 1) ? 'Maintainers' : 'Maintainer',
-                            value: item.meta.maintainers.join(', ')
+                            label: DDG.pluralize(item.meta.maintainers.length, 'Maintainer'),
+                            value: Handlebars.helpers.ellipsis(item.meta.maintainers.join(', '), 50)
                         });
                     }
 
                     if (Array.isArray(item.meta.contributors) && item.meta.contributors.length > 0) {
                         infoboxData.push({
-                            label: (item.meta.contributors.length > 1) ? 'Contributors' : 'Contributor',
-                            value: item.meta.contributors.join(', ')
+                            label: DDG.pluralize(item.meta.contributors.length, 'Contributor'),
+                            value: Handlebars.helpers.ellipsis(item.meta.contributors.join(', '), 50)
                         });
                     }
 
                     if (Array.isArray(item.meta.licenses) && item.meta.licenses.length > 0) {
                         infoboxData.push({
-                            label: (item.meta.licenses.length > 1) ? 'Licenses' : 'License',
+                            label: DDG.pluralize(item.meta.licenses.length, 'License'),
                             value: item.meta.licenses.join(', ')
                         });
                     }
@@ -64,13 +64,13 @@
                     item.numberOfLinks = Object.keys(item.meta.links).length;
 
                     if (item.numberOfLinks > 0) {
-                        item.linkLabel = (item.numberOfLinks > 1) ? 'links' : 'link';
+                        item.linkLabel = DDG.pluralize(item.numberOfLinks, 'link');
                     }
 
                     return {
                         title: item.name + ' ' + item.releases[0].version,
                         url: item.url,
-                        subtitle: item.meta.description,
+                        subtitle: Handlebars.helpers.ellipsis(item.meta.description, 50),
                         infoboxData: infoboxData
                     };
                 },


### PR DESCRIPTION
This commit fixes an issue found by @moollaza, which appears in Elixir packages with a long description (e.g. [math](https://hex.pm/packages/math)), you can find more details about the issue [here](https://github.com/duckduckgo/zeroclickinfo-spice/pull/2690#issuecomment-211601869)

Also, with this commit, you can see a custom Handlebars helper to return the singular or plural form of a given word base on the value of a number.

----
Hex IA page: https://duck.co/ia/view/hex