### PR TITLE
Bump mapbox geocoder from v4 to v5

### DIFF
--- a/lib/DDG/Spice/Maps/Maps.pm
+++ b/lib/DDG/Spice/Maps/Maps.pm
@@ -6,7 +6,7 @@ use Text::Trim;
 use DDG::Spice;
 use Data::Dumper;
 
-spice to => 'https://api.mapbox.com/v4/geocode/mapbox.places/$1.json?access_token={{ENV{DDG_SPICE_MAPBOX_KEY}}}';
+spice to => 'https://api.mapbox.com/geocoding/v5/mapbox.places/$1.json?access_token={{ENV{DDG_SPICE_MAPBOX_KEY}}}';
 spice is_cached => 0;
 spice proxy_cache_valid => "418 1d";
 spice wrap_jsonp_callback => 1;


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

Bump mapbox API from v4 to v5.

- [x] Improvement
    - [x] Enhancement: **`{maps_maps}: {Bump mapbox API from v4 to v5}`**

---

Instant Answer Page: https://duck.co/ia/view/maps_maps

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @nilnilnil 

