### PR TITLE
change api call to HTTPS

### DIFF
--- a/lib/DDG/Spice/SoundCloud.pm
+++ b/lib/DDG/Spice/SoundCloud.pm
@@ -8,7 +8,7 @@ spice call_type => 'self';
 
 spice alt_to => {
 	sound_cloud_result => {
-		to => 'http://api.soundcloud.com/tracks.json?client_id={{ENV{DDG_SPICE_SOUNDCLOUD_APIKEY}}}&q=$1&limit=35&filter=streamable'
+		to => 'https://api.soundcloud.com/tracks.json?client_id={{ENV{DDG_SPICE_SOUNDCLOUD_APIKEY}}}&q=$1&limit=35&filter=streamable'
 	}
 };
 


### PR DESCRIPTION
Changing this call to https in hopes that it fixes the spike in soundcloud failures. Seems like the redirect from http -> https is what is causing no results to be returned.

@bsstoner @jagtalon 