### PR TITLE
Whois: Fixed the sourceUrl

### DIFF
--- a/share/spice/whois/whois.js
+++ b/share/spice/whois/whois.js
@@ -172,9 +172,9 @@
             name: 'Whois',
             meta: {
                 sourceName: 'Whois API',
-                sourceUrl: 'https://www.whoisxmlapi.com/#whoisserver/WhoisService?domainName='
+                sourceUrl: 'https://www.whoisxmlapi.com/whois-api-doc.php?domainName='
                     + api_result.domainName
-                    + '&target=raw'
+                    + '&outputFormat=json'
             },
             normalize: function(item) {
                 return {

--- a/share/spice/whois/whois.js
+++ b/share/spice/whois/whois.js
@@ -172,9 +172,8 @@
             name: 'Whois',
             meta: {
                 sourceName: 'Whois API',
-                sourceUrl: 'https://www.whoisxmlapi.com/whois-api-doc.php?domainName='
+                sourceUrl: 'http://whois.whoisxmlapi.com/'
                     + api_result.domainName
-                    + '&outputFormat=json'
             },
             normalize: function(item) {
                 return {


### PR DESCRIPTION
I've noticed that the Whois spice didn't redirect to a valid page when you click on the link that appears on the bottom of the instant answer. I modified the URL to now redirect to the correct page.

One issue is, I couldn't find a URL that would show the "raw text" version of the whois response. The best I could get is JSON, and then the user can click over to the "raw text" page. 

---

Instant Answer Page: https://duck.co/ia/view/whois

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @b1ake 