### PR TITLE
currency: Show localised currency conversion result

### DIFF
--- a/lib/DDG/Spice/Currency.pm
+++ b/lib/DDG/Spice/Currency.pm
@@ -14,6 +14,7 @@ my %currHash = ();
 
 # load decimal => unicode currency codes
 my $currencyCodes = LoadFile share("currencySymbols.yml");
+my $country = LoadFile share("country.yml");
 
 foreach my $currency (@currencies){
     chomp($currency);
@@ -101,7 +102,7 @@ sub checkCurrencyCode {
             # This should probably depend on the user's location.
             # For example, if I was in the Philippines, I would expect "10 usd" to mean "10 usd to php"
             # But this would mean mapping currencies to countries.
-            $to = $from eq 'usd' ? 'eur' : 'usd';
+            $to = $country->{$loc->{"country_name"}};
         }
     }
 

--- a/share/spice/currency/country.yml
+++ b/share/spice/currency/country.yml
@@ -1,0 +1,2 @@
+"Germany": "eur"
+"India": "inr"

--- a/share/spice/currency/country.yml
+++ b/share/spice/currency/country.yml
@@ -1,2 +1,6 @@
+"Australia": "aud"
+"Canada": "cad"
 "Germany": "eur"
 "India": "inr"
+"Malaysia": "myr"
+"United States": "usd"


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

Choose the most relevant items and use the following title template to name
your Pull Request.
- [ ] New Instant Answer: **`New {IA Name} Instant Answer`**
- [x] Improvement
  - [x] Bug fix: **`currency: Fix {#2735}`**
  - [ ] Enhancement: **`{IA Name}: {Description of Improvements}`**
- [ ] Non–Instant Answer
  - [ ] Other (Role, Template, Test, Documentation, etc.): **`{SpiceRole/Templates/Tests/Docs}: {Short Description}`**
###### Description of changes

If the user queries for `42 gel`, he should be shown currency
conversion result (localised) according to the region. This could
be done by mapping countries list to currency list, and setting
a fallback to `localised` currency.

Provide an overview of the changes this pull request introduces.
- added yml file with country-currency mapping
- show localised currency conversion results
###### Which issues (if any) does this fix?

See also: #2735

Fixes #NNNN - how specifically does it fix the issue?
###### People to notify (@maslic , @moollaza , @GuiltyDolphin , @mintsoft )

---

Instant Answer Page: https://duck.co/ia/view/currency

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @MrChrisW
