### PR TITLE
Switch ES6 arrows to ES5 functions

### DIFF
--- a/share/spice/just_delete_me/just_delete_me.js
+++ b/share/spice/just_delete_me/just_delete_me.js
@@ -31,7 +31,7 @@
         function filterResults(api_result) {
             // check for exact match by name
             var results = api_result.filter(function (item) {
-                item.name.toLowerCase() === decodedQuery;
+                return item.name.toLowerCase() === decodedQuery;
             });
 
             if (results > 0)
@@ -39,7 +39,7 @@
             else {
                 // check for exact domain match
                 results = api_result.filter(function (item) {
-                    item.domains.indexOf(decodedQuery) != -1;
+                    return item.domains.indexOf(decodedQuery) !== -1;
                 });
             }
             if (results > 0)

--- a/share/spice/just_delete_me/just_delete_me.js
+++ b/share/spice/just_delete_me/just_delete_me.js
@@ -13,7 +13,9 @@
             return Spice.failed('just_delete_me');
         }
         var matchPartial = function(item) {
-            return (item.name.toLowerCase().includes(this) || item.domains.some(domain => domain.includes(this)));
+            return (item.name.toLowerCase().includes(this) || item.domains.some(function(domain) {
+                return domain.includes(this)
+            }));
         }
         function normalizeDomains(api_result) {
             for (var i=0;i<api_result.length; i++) {
@@ -27,11 +29,18 @@
             }
         }
         function filterResults(api_result) {
-            var results = api_result.filter(item => item.name.toLowerCase() === decodedQuery); // check for exact match by name
+            // check for exact match by name
+            var results = api_result.filter(function (item) {
+                item.name.toLowerCase() === decodedQuery;
+            });
+
             if (results > 0)
                 results = [results[0]]; // take only first exact match
             else {
-                results = api_result.filter(item => item.domains.indexOf(decodedQuery) != -1); // check for exact domain match
+                // check for exact domain match
+                results = api_result.filter(function (item) {
+                    item.domains.indexOf(decodedQuery) != -1;
+                });
             }
             if (results > 0)
                 results = [results[0]]; // take only first exact match


### PR DESCRIPTION
Converted arrow functions to anonymous functions. Arrow functions cause problems for our build system because we're using UglifyJS which can't handle ES6.

/cc @riqpe 

https://duck.co/ia/view/just_delete_me