### PR TITLE
Bible: adding verse of the day

### DIFF
--- a/lib/DDG/Spice/Bible.pm
+++ b/lib/DDG/Spice/Bible.pm
@@ -13,6 +13,9 @@ handle query_lc => sub {
     if ($_ =~ /^bible\s+([a-z]+\s*?[0-9]+:[0-9]+)$/i || $_ =~ /^((?:genesis|exodus|leviticus|numbers|deuteronomy|joshua|judges|ruth|1 samuel|2 samuel|1 kings|2 kings|1 chronicles|2 chronicles|ezra|nehemiah|esther|job|psalm|proverbs|ecclesiastes|song of solomon|isaiah|jeremiah|lamentations|ezekiel|daniel|hosea|joel|amos|obadiah|jonah|micah|nahum|habakkuk|zephaniah|haggai|zechariah|malachi|matthew|mark|luke|john|acts|romans|1 corinthians|2 corinthians|galatians|ephesians|philippians|colossians|1 thessalonians|2 thessalonians|1 timothy|2 timothy|titus|philemon|hebrews|james|1 peter|2 peter|1 john|2 john|3 john|jude|revelation)\s+[0-9]+:[0-9]+)$/) {
         return $1 if $1;
     }
+    if ($_ =~ /^bible\s+(verse of the day|verse of today)$/i || $_ =~ /^verse\s+(of the day|of today)$/i) {
+        return 'votd';
+    }
     return;
 };
 

--- a/share/spice/bible/triggers.txt
+++ b/share/spice/bible/triggers.txt
@@ -65,3 +65,7 @@ song of solomon
 titus
 zechariah
 zephaniah
+bible verse of the day
+verse of the day
+bible verse of today
+verse of today

--- a/t/Bible.t
+++ b/t/Bible.t
@@ -20,6 +20,22 @@ ddg_spice_test(
         '/js/spice/bible/genesis%2026%3A4',
         caller    => 'DDG::Spice::Bible',
     ),
+    'bible verse of the day' => test_spice(
+        '/js/spice/bible/votd',
+        caller    => 'DDG::Spice::Bible',
+    ),
+    'verse of the day' => test_spice(
+        '/js/spice/bible/votd',
+        caller    => 'DDG::Spice::Bible',
+    ),
+    'bible verse of today' => test_spice(
+        '/js/spice/bible/votd',
+        caller    => 'DDG::Spice::Bible',
+    ),
+    'verse of today' => test_spice(
+        '/js/spice/bible/votd',
+        caller    => 'DDG::Spice::Bible',
+    ),
 );
 
 done_testing;


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

Choose the most relevant items and use the following title template to name
your Pull Request.

- [ ] New Instant Answer: **`New {IA Name} Instant Answer`**
- [X] Improvement
    - [ ] Bug fix: **`{IA Name}: Fix {Issue number or one-line description}`**
    - [X] Enhancement: **`{IA Name}: {Description of Improvements}`**
- [ ] Non–Instant Answer
    - [ ] Other (Role, Template, Test, Documentation, etc.): **`{SpiceRole/Templates/Tests/Docs}: {Short Description}`**

###### Description of changes

Adding 

> bible verse of the day

 triggers and tests.  Uses the NET Bible API [verse of the day](http://labs.bible.org/api_web_service).  The default 1 day caching seems ok for this verse of the day or should this one also be split out to a separate IA like what is being suggested in #2826 for random bible verse and then enable a much longer cache duration on this current IA?

###### Which issues (if any) does this fix?

Fixes #2929  - Adds regex for verse of day and various tests.

###### People to notify (@mention interested parties)
@pnpninja @tagawa @hunterlang 

---

Instant Answer Page: https://duck.co/ia/view/bible

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @mention

