### PR TITLE
Rust Cargo: Fix 2718 / Search for crates instead of displaying a single crate

### DIFF
--- a/lib/DDG/Spice/RustCargo.pm
+++ b/lib/DDG/Spice/RustCargo.pm
@@ -6,7 +6,7 @@ use DDG::Spice;
 
 triggers startend => 'cargo package', 'cargo packages', 'rust package', 'rust packages', 'rust cargo';
 
-spice to => 'https://crates.io/api/v1/crates/$1';
+spice to => 'https://crates.io/api/v1/crates?q=$1';
 spice wrap_jsonp_callback => 1;
 
 handle remainder => sub {

--- a/share/spice/rust_cargo/content.handlebars
+++ b/share/spice/rust_cargo/content.handlebars
@@ -1,4 +1,0 @@
-<pre>
-    [dependencies]
-    {{name}} = "{{max_version}}"
-</pre>

--- a/share/spice/rust_cargo/footer.handlebars
+++ b/share/spice/rust_cargo/footer.handlebars
@@ -1,0 +1,3 @@
+<div class="tile__update__info one-line">
+  <span class="ddgsi">⬇</span> {{downloads}} &middot; Latest version {{max_version}}
+</div>

--- a/share/spice/rust_cargo/footer.handlebars
+++ b/share/spice/rust_cargo/footer.handlebars
@@ -1,3 +1,3 @@
 <div class="tile__update__info one-line">
-  <span class="ddgsi">⬇</span> {{downloads}} &middot; Latest version {{max_version}}
+  <span class="ddgsi">⬇</span> {{abbrevDownloads}} &middot; Latest version {{max_version}}
 </div>

--- a/share/spice/rust_cargo/rust_cargo.js
+++ b/share/spice/rust_cargo/rust_cargo.js
@@ -2,84 +2,51 @@
     "use strict";
     env.ddg_spice_rust_cargo = function(api_result){
 
-        if (!api_result || !api_result.crate) {
+        if (!api_result || !api_result.crates) {
             return Spice.failed('rust_cargo');
         }
-        var crate = api_result.crate;
+        var crates = api_result.crates;
         
-        Spice.add({
-            id: "rust_cargo",
-            name: "Software",
-            data: crate,
-            meta: {
-                sourceName: "Cargo",
-                sourceUrl: 'https://crates.io/crates/' + crate.name
-            },
-            normalize: function(item) {
-                var boxData = [{heading: 'Package Information:'}];
-                
-                if (item.max_version) {
-                    var value = item.max_version;
-                    if (api_result.versions[0].yanked) {
-                        value += " (yanked)";
+        var query = DDG.get_query().replace(/(cargo|rust) (package|crate)(s)?/, "").trim();
+        
+        DDG.require("moment.js", function() {
+            Spice.add({
+                id: "rust_cargo",
+                name: "Software",
+                data: crates,
+                meta: {
+                    itemType: "Cargo crates",
+                    searchTerm: query,
+                    sourceName: "Cargo",
+                    sourceUrl: 'https://crates.io/search?q=' + encodeURIComponent(query)
+                },
+                normalize: function(item) {
+                    return {
+                        title: item.name + " " + item.max_version,
+                        subtitle: "Last updated " + moment(item.updated_at).fromNow(),
+                        description: item.description,
+                        url: "https://crates.io/crates/" + encodeURIComponent(item.id)
+                    }  
+                },
+
+                templates: {
+                    group: 'text',
+                    detail: false,
+                    item_detail: false,
+                    options: {
+                        footer: Spice.rust_cargo.footer
+                    },
+                    variants: {
+                        tile: 'basic4'
                     }
-                    boxData.push({
-                        label: "Latest Version",
-                        value: value
-                    });
-                }
-
-                if (item.homepage) {
-                    boxData.push({
-                        label: "Project Homepage",
-                        value: item.homepage
-                    });
-                }
-                
-                if (item.documentation) {
-                    boxData.push({
-                        label: "Documentation",
-                        value: item.documentation
-                    });
-                }
-                
-                if (item.license) {
-                    boxData.push({
-                        label: "License",
-                        value: item.license
-                    });
-                }
-
-                if (item.repository) {
-                    boxData.push({
-                        label: "Repository",
-                        value: item.repository
-                    });
-                }
-
-                if (item.keywords && item.keywords.length > 0) {      
-                    var keywords = item.keywords.join(", ");
-
-                    boxData.push({
-                        label: "Keywords",
-                        value: keywords
-                    });
-                }
- 
-                return {
-                    title: item.name + " " + item.max_version,
-                    subtitle: item.description,
-                    infoboxData: boxData,
-                }  
-            },
-
-            templates: {
-                group: 'text',
-                options: {
-                    content: Spice.rust_cargo.content,
-                    moreAt: true
-                }
-            }
+                },
+                sort_fields: {
+                    downloads: function(a, b) {
+                        return a.downloads > b.downloads ? -1 : 1;
+                    }
+                },
+                sort_default: 'downloads'
+            });
         });
     };
 }(this));

--- a/share/spice/rust_cargo/rust_cargo.js
+++ b/share/spice/rust_cargo/rust_cargo.js
@@ -7,7 +7,7 @@
         }
         var crates = api_result.crates;
         
-        var query = DDG.get_query().replace(/(cargo|rust) (package|crate)(s)?/, "").trim();
+        var query = DDG.get_query().replace(/(cargo|rust) (package|crate|cargo)(s)?/, "").trim();
         
         DDG.require("moment.js", function() {
             Spice.add({

--- a/share/spice/rust_cargo/rust_cargo.js
+++ b/share/spice/rust_cargo/rust_cargo.js
@@ -25,7 +25,8 @@
                         title: item.name + " " + item.max_version,
                         subtitle: "Last updated " + moment(item.updated_at).fromNow(),
                         description: item.description,
-                        url: "https://crates.io/crates/" + encodeURIComponent(item.id)
+                        url: "https://crates.io/crates/" + encodeURIComponent(item.id),
+                        abbrevDownloads: DDG.abbrevNumber(item.downloads)
                     }  
                 },
 


### PR DESCRIPTION
![](http://i.imgur.com/53GRe6O.png?1)
# Changes
+ Searches for crates instead of displaying a single crate
+ Now uses the same layout as the GitHub IA.
+ Sorts the relevant crates by downloads.
+ It displays a crates' name, version, date of last release, description and number of downloads.

# Issues this fixes

Fixes #2718 by implementing fuzzy searching.

# People to notify

@tagawa

---

Instant Answer Page:

https://duck.co/ia/view/rust-cargo