### PR TITLE
Use new GBFS feed for CitiBike NYC

### DIFF
--- a/lib/DDG/Spice/BikeSharing/CitiBikeNYC.pm
+++ b/lib/DDG/Spice/BikeSharing/CitiBikeNYC.pm
@@ -5,7 +5,7 @@ use DDG::Spice;
 
 triggers any => 'citibike', 'citi bike', 'bike sharing', 'bike share', 'bikeshare';
 
-spice to => 'https://www.citibikenyc.com/stations/json';
+spice to => 'https://gbfs.citibikenyc.com/gbfs/en/station_information.json';
 spice wrap_jsonp_callback => 1;
 spice is_cached => 0;
 spice proxy_cache_valid => '200 304 15m';

--- a/share/spice/bike_sharing/citi_bike_nyc/bike_sharing_citi_bike_nyc.js
+++ b/share/spice/bike_sharing/citi_bike_nyc/bike_sharing_citi_bike_nyc.js
@@ -16,80 +16,101 @@
         }
     };
 
+    function get_query() {
+        var script = $('[src*="/js/spice/bike_sharing/citi_bike_nyc/"]')[0],
+            source = $(script).attr("src");
+        return source.match(/citi_bike_nyc\/([^\/]+)/)[1];
+    }
+
     env.ddg_spice_bike_sharing_citi_bike_nyc = function(api_result) {
-        if (!api_result || !api_result.stationBeanList) {
+        if (!api_result || !api_result.data || !api_result.data.stations) {
             return Spice.failed('citi_bike_nyc');
         }
 
-        var script = $('[src*="/js/spice/bike_sharing/citi_bike_nyc/"]')[0],
-            source = $(script).attr("src"),
-            query = source.match(/citi_bike_nyc\/([^\/]+)/)[1];
+        $.getJSON("https://gbfs.citibikenyc.com/gbfs/en/station_status.json")
+            .done(function(status_api_result) {
+                if (!status_api_result || !status_api_result.data || !status_api_result.data.stations) {
+                    return Spice.failed('citi_bike_nyc');
+                }
 
-        DDG.require(['moment.js', 'maps'], function() {
-            moment.locale('en', {
-                relativeTime : {
-                    past: "%s ago",
-                    s:    "1 sec",
-                    ss:   "%d sec",
-                    m:    "1 min",
-                    mm:   "%d min",
-                    h:    "1 hour",
-                    hh:   "%d hours",
-                    d:    "1 day",
-                    dd:   "%d days",
-                    M:    "1 month",
-                    MM:   "%d months",
-                    y:    "1 year",
-                    yy:   "%d years"
-                }
-            });
-            Spice.add({
-                id: 'citi_bike_nyc',
-                name: 'Bike Sharing',
-                meta: {
-                    sourceName: 'Citi Bike NYC',
-                    sourceUrl: 'https://www.citibikenyc.com/stations',
-                    primaryText: 'Showing ' + api_result.stationBeanList.length + ' Stations',
-                    pinIcon: 'ddgsi-circle',
-                    pinIconSelected: 'ddgsi-star'
-                },
-                model: 'Place',
-                view: 'Places',
-                templates: {
-                    item: 'base_item',
-                    options: {
-                        content: Spice.bike_sharing_citi_bike_nyc.content
-                    },
-                    variants: {
-                        tile: 'narrow'
+                var stations_information = api_result.data.stations.reduce(function(stations, station) {
+                    stations[station.station_id] = station;
+                    return stations;
+                }, {});
+
+                var full_data = status_api_result.data.stations.map(function(station_status) {
+                    var station_information = stations_information[station_status.station_id];
+                    if (station_information) {
+                        return $.extend({}, station_status, station_information);
                     }
-                },
-                sort_fields: {
-                    distance: function(a, b) {
-                        return a.distanceToReference - b.distanceToReference;
-                    }
-                },
-                sort_default: 'distance',
-                data: api_result.stationBeanList,
-                normalize: function(item) {
-                    if (item.testStation || item.statusKey != 1) {
-                        return null;
-                    }
-                    if (references[query]) {
-                        var pointOfReference = L.latLng(references[query]);
-                    }
-                    return {
-                        name: item.stationName,
-                        lat: item.latitude,
-                        lon: item.longitude,
-                        distanceToReference: pointOfReference ? L.latLng(item.latitude, item.longitude).distanceTo(pointOfReference) : item.id,
-                        title: item.stationName,
-                        availableDocks: item.availableDocks,
-                        availableBikes: item.availableBikes,
-                        lastCommunication: moment(new Date(item.lastCommunicationTime)).fromNow()
-                    };
-                }
-            });
+                    return null;
+                }).filter(function(station) {
+                    return station && station.is_installed;
+                });
+
+                var query = get_query();
+
+                DDG.require(['moment.js', 'maps'], function() {
+                    var pointOfReference = references[query] ? L.latLng(references[query]) : null;
+                    moment.locale('en', {
+                        relativeTime : {
+                            past: "%s ago",
+                            s:    "1 sec",
+                            ss:   "%d sec",
+                            m:    "1 min",
+                            mm:   "%d min",
+                            h:    "1 hour",
+                            hh:   "%d hours",
+                            d:    "1 day",
+                            dd:   "%d days",
+                            M:    "1 month",
+                            MM:   "%d months",
+                            y:    "1 year",
+                            yy:   "%d years"
+                        }
+                    });
+                    Spice.add({
+                        id: 'citi_bike_nyc',
+                        name: 'Bike Sharing',
+                        meta: {
+                            sourceName: 'Citi Bike NYC',
+                            sourceUrl: 'https://www.citibikenyc.com/stations',
+                            primaryText: 'Showing ' + full_data.length + ' Stations',
+                            pinIcon: 'ddgsi-circle',
+                            pinIconSelected: 'ddgsi-star'
+                        },
+                        model: 'Place',
+                        view: 'Places',
+                        templates: {
+                            item: 'base_item',
+                            options: {
+                                content: Spice.bike_sharing_citi_bike_nyc.content
+                            },
+                            variants: {
+                                tile: 'narrow'
+                            }
+                        },
+                        sort_fields: {
+                            distance: function(a, b) {
+                                return a.distanceToReference - b.distanceToReference;
+                            }
+                        },
+                        sort_default: 'distance',
+                        data: full_data,
+                        normalize: function(station) {
+                            return {
+                                name: station.name,
+                                lat: station.lat,
+                                lon: station.lon,
+                                distanceToReference: pointOfReference ? L.latLng(station.lat, station.lon).distanceTo(pointOfReference) : station.station_id,
+                                title: station.name,
+                                availableDocks: station.num_docks_available,
+                                availableBikes: station.num_bikes_available,
+                                lastCommunication: moment(new Date(parseInt(station.last_reported)*1000)).fromNow()
+                            };
+                        }
+                    });
+                });
         });
     }
 }(this));


### PR DESCRIPTION
The new GBFS feeds will be the only maintained from now on
More info: https://github.com/NABSA/gbfs/
As a side effect, #2156 is fixed, as they now use POSIX timestamps

Fixes #2745, Fixes #2156 

---
IA Page: https://duck.co/ia/view/citi_bike_nyc