### PR TITLE
Color Picker: Updated the regex to extract 'possible_color_code'  from query string

### DIFF
--- a/share/spice/color_picker/color_picker.js
+++ b/share/spice/color_picker/color_picker.js
@@ -578,7 +578,7 @@
             //  format it for later processing. The result will have all spaces, and parentheses
             //  replaced with commas such that there will only be one comma between any text.
             //  For example, HSV(1, 2, 3) becomes hsv,1,2,3
-            var possible_color_query = query.split(/[\s,()]+/).slice(2)
+            var possible_color_query = query.split(/colou?r\s?picker\s?/i).slice(1);
             possible_color_query = $.map(possible_color_query, function(el) { if (el.length > 0) return el; }).join(',').toLowerCase();
             if (possible_color_query.length === 0)
                 return null;

--- a/t/ColorPicker.t
+++ b/t/ColorPicker.t
@@ -22,7 +22,10 @@ ddg_spice_test(
     'color picker #aaa111' => test_spice(@test_args),
     'color picker rgb(192, 168, 1)' => test_spice(@test_args),
     'color picker hsv(270, 65%, 80%)' => test_spice(@test_args),
-    'color picker cmyk(10, 20, 30, 40)' => test_spice(@test_args)
+    'color picker cmyk(10, 20, 30, 40)' => test_spice(@test_args),
+    'colour Picker' => test_spice(@test_args),
+    'ColorPicker' => test_spice(@test_args),
+    'colorPicker' => test_spice(@test_args)
 );
 
 done_testing;


### PR DESCRIPTION
###### Updated the regex to extract 'possible_color_code'  from query string

Choose the most relevant items and use the following title template to name
your Pull Request.

- [ ] Improvement
    - [ ] Bug fix: **`Color Picker: Updated the regex to extract 'possible_color_code'  from query string`**
###### Description of changes

Updated the regex to extract the color code from the query string. The regex now support case-insensitive queries and even work for "color picker" and "colorpicker", i.e. space is optional now.

###### Fix the issue of exact query to open Color Picker with color code

Fixes #2675  - The space is optional now and it can work even without a space like "colorpicker"
Fixed #2721 - It can now add Upper Cases query too. 

###### People to notify @moollaza @jkrobles 


---

Instant Answer Page: https://duck.co/ia/view/color_picker

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @mention
