### PR TITLE
MetaCPAN: Attempt to extract module name when additional words are in query

### DIFF
--- a/lib/DDG/Spice/MetaCPAN.pm
+++ b/lib/DDG/Spice/MetaCPAN.pm
@@ -15,6 +15,7 @@ triggers startend => "cpan", "cpanm", "metacpan", "mcpan", "meta cpan", "perl mo
 handle remainder => sub {
     if ($_) {
         $_ =~ s/-/::/g;
+        $_ = ( grep { /::/ } split /\s+/, $_ )[0] || $_;
         my $clean = $_ =~ s/::/ /gr;
         return $_, $clean;
     }


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

Choose the most relevant items and use the following title template to name
your Pull Request.

- [ ] New Instant Answer: **`New {IA Name} Instant Answer`**
- [x] Improvement
    - [ ] Bug fix: **`{IA Name}: Fix {Issue number or one-line description}`**
    - [x] Enhancement: **`MetaCPAN: Attempt to extract module name when additional words are in query`**
- [ ] Non–Instant Answer
    - [ ] Other (Role, Template, Test, Documentation, etc.): **`{SpiceRole/Templates/Tests/Docs}: {Short Description}`**

###### Description of changes

When additional query words are provided alongside an apparent module name, this change will extract the module name and ignore other terms.

###### Which issues (if any) does this fix?

Improvement for #2877 though probably not a complete fix.

###### People to notify (@mention interested parties)

@GuiltyDolphin @sahildua2305 

---

Instant Answer Page: https://duck.co/ia/view/meta_cpan

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): **N/A**

