### PR TITLE
Initial Commit on Spice IA : Biblio Search

### DIFF
--- a/lib/DDG/Spice/BiblioSearch/BooksByAuthor.pm
+++ b/lib/DDG/Spice/BiblioSearch/BooksByAuthor.pm
@@ -1,0 +1,53 @@
+package DDG::Spice::BiblioSearch::BooksByAuthor;
+# ABSTRACT: This module fetches books authored by a person searched for in DDG.
+
+use strict;
+use DDG::Spice;
+use URI::Escape;
+
+# Caching - https://duck.co/duckduckhack/spice_advanced_backend#caching-api-responses
+spice is_cached => 1;
+
+# Metadata.  See https://duck.co/duckduckhack/metadata for help in filling out this section.
+name "BiblioSearch - Books By Author";
+source "Goodreads";
+icon_url "https://www.goodreads.com/images/icons/goodreads_icon_32x32.png";
+description "Displays a list of books written/co-writen/edited by certain author.";
+primary_example_queries "Books by Arundhati Roy, Books authored by Shakespeare";
+code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/BiblioSearch/BooksByAuthor.pm";
+attribution github => ["iammrigank", "Mriganka Ghosh"],
+            twitter => "tweetmrigank";
+
+# Goodreads API endpoint
+my $api_key = '{{ENV{DDG_SPICE_BIBLIOSEARCH_GODREADS_APIKEY}}}';
+my $api_search_endpoint = uri_escape("https://www.goodreads.com/search/index.xml?key=") . $api_key . uri_escape("&search[field]=authors&q=") . '$1';
+
+spice to => 'https://duckduckgo.com/x.js?u=' . $api_search_endpoint;
+spice wrap_jsonp_callback => 1;
+
+# Triggers - https://duck.co/duckduckhack/spice_triggers
+# my $trigger_regex = qr{^(list )?(of )?book(s)? (authored |written )?(of|by)?};
+
+triggers startend => (
+    "books by",
+    "book by",
+    "books of",
+    "book of",
+    "books written by",
+    "book written by",
+    "books authored by",
+    "book authored by",
+    "list of books by",
+    "list of books written by",
+    "list of books authored by"
+);
+
+# Handle statement
+handle remainder_lc => sub {
+    return unless qr{^\w+};
+
+    return $_ if $_;
+    return;
+};
+
+1;

--- a/lib/DDG/Spice/BiblioSearch/BooksOnPersonality.pm
+++ b/lib/DDG/Spice/BiblioSearch/BooksOnPersonality.pm
@@ -1,0 +1,54 @@
+package DDG::Spice::BiblioSearch::BooksOnPersonality;
+# ABSTRACT: This module fetches books authored by a person searched for in DDG.
+
+use strict;
+use DDG::Spice;
+use URI::Escape;
+
+# Caching - https://duck.co/duckduckhack/spice_advanced_backend#caching-api-responses
+spice is_cached => 1;
+
+# Metadata.  See https://duck.co/duckduckhack/metadata for help in filling out this section.
+name "BiblioSearch - Books On Personality";
+source "Goodreads";
+icon_url "https://www.goodreads.com/images/icons/goodreads_icon_32x32.png";
+description "Displays a list of books written about a certain person/topic. This might include books written by the same person.";
+primary_example_queries "Books on Kurt Cobain, Books about Tata";
+code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/BiblioSearch/BooksOnPersonality.pm";
+attribution github => ["iammrigank", "Mriganka Ghosh"],
+            twitter => "tweetmrigank";
+
+# API endpoint
+my $api_key = '{{ENV{DDG_SPICE_BIBLIOSEARCH_GODREADS_APIKEY}}}';
+my $api_search_endpoint = uri_escape("https://www.goodreads.com/search/index.xml?key=") . $api_key . uri_escape("&search[field]=title&q=") . '$1';
+
+spice to => 'https://duckduckgo.com/x.js?u=' . $api_search_endpoint;
+spice wrap_jsonp_callback => 1;
+
+# my $trigger_regex = qr{^(list )?(of )?book(s)? (about|on)?};
+
+# Triggers - https://duck.co/duckduckhack/spice_triggers
+triggers startend => (
+    "books on",
+    "book on",
+    "books about",
+    "book about",
+    "books written by on",
+    "book written by on",
+    "books authored on",
+    "book authored on",
+    "list of books on",
+    "list of books written on"
+);
+  
+# Handle statement
+handle query_lc => sub {
+
+    # optional - regex guard
+    return unless qr/^\w+/;
+    return unless $_;
+    
+    return $_;
+};
+
+1;

