### PR TITLE
Dictionary Definition: Remove quotes before passing it to Wordnik

### DIFF
--- a/lib/DDG/Spice/Dictionary/Definition.pm
+++ b/lib/DDG/Spice/Dictionary/Definition.pm
@@ -3,6 +3,7 @@ package DDG::Spice::Dictionary::Definition;
 
 use strict;
 use DDG::Spice;
+use Text::Trim;
 
 spice to => 'http://api.wordnik.com/v4/word.json/$1/definitions?includeRelated=true&includeTags=true&limit=3&api_key={{ENV{DDG_SPICE_WORDNIK_APIKEY}}}&callback={{callback}}';
 spice proxy_cache_valid => '200 30d';
@@ -38,7 +39,15 @@ triggers startend => (
 
 
 handle remainder => sub {
-    return lc($_) if $_;
+    if ($_) {
+        # Remove quotes from the string since Wordnik does not have
+        # any words that start or end with quotes.
+        $_ =~ tr/"//d;
+        
+        # Make sure to transform the string to lowercase as well.
+        return lc($_);
+    }
+
     return;
 };
 

--- a/lib/DDG/Spice/Dictionary/Definition.pm
+++ b/lib/DDG/Spice/Dictionary/Definition.pm
@@ -3,7 +3,6 @@ package DDG::Spice::Dictionary::Definition;
 
 use strict;
 use DDG::Spice;
-use Text::Trim;
 
 spice to => 'http://api.wordnik.com/v4/word.json/$1/definitions?includeRelated=true&includeTags=true&limit=3&api_key={{ENV{DDG_SPICE_WORDNIK_APIKEY}}}&callback={{callback}}';
 spice proxy_cache_valid => '200 30d';

--- a/t/Dictionary.t
+++ b/t/Dictionary.t
@@ -23,6 +23,11 @@ ddg_spice_test(
         '/js/spice/dictionary/definition/define',
         call_type => 'include',
         caller => 'DDG::Spice::Dictionary::Definition'
+    ),
+    'define "round robin"' => test_spice(
+        '/js/spice/dictionary/definition/round%20robin',
+        call_type => 'include',
+        caller => 'DDG::Spice::Dictionary::Definition'
     )
 );
 


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

Choose the most relevant items and use the following title template to name
your Pull Request.

- [ ] New Instant Answer: **`New {IA Name} Instant Answer`**
- [x] Improvement
    - [x] Bug fix: **`{IA Name}: Fix {Issue number or one-line description}`**
    - [ ] Enhancement: **`{IA Name}: {Description of Improvements}`**
- [ ] Non–Instant Answer
    - [ ] Other (Role, Template, Test, Documentation, etc.): **`{SpiceRole/Templates/Tests/Docs}: {Short Description}`**

###### Description of changes

Wordnik doesn't handle queries that have "" in the request and it chokes and turns blue.

For example, `/v4/word.json/#22round%20robbin#22/definitions?includeRelated=true&includeTags=true&limit=3&api_key=(key
removed)&callback=ddg_spice_dictionary_definition`

This strips out the quotes.

---

Instant Answer Page: https://duck.co/ia/view/dictionary_definition