### PR TITLE
quote_of_the_day: Make spice result responsive in design on small screen devices

### DIFF
--- a/share/spice/quote_of_the_day/content.handlebars
+++ b/share/spice/quote_of_the_day/content.handlebars
@@ -1,8 +1,8 @@
-<div class="zci-quote_of_the_day--container">
-  <div class="zci-quote_of_the_day">
+<div class="quote_of_the_day_container">
+  <div class="quote_of_the_day">
     {{ellipsis quote 150}}
   </div>
-  <div class="zci-quote_of_the_day--attribution">
+  <div class="quote_of_the_day_attribution">
     {{person}}
   </div>
 </div>

--- a/share/spice/quote_of_the_day/quote_of_the_day.css
+++ b/share/spice/quote_of_the_day/quote_of_the_day.css
@@ -53,3 +53,17 @@
 .is-mobile .zci--quote_of_the_day .zci-quote_of_the_day--attribution {
     margin-left: 40px;
 }
+
+@media only screen and (max-width: 634px) {
+    .zci-quote_of_the_day--attribution{
+        margin-left: 3em;
+    }
+
+    .zci-quote_of_the_day{
+	margin-left: 2em;
+     }
+
+    .zci-quote_of_the_day:before {
+        display:none;
+     }
+}

--- a/share/spice/quote_of_the_day/quote_of_the_day.css
+++ b/share/spice/quote_of_the_day/quote_of_the_day.css
@@ -1,69 +1,55 @@
-.zci-quote_of_the_day--container {
+.quote_of_the_day_container {
+    overflow: hidden;
     margin-left: -2.8em;
-    margin-top: 1.0em;
 }
 
-.zci-quote_of_the_day {
+.quote_of_the_day {
     quotes: "“" "”";
     font-size: 1.5em;
     font-weight: 300;
 }
 
-.zci-quote_of_the_day .zci__body {
+.zci--quote_of_the_day_ .zci__body {
     margin-left: -2em;
     padding-top: 0.5em;
     padding-bottom: 0.5em;
     padding-left: 2.8em;
 }
 
-.zci-quote_of_the_day:before {
+.quote_of_the_day:before {
     color: #D4D4D4;
     content: open-quote;
     float: left;
     font-size: 4em;
-    margin-top: -0.5em;
+    margin-top: -0.25em;
     margin-right: 0.1em;
 }
 
-.zci-quote_of_the_day--attribution {
+.quote_of_the_day_attribution {
     color: #999;
     float: left;
     margin-top: 5px;
 }
 
-.zci--quote_of_the_day .zci__content.chomp {
+.zci--quote_of_the_day_ .zci__content.chomp {
     max-height: none;
     margin-bottom: 0;
 }
 
-.zci--quote_of_the_day .zci__body.zci__body--info {
+.zci--quote_of_the_day_ .zci__body.zci__body--info {
     padding-left: 0.25em;
 }
 
-.is-mobile .zci-quote_of_the_day--container2 {
+.is-mobile .quote_of_the_day_container {
     margin-left: 0px;
     margin-bottom: 0.5em;
 }
 
-.is-mobile .zci--quote_of_the_day .zci__more-at {
+.is-mobile .zci--quote_of_the_day_ .zci__more-at {
     margin-left: 40px;
 
 }
 
-.is-mobile .zci--quote_of_the_day .zci-quote_of_the_day--attribution {
+.is-mobile .zci--quote_of_the_day_ .quote_of_the_day_attribution {
     margin-left: 40px;
-}
-
-@media only screen and (max-width: 634px) {
-    .zci-quote_of_the_day--attribution{
-        margin-left: 3em;
-    }
-
-    .zci-quote_of_the_day{
-	margin-left: 2em;
-     }
-
-    .zci-quote_of_the_day:before {
-        display:none;
-     }
 }


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

Choose the most relevant items and use the following title template to name
your Pull Request.

- [ ] New Instant Answer: **`New {IA Name} Instant Answer`**
- [x] Improvement
    - [ ] Bug fix: **`{IA Name}: Fix {Issue number or one-line description}`**
    - [x] Enhancement: **`quote_of_the_day: responsive design output on small screen devices`**
- [ ] Non–Instant Answer
    - [ ] Other (Role, Template, Test, Documentation, etc.): **`{SpiceRole/Templates/Tests/Docs}: {Short Description}`**

###### Description of changes

On `quote_of_the_day` spice, the output clipped the quote icon on
small screen devices. Also, the author name was misaligned on small
screen devices.

Provide an overview of the changes this pull request introduces.

* quote icon hidden on small screen devices using CSS styling

* author name aligned correctly on small screen devices

* CSS media queries were used

###### Which issues (if any) does this fix?

See also: #2758

Fixes #NNNN - how specifically does it fix the issue?

###### People to notify (@moollaza)


---

Instant Answer Page: https://duck.co/ia/view/quote_of_the_day

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @pnpninja

