### PR TITLE
updated regex not to include unrelated integral terms

### DIFF
--- a/lib/DDG/Spice/Symbolab.pm
+++ b/lib/DDG/Spice/Symbolab.pm
@@ -9,7 +9,7 @@ spice wrap_jsonp_callback => 1;
 
 triggers startend => "calculate", "solve", "compute", "integral", "integrate", "integration", "antiderivative", "derivative", "derive", "differentiate", "derivation";
 handle query_lc => sub {
-    if ($_ =~ /[\^\*\=\+\-\/\\]/ or $_ =~ /\b(sin|cos|tan|cot|csc|sec|ln|log|sqrt|integr|deriv|diff)/i) {
+    if ($_ =~ /[\^\*\=\+\-\/\\]/ or $_ =~ /\b(sin|cos|tan|cot|csc|sec|ln|log|sqrt)/i) {
         return $_;
     }
     return;

--- a/t/Symbolab.t
+++ b/t/Symbolab.t
@@ -69,7 +69,33 @@ ddg_spice_test(
         caller => 'DDG::Spice::Symbolab',
         is_cashed => 1
     ), 
+
+    'integral x^3/e^x-1' => test_spice(
+        '/js/spice/symbolab/integral%20x%5E3%2Fe%5Ex-1',
+        call_type => 'include',
+        caller => 'DDG::Spice::Symbolab',
+        is_cashed => 1
+    ), 
     
+    'integral of tan u' => test_spice(
+        '/js/spice/symbolab/integral%20of%20tan%20u',
+        call_type => 'include',
+        caller => 'DDG::Spice::Symbolab',
+        is_cashed => 1
+    ), 
+
+    'derivative of a vector function' => undef, 
+    'integral' => undef, 
+    'current version plugin gnome shell integration' => undef, 
+    'continuous integration' => undef, 
+    'integration by parts' => undef, 
+    'derivative of arctan' => undef, 
+    'line integral' => undef, 
+    'integral calcultor' => undef, 
+    'derivative of a summation' => undef, 
+    'integral ad science' => undef, 
+    'derivative of a pmf' => undef, 
+    'integration vs unit tests' => undef, 
     'instant' => undef,
     'calculate' => undef,
     'calculate mortgage' => undef


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

Choose the most relevant items and use the following title template to name
your Pull Request.

Bug fix: **`Symbolab: Fix #2708`**

###### Description of changes
Updated the reigger regex not to fire on unrelated queries such as:
'derivative of a vector function' => undef, 
    'integral' 
    'current version plugin gnome shell integration' 
    'continuous integration'
    'integration by parts' 
    'derivative of arctan'
    'line integral'
    'integral calcultor' 
    'derivative of a summation' 
    'integral ad science'
    'derivative of a pmf' 
    'integration vs unit tests' 
Also updated unit tests accordingly.

###### Which issues (if any) does this fix?
Fix #2708

###### People to notify (@mention interested parties)
@moollaza @GuiltyDolphin 

---

Instant Answer Page: https://duck.co/ia/view/symbolab