--- a/lib/DDG/Spice/BiblioSearch/GetBookDetails.pm
+++ b/lib/DDG/Spice/BiblioSearch/GetBookDetails.pm
@@ -1,0 +1,22 @@
+package DDG::Spice::BiblioSearch::GetBookDetails;
+
+use strict;
+use DDG::Spice;
+use URI::Escape;
+
+triggers any => '///***never_trigger***///';
+
+my $api_key = '{{ENV{DDG_SPICE_BIBLIOSEARCH_GODREADS_APIKEY}}}';
+# my $api_search_endpoint = uri_escape("https://www.goodreads.com/book/isbn?format=xml&key=") . $api_key . uri_escape("&isbn=") . '$1';
+my $api_search_endpoint = uri_escape("https://www.goodreads.com/book/show/") . '$1' . uri_escape("?format=xml&key=") . $api_key;
+
+spice to => 'https://duckduckgo.com/x.js?u=' . $api_search_endpoint;
+
+spice is_cached => 1;
+spice proxy_cache_valid => "200 30d";
+
+handle query_lc => sub {
+    return $_ if $_;
+    return;
+};
+1;

--- a/lib/DDG/Spice/BiblioSearch/GetImageForBook.pm
+++ b/lib/DDG/Spice/BiblioSearch/GetImageForBook.pm
@@ -1,0 +1,18 @@
+package DDG::Spice::BiblioSearch::GetImageForBook;
+
+use strict;
+use DDG::Spice;
+use URI::Escape;
+
+triggers any => '///***do not trigger***///';
+
+spice to => 'https://duckduckgo.com/m.js?q=$1';
+
+spice is_cached => 1;
+spice proxy_cache_valid => "200 30d";
+
+handle query_lc => sub {
+    return $_ if $_;
+    return;
+};
+1;

--- a/share/spice/biblio_search/books_by_author/biblio_search_books_by_author.handlebars
+++ b/share/spice/biblio_search/books_by_author/biblio_search_books_by_author.handlebars
@@ -1,0 +1,4 @@
+<span>{{name}}</span>
+<a href="http://some.url/profile/data1">
+   <img src="/iu/?u=Place a image url here">
+</a>

