### PR TITLE
Fix precedence of maps_maps triggers.

### DIFF
--- a/lib/DDG/Spice/Maps/Maps.pm
+++ b/lib/DDG/Spice/Maps/Maps.pm
@@ -11,7 +11,12 @@ spice is_cached => 0;
 spice proxy_cache_valid => "418 1d";
 spice wrap_jsonp_callback => 1;
 
-my @startend_triggers = ("map of", "map", "maps", "current location");
+# (mohammed): When adding triggers, put plural or compound forms of the same word first.
+# For example, if you have @startend_triggers = ("map", "maps") and the input query is
+# "maps", in the matching step, the query will match "map" first and will then split the
+# input query into "map" and "s" and pass "s" to the upstream, this is obviously wrong,
+# so your @startend_triggers should look like ("maps", "map").
+my @startend_triggers = ("maps of", "maps", "map of", "map", "current location");
 my $startend_joined = join "|", @startend_triggers;
 my $start_qr = qr/^($startend_joined)/;
 my $end_qr = qr/($startend_joined)$/;


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

Choose the most relevant items and use the following title template to name
your Pull Request.

- [ ] New Instant Answer: **`New {IA Name} Instant Answer`**
- [x] Improvement
    - [x] Bug fix: **`{maps_maps}: Fix {Fix precedence issue of maps triggers}`**
    - [ ] Enhancement: **`{IA Name}: {Description of Improvements}`**
- [ ] Non–Instant Answer
    - [ ] Other (Role, Template, Test, Documentation, etc.): **`{SpiceRole/Templates/Tests/Docs}: {Short Description}`**

###### Description of changes

When adding triggers, put plural or compound forms of the same word first.
For example, if you have @startend_triggers = ("map", "maps") and the input query is
"maps", in the matching step, the query will match "map" first and will then split the
input query into "map" and "s" and pass "s" to the upstream, this is obviously wrong,
so your @startend_triggers should look like ("maps", "map").


###### Which issues (if any) does this fix?
Fixes the precedence issues in maps triggers.

###### People to notify (@mention interested parties)
@nilnilnil @b2ddg 

---

Instant Answer Page: https://duck.co/ia/view/maps_maps

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @nilnilnil 

