### PR TITLE
Remove use of several vars on global scope

### DIFF
--- a/share/spice/cryptocurrency/cryptocurrency.js
+++ b/share/spice/cryptocurrency/cryptocurrency.js
@@ -275,7 +275,7 @@
             onShow: function() {
                 // The desktop template depends on a JS function that manages the
                 // size of the container.
-                if(!is_mobile) {
+                if(!DDG.device.isMobile) {
                     $(window).on('load', resize);
                     $(window).resize(resize);
                 } else {

--- a/share/spice/currency/currency.js
+++ b/share/spice/currency/currency.js
@@ -158,7 +158,7 @@
             onShow: function() {
                 // The desktop template depends on a JS function that manages the
                 // size of the container.
-                if(!is_mobile) {
+                if(!DDG.device.isMobile) {
                     $(window).on('load', resize);
                     $(window).resize(resize);
                 } else {

--- a/share/spice/dictionary/definition/dictionary_definition.js
+++ b/share/spice/dictionary/definition/dictionary_definition.js
@@ -80,7 +80,7 @@ var ddg_spice_dictionary = {
                 // otherwise the loading of the audio resources is deferred until the user clicks
                 // the button and loading things and waiting for them to load takes to long and
                 // the mobile browsers won't let us auto-play the audio after that:
-                if (is_mobile_device) {
+                if (DDG.device.isMobileDevice) {
                     DDG.require('audio', function(){});
                 }
             }

--- a/share/spice/editor/editor.js
+++ b/share/spice/editor/editor.js
@@ -1,7 +1,7 @@
 (function(env){
     "use strict";
 
-    if (is_mobile) {
+    if (DDG.device.isMobile) {
         return Spice.failed('editor');
     }
 

--- a/share/spice/forecast/forecast.js
+++ b/share/spice/forecast/forecast.js
@@ -65,7 +65,7 @@
 
       currentObj.isCurrent = 1;
       // If the next-hour summary is interesting enough (and we're not on mobile), use that instead
-      if(!is_mobile && f.minutely && !f.minutely.summary.match(/ for the hour\.$/)) {
+      if(!DDG.device.isMobile && f.minutely && !f.minutely.summary.match(/ for the hour\.$/)) {
         current_summary = f.minutely.summary;
       }
 
@@ -160,7 +160,7 @@
         
         if (i == 0) { 
             dailyObj[i].day = 'Today';
-        } else if (is_mobile) {
+        } else if (DDG.device.isMobile) {
             dailyObj[i].day = tmp_date.format("ddd").toUpperCase();
         } else {
             dailyObj[i].day = tmp_date.format("dddd");
@@ -210,7 +210,7 @@
       }
 
       // structure the data differently for mobile and desktop views
-      if (is_mobile) {
+      if (DDG.device.isMobile) {
         spiceData = weatherData;
       } else {
         spiceData = [weatherData.current, weatherData.daily[0], weatherData.daily[1], weatherData.daily[2], weatherData.daily[3], weatherData.daily[4], weatherData.daily[5], weatherData.daily[6]];
@@ -317,7 +317,7 @@
       }
 
       //insert the new temps in the html
-      var day_class = is_mobile ? '.fe_day--bar' : '.fe_day';
+      var day_class = DDG.device.isMobile ? '.fe_day--bar' : '.fe_day';
 
       $('.fe_currently').find('.fe_temp_str').html(Math.round(temps.current) + '&deg;');
       $(day_class).each(function(i){

--- a/share/spice/missing_kids/missing_kids.js
+++ b/share/spice/missing_kids/missing_kids.js
@@ -67,7 +67,7 @@
                 data: articles,
                 meta: {
                     primaryText: 'Missing children in ' + decodedQuery,
-                    sourceName: is_mobile ? 'NCMEC' : 'National Center for Missing & Exploited Children',
+                    sourceName: DDG.device.isMobile ? 'NCMEC' : 'National Center for Missing & Exploited Children',
                     sourceUrl: 'http://www.missingkids.com',
                     count: articles.length
                 },

--- a/share/spice/octopart/octopart.js
+++ b/share/spice/octopart/octopart.js
@@ -7,7 +7,7 @@
         var images = {};
 
         $.each(imagesets, function(){
-            if (!is_mobile && this.large_image && this.medium_image){
+            if (!DDG.device.isMobile && this.large_image && this.medium_image){
                 images.large  = DDG.toHTTP(this.large_image.url);
                 images.medium = DDG.toHTTP(this.medium_image.url);
                 return false;

--- a/share/spice/recipes/recipes.js
+++ b/share/spice/recipes/recipes.js
@@ -38,7 +38,7 @@
             }
 
             if(item.ingredients && item.ingredients.length){
-                var searchTermContainsRecipe = rq.match(/recipe/i),
+                var searchTermContainsRecipe = query_encoded.match(/recipe/i),
                     len = item.ingredients.length;
 
                 m.ingredientString = item.ingredients.join(", ");

--- a/share/spice/today_in_history/today_in_history.js
+++ b/share/spice/today_in_history/today_in_history.js
@@ -68,7 +68,7 @@
                     plaintext = $("<p>" + html + "</p>").text();
 
                 return {
-                    canExpand: plaintext.length > 150 && !is_mobile,
+                    canExpand: plaintext.length > 150 && !DDG.device.isMobile,
                     text: html,
                     year: wiki_to_html(item.wikiYear)
                 };

--- a/share/spice/urban_dictionary/urban_dictionary.js
+++ b/share/spice/urban_dictionary/urban_dictionary.js
@@ -37,7 +37,7 @@
                         if (term !== word) {
                             infoboxData.push({
                                 label: DDG.capitalizeWords(term),
-                                url: window.location.origin + '/?q=ud+' + term + '&ia=dictionary' + kurl
+                                url: window.location.origin + '/?q=ud+' + term + '&ia=dictionary' + DDG.settings.queryStringAppend
                             });
                         }
                     }

--- a/share/spice/xkcd/display/xkcd_display.js
+++ b/share/spice/xkcd/display/xkcd_display.js
@@ -102,7 +102,7 @@
                 }
             });
             
-            if (is_mobile) {
+            if (DDG.device.isMobile) {
                 $('.zci--xkcd .c-base__sub .sep').first().replaceWith("<br>");
             }
         });


### PR DESCRIPTION
Requires an internal PR. Unfortunately that use of `kurl` in the Urban Dictionary IA means we can't merge this until the internal PR is in.

cc @bsstoner @bbraithwaite 