--- a/share/spice/biblio_search/books_by_author/biblio_search_books_by_author.js
+++ b/share/spice/biblio_search/books_by_author/biblio_search_books_by_author.js
@@ -1,0 +1,90 @@
+(function(env) {
+  "use strict";
+
+  env.ddg_spice_biblio_search_books_by_author = function(api_result) {
+    console.info(api_result);
+    
+    String.prototype.trunc = String.prototype.trunc ||
+      function(n){
+          return (this.length > n) ? this.substr(0,n-1)+'&hellip;' : this;
+      };
+
+    // Validating response
+    if(!api_result || api_result.GoodreadsResponse.search["total-results"].text == "0") {
+      return Spice.failed('biblio_search_books_by_authors');
+    }
+    var author_name = api_result.GoodreadsResponse.search.query.text,
+      source_url = "https://www.goodreads.com/search?utf8=✓&q=" + author_name + "&search_type=books&search%5Bfield%5D=author";
+    
+    var get_details_uri = '/js/spice/biblio_search/get_book_details/',
+      get_image_for_book_uri = '/js/spice/biblio_search/get_image_for_book/';
+    
+    // Render the response
+    Spice.add({
+      id: "biblio_search_books_by_authors",
+      // Customize these properties
+      name: "Books",
+      data: api_result.GoodreadsResponse.search.results.work,
+      meta: {
+        primaryText: "Books by " + author_name,
+        sourceName: "GoodReads",
+        sourceUrl: source_url
+      },
+      onItemShown: function(item) {
+        $.ajaxSetup({ cache: true });
+        
+        // Good reads description API
+        $.getJSON(get_details_uri + item.best_book.id.text, function(data) {
+          console.info(data);
+          
+          var description = data.GoodreadsResponse.book.description.text || "-- No Description Found --";
+          
+          // The desciption might contain some html tags. Removing those...
+          item['abstract'] = description && description.replace(/<\/?\w*>/gm, '').trunc(400);
+          item['heading'] = item.best_book.title.text;
+          item['isbn'] = data.GoodreadsResponse.book.isbn && data.GoodreadsResponse.book.isbn.text;
+          item['isbn13'] = data.GoodreadsResponse.book.isbn13 && data.GoodreadsResponse.book.isbn13.text;
+          
+          $.getJSON(get_image_for_book_uri + data.GoodreadsResponse.book.isbn13.text, function(image_object) {
+            console.info(image_object);
+            item['img_m'] = image_object.results[0].img_m;
+          });
+        });
+      },
+      normalize: function(item) {
+        return {
+          url: "https://www.goodreads.com/book/show/" + item.best_book.id.text,
+          //               description: "by " + item.best_book.author.name.text,
+          title: item.best_book.title.text,
+          image: item.best_book.image_url.text,
+          img_m: item.best_book.image_url.text,
+          rating: parseFloat(item.average_rating.text),
+          ratingText: item.average_rating.text,
+          brand: item.best_book.author.name.text,
+          reviewCount: parseInt(item.text_reviews_count.text)
+        };
+      },
+      templates: {
+        item: 'basic_image_item',
+        item_detail: 'products_item_detail',
+        wrap_detail: 'base_detail',
+        options: {
+          rating: true,
+          brand: true,
+          moreAt: true,
+//           subtitle_content: DDH.biblio_search.subtitle_content
+        },
+        /*
+              group: "info",
+              item_detail: "products_item_detail",//"media_item_detail",
+              options: {
+                  content: Spice.biblio_search_books_by_author.content,
+                  moreAt: true
+              }*/
+        variants: {
+          tile: 'poster'
+        }
+      }
+    });
+  };
+}(this));

