### PR TITLE
Bug Fix: Whois: Fix #2887

### DIFF
--- a/share/spice/whois/whois.js
+++ b/share/spice/whois/whois.js
@@ -125,17 +125,20 @@
     // Searches an array of objects for the first value
     // at the specified key.
     function get_first_by_key(arr, key) {
-        if(!arr || arr.length == 0) return;
-        var first;
-        $.each(arr, function(index, obj) {
-            var value = obj && obj[key];
-            // update the first var if the value is truthy
-            // and first hasn't already been found
-            if (!first && value) {
-                first = value;
+        var arrLength, i, obj;
+
+        if(!arr || (arrLength = arr.length) === 0) {
+            return;
+        }
+
+        for(i = 0; i < arrLength; ++i) {
+            obj = arr[i];
+            if(obj && obj[key]) {
+                return obj[key];
             }
-        });
-        return first;
+        }
+
+        return;
     }
 
     //Converts timestamp into local time using moment.js

--- a/share/spice/whois/whois.js
+++ b/share/spice/whois/whois.js
@@ -53,6 +53,10 @@
         var dateOutputFormat = "MMM DD, YYYY",
             dateUTCParse = "YYYY-MM-DD HH:mm:ss Z";
 
+        // set objects if they don't exist to prevent TypeError's with
+        // undefined variables being tested as if they were objects.
+        api_result.registryData = api_result.registryData || {};
+
         // store the domain's various contacts in an array.
         // we'll iterate through this array in order, using
         // info from the first contact that contains the field we want.


### PR DESCRIPTION
In this pull, I fix the issue of #2887, which was if the API Response didn't container the key of `registryData`, it would throw an error because it was checking for values inside of it.

I also added a small performance/readability fix in the `get_first_by_key` function. It now will return the value once it's found, instead of continuing looping through the rest of values.

Fixes #2887  - ensures that objects we are going to check are actually objects and are not undefined.

---

Instant Answer Page: https://duck.co/ia/view/whois

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @b1ake 
