### PR TITLE
dota2: Use English language for heroes and items

### DIFF
--- a/lib/DDG/Spice/Dota2.pm
+++ b/lib/DDG/Spice/Dota2.pm
@@ -15,7 +15,7 @@ attribution github => ["https://github.com/echosa", "Echosa"],
 
 triggers startend => 'dota2', 'dota 2';
 
-spice to => 'https://www.dota2.com/jsfeed/heropediadata?feeds=itemdata,herodata,abilitydata';
+spice to => 'https://www.dota2.com/jsfeed/heropediadata?feeds=itemdata,herodata,abilitydata&l=english';
 spice wrap_jsonp_callback => 1;
 
 handle remainder => sub {


### PR DESCRIPTION
###### Description of changes

Always retrieves the English version of Heroes, Abilities and Items.
###### Related Issues or Discussions

If no language is specified in the spice to url, there is a chance that a non-English version is returned. In my case it was a German version. Until the time when it is possible to use the preferred language the user has set in DDG I believe it is best to force English.

Things to note: if a language also changes the name of the item/hero (for example 'l=schinese' for simplified Chinese), the entered name must also be in that language otherwise the item/hero won't be found.

---

Instant Answer Page: https://duck.co/ia/view/dota2

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @echosa 
