### PR TITLE
YogaAsanas: Don't allow 'pose' to trigger when part of other words

### DIFF
--- a/lib/DDG/Spice/YogaAsanas.pm
+++ b/lib/DDG/Spice/YogaAsanas.pm
@@ -14,7 +14,7 @@ triggers query_lc => qr{
 	(?:\w+pitham\b)|
 	(?:samasthitih?)|
 	(?:tplutih?)|
-	(?:postures?|poses?)|
+	(?:\b(?:\bpostures?|poses?)\b)|
 	(?:sun\s+salutation)|
 	(?:s[uū]rya[\s-]+namask[aā]ra)|
 	(?:(?:ashtanga|yoga)\s+(primary|intermediate|advanced)\s+series)|

--- a/lib/DDG/Spice/YogaAsanas.pm
+++ b/lib/DDG/Spice/YogaAsanas.pm
@@ -14,7 +14,7 @@ triggers query_lc => qr{
 	(?:\w+pitham\b)|
 	(?:samasthitih?)|
 	(?:tplutih?)|
-	(?:\b(?:\bpostures?|poses?)\b)|
+	(?:\b(?:postures?|poses?)\b)|
 	(?:sun\s+salutation)|
 	(?:s[uū]rya[\s-]+namask[aā]ra)|
 	(?:(?:ashtanga|yoga)\s+(primary|intermediate|advanced)\s+series)|


### PR DESCRIPTION
Don't allow `pose` to trigger when part of other words.

IA Page: https://duck.co/ia/view/yoga_asanas