### PR TITLE
Air Quality Index:Fixes #2579 to Overtake About

### DIFF
--- a/share/spice/aqi/aqi.js
+++ b/share/spice/aqi/aqi.js
@@ -28,6 +28,7 @@
         sourceName: "airnowapi.org",
         sourceUrl: 'http://www.airnow.gov/?action=airnow.local_city&zipcode=' + zip,
       },
+      signal: 'high',
       normalize: function(item){
         return {
           title: locationString,


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

Choose the most relevant items and use the following title template to name
your Pull Request.

- [ ] New Instant Answer: **`New {IA Name} Instant Answer`**
- [ ] Improvement
    - [ ] Bug fix: **`{IA Name}: Fix {Issue number or one-line description}`**
    - [ X] Enhancement: **`Air Quality Index: Fixes #2579 to Overtake About`**
- [ ] Non–Instant Answer
    - [ ] Other (Role, Template, Test, Documentation, etc.): **`{SpiceRole/Templates/Tests/Docs}: {Short Description}`**

###### Description of changes

This PR includes the suggestion to add signal:'high' in aqi.js as per #2579 to allow for air quality index tab contents to be displayed when user types in 'air quality' as opposed to the 'About' tab. 

###### Which issues (if any) does this fix?

Fixes #2579 - The air quality index tab is now displayed when the query is 'air quality'

###### People to notify (@mention interested parties)
@moollaza, @GuiltyDolphin 

---

Instant Answer Page: IA Page: http://duck.co/ia/view/aqi 
[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @schluchc

