### PR TITLE
Fix airlines IA trigger and date parsing

### DIFF
--- a/share/spice/airlines/airlines.js
+++ b/share/spice/airlines/airlines.js
@@ -80,7 +80,7 @@
             var apiResponseDate = moment(api_result.request.date.year + "-" +
                                         api_result.request.date.month + "-" + 
                                         api_result.request.date.day + " " +
-                                        originalRequestHour, "YYYY-MM-DD HH").utc();
+                                        originalRequestHour, "YYYY-MM-DD HH:00Z");
 
             // if this response is for the original same-day request...
             if (originalRequestDayOfMonth == apiResponseDate.date()) {


### PR DESCRIPTION
Given that the original query is done using GTM time, when parsing
the data, the timezone needs to be specified as Z, instead of using
local and then requesting the UTC version of the moment object

Fixes #2771

IA Page: http://duck.co/ia/view/airlines 
Maintainer: @amoraleda