### PR TITLE
PlayingCards: Improve Validation Regex

### DIFF
--- a/lib/DDG/Spice/PlayingCards.pm
+++ b/lib/DDG/Spice/PlayingCards.pm
@@ -13,11 +13,11 @@ spice proxy_cache_valid => "418 1d";
 handle remainder => sub {
     my $query = $_;
     
-    if ($query && $query =~ m/(\d{1,2})(?:random )?(?:(?:playing )? cards)?/) {
+    if ($query && $query =~ m/^(\d{1,2})\s(?:random )?(?:playing )?(?:card(?:s)?)$/) {
         my $num = (split)[0];
         return $num if ($num >= 1 && $num <= 52);
     }
-    
+
     return;
 };
 

--- a/t/PlayingCards.t
+++ b/t/PlayingCards.t
@@ -9,12 +9,6 @@ use DDG::Test::Spice;
 ddg_spice_test(
     [qw( DDG::Spice::PlayingCards )],
 
-    'deal 9' => test_spice(
-        '/js/spice/playing_cards/9',
-        call_type => 'include',
-        caller => 'DDG::Spice::PlayingCards',
-    ),
-
     'deal 10 cards' => test_spice(
         '/js/spice/playing_cards/10',
         call_type => 'include',
@@ -27,7 +21,7 @@ ddg_spice_test(
         caller => 'DDG::Spice::PlayingCards',
     ),
     
-    'draw 10 cards' => test_spice(
+    'draw 10 random cards' => test_spice(
         '/js/spice/playing_cards/10',
         call_type => 'include',
         caller => 'DDG::Spice::PlayingCards',
@@ -36,7 +30,11 @@ ddg_spice_test(
     'cheap deal' => undef,
     'deal or no deal' => undef,
     'deal' => undef,
-    'deal 53 cards' => undef
+    'deal 9' => undef,
+    'deal 53 cards' => undef,
+    'deal 33 cards pokemon tcg' => undef,
+    'deal 4 damage to target creature' => undef,
+    'deal 4 u' => undef
 );
 
 # This function call is expected by Test::More. It makes sure the program


### PR DESCRIPTION
This is in reference to #2788.

While the Instant Answer will no longer trigger on `deal 4` and anything without `card` or `cards`, I did allow the "s" in "cards" to be optional.
i.e. `deal 10 card` is still a valid match.

Grammatical transgression aside, this should stop triggering on irrelevant queries.

***
IA Page: <http://duck.co/ia/view/playing_cards>