### PR TITLE
Holiday: if holiday occurs on present day display current year as answer

### DIFF
--- a/share/spice/holiday/holiday.js
+++ b/share/spice/holiday/holiday.js
@@ -27,7 +27,7 @@
                 // If the holiday being queried for has already past in the given year requery for the following year
                 var currentDate = moment();
                 var holidayDate = moment(holiday.o[0].d);
-                if (currentDate.isAfter(holidayDate)) {                    
+                if (currentDate.isAfter(holidayDate, 'day')) {                    
                     $.getScript('/js/spice/holiday/' + country + '/' + query + '/' + holidayDate.add(1, 'years').format('YYYY') + '/0');
                     return;
                 }                    


### PR DESCRIPTION
Bug fix:

When a user searches for a holiday that occurs on the present day the IA incorrectly displays the following years occurrence as the answer. This is due to the level of precision used when testing if the current date is after the holiday date, we now use `days` instead of the default `milliseconds`. For example if you search for `when is senior citizens day usa` which occurs today (21 aug) it will bring up the 2017 result instead of 2016.

---

Instant Answer Page: https://duck.co/ia/view/holiday