--- a/share/spice/biblio_search/books_on_personality/biblio_search_books_on_personality.js
+++ b/share/spice/biblio_search/books_on_personality/biblio_search_books_on_personality.js
@@ -1,0 +1,85 @@
+(function(env) {
+  "use strict";
+
+  env.ddg_spice_biblio_search_books_on_personality = function(api_result) {
+    console.info(api_result);
+    
+    String.prototype.trunc = String.prototype.trunc ||
+      function(n){
+          return (this.length > n) ? this.substr(0,n-1)+'&hellip;' : this;
+      };
+    
+    // Validating response
+    if(!api_result || api_result.GoodreadsResponse.search["total-results"].text == "0") {
+      return Spice.failed('biblio_search_books_by_authors');
+    }
+    
+    var personality = api_result.GoodreadsResponse.search.query.text,
+      source_url = "https://www.goodreads.com/search?q=" + personality + "&search_type=books";
+    
+    var get_details_uri = '/js/spice/biblio_search/get_book_details/',
+      get_image_for_book_uri = '/js/spice/biblio_search/get_image_for_book/';
+    
+    // Render the response
+    Spice.add({
+      id: "biblio_search_books_on_personality",
+      
+      // Customize these properties
+      name: "Books",
+      data: api_result.GoodreadsResponse.search.results.work,
+      meta: {
+        primaryText: "Books on " + personality,
+        sourceName: "GoodReads",
+        sourceUrl: source_url
+      },
+      onItemShown: function(item) {
+        $.ajaxSetup({ cache: true });
+        
+        // Good reads description API
+        $.getJSON(get_details_uri + item.best_book.id.text, function(data) {
+          console.info(data);
+          
+          var description = data.GoodreadsResponse.book.description.text || "-- No Description Found --";
+          
+          // The desciption might contain some html tags. Removing those...
+          item['abstract'] = description && description.replace(/<\/?\w*>/gm, '').trunc(400);
+          item['heading'] = item.best_book.title.text;
+          item['isbn'] = data.GoodreadsResponse.book.isbn && data.GoodreadsResponse.book.isbn.text;
+          item['isbn13'] = data.GoodreadsResponse.book.isbn13 && data.GoodreadsResponse.book.isbn13.text;
+          
+          $.getJSON(get_image_for_book_uri + data.GoodreadsResponse.book.isbn13.text, function(image_object) {
+            console.info("image_object:\n");
+            console.info(image_object);
+            item['img_m'] = image_object.results[0].img_m || item['img_m'];
+          });
+        });
+      },
+      normalize: function(item) {
+        return {
+          url: "https://www.goodreads.com/book/show/" + item.best_book.id.text,
+          title: item.best_book.title.text,
+          image: item.best_book.image_url.text,
+          img_m: item.best_book.image_url.text,
+          rating: parseFloat(item.average_rating.text),
+          ratingText: item.average_rating.text,
+          brand: item.best_book.author.name.text,
+          reviewCount: item.text_reviews_count && parseInt(item.text_reviews_count.text) || "Not Found"
+        };
+      },
+      templates: {
+        item: 'basic_image_item',
+        item_detail: 'products_item_detail',
+        wrap_detail: 'base_detail',
+        options: {
+          rating: true,
+          brand: true,
+          moreAt: true,
+          subtitle_content: Spice.biblio_search.subtitle_content
+        },
+        variants: {
+          tile: 'poster'
+        }
+      }
+    });
+  };
+}(this));

--- a/share/spice/biblio_search/subtitle_content.handlebars
+++ b/share/spice/biblio_search/subtitle_content.handlebars
@@ -1,0 +1,4 @@
+{{#if isbn}}
+<h1> {{isbn}} </h1>
+{{/if}}
+<h1> YOLO </h1>

--- a/t/BiblioSearch.t
+++ b/t/BiblioSearch.t
@@ -1,0 +1,26 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+spice is_cached => 1;
+
+ddg_spice_test(
+    [qw( DDG::Spice::BooksAndAuthors)],
+    # At a minimum, be sure to include tests for all:
+    # - primary_example_queries
+    # - secondary_example_queries
+    'example query' => test_spice(
+        '/js/spice/books_and_authors/query',
+        call_type => 'include',
+        caller => 'DDG::Spice::BooksAndAuthors'
+    ),
+    # Try to include some examples of queries on which it might
+    # appear that your answer will trigger, but does not.
+    'bad example query' => undef,
+);
+
+done_testing;
+


### PR DESCRIPTION
Hello, this is a new IA called Biblio Search intended for searching books and works of authors and personalities on DDG. This IA intends to show the ratings of the book, description about the story and details of the books. I am trying to figure out how to add reviews but it's not done yet. 
The info about the books are made available from **GoodReads** and **Amazon**. 
I would like to include a `Reviews of {BookName}` button that takes user to GR review page. 
Work is still left on this but I wanted to have this code checked before proceeding.

An important thing to consider is how the IA currently works. The IA on search request makes call to search api of GR and fetches the results. During `onItemShown` GR description api is called to get the details of the book including ISBN. amazon api is then called for using ISBN. the intension behind this is that the GR api, due to their policy restrictions, does not provide images for all books. 

This was the short description on the IA. Hope it will contribute in making DDG cooler.

Link to IA : https://duck.co/ia/view/bibliosearch