### PR TITLE
Specifically target xkcd separators when running mobile enhancement

### DIFF
--- a/share/spice/xkcd/display/xkcd_display.js
+++ b/share/spice/xkcd/display/xkcd_display.js
@@ -98,7 +98,7 @@
             });
             
             if (is_mobile) {
-                $('.c-base__sub .sep').first().replaceWith("<br>");
+                $('.zci--xkcd .c-base__sub .sep').first().replaceWith("<br>");
             }
         });
         


### PR DESCRIPTION
Per the suggestion in #2673, making the mobile enhancement safer for XKCD IA.

https://duck.co/ia/view/xkcd