### PR TITLE
Minecraft Status: Fix #2774 - Use Mojang API Directly

### DIFF
--- a/lib/DDG/Spice/MinecraftStatus.pm
+++ b/lib/DDG/Spice/MinecraftStatus.pm
@@ -6,7 +6,7 @@ use DDG::Spice;
 
 triggers any => 'minecraft', 'mcstatus', 'mc', 'mine craft';
 
-spice to => 'https://mcstatusraw.thedestruc7i0n.ca/';
+spice to => 'https://status.mojang.com/check';
 spice wrap_jsonp_callback => 1;
 
 spice is_cached => 1;

--- a/share/spice/minecraft_status/minecraft_status.js
+++ b/share/spice/minecraft_status/minecraft_status.js
@@ -1,17 +1,13 @@
 (function (env) {
     'use strict';
-    env.ddg_spice_minecraft_status = function(api_result) {
-        
-        if (!api_result) {
-            return Spice.failed('minecraft_status');
-        }     
-        
+    
+    function getStatus(data) {
         var green = [];
         var yellow = [];
         var red = [];        
-        
-        for (var i = 0; i < api_result.length; i++) {
-            var service = api_result[i];
+
+        for (var i = 0; i < data.length; i++) {
+            var service = data[i];
             var status = Object.keys(service)[1];
             var name = Object.keys(service)[0];
 
@@ -27,14 +23,25 @@
                     break;
             }
         } 
-        
-        var status = good;
-        
+
+        var status = 'good';
+
         if(red.length >= 1) {
             status = 'major';
         } else if(yellow.length >= 1) {
             status = 'minor';
         }
+
+        return status;
+    }
+    
+    env.ddg_spice_minecraft_status = function(api_result) {
+        
+        if (!api_result) {
+            return Spice.failed('minecraft_status');
+        }    
+        
+        var status = getStatus(api_result);
 
         Spice.add({
             id: 'minecraft_status',

--- a/share/spice/minecraft_status/minecraft_status.js
+++ b/share/spice/minecraft_status/minecraft_status.js
@@ -4,12 +4,42 @@
         
         if (!api_result) {
             return Spice.failed('minecraft_status');
+        }     
+        
+        var green = [];
+        var yellow = [];
+        var red = [];        
+        
+        for (var i = 0; i < api_result.length; i++) {
+            var service = api_result[i];
+            var status = Object.keys(service)[1];
+            var name = Object.keys(service)[0];
+
+            switch(status) {
+                case "green":
+                    green.push(name);
+                    break;
+                case "yellow":
+                    yellow.push(name);
+                    break;
+                case "red":
+                    red.push(name);
+                    break;
+            }
+        } 
+        
+        var final = {status: "good"}
+        
+        if(red.length >= 1) {
+            final.status = "major";
+        } else if(yellow.length >= 1) {
+            final.status = "minor";
         }
 
         Spice.add({
             id: 'minecraft_status',
             name: 'Status',
-            data: api_result,
+            data: final,
             meta: {
                 sourceName: 'Mojang Support',
                 sourceUrl: 'https://help.mojang.com/',

--- a/share/spice/minecraft_status/minecraft_status.js
+++ b/share/spice/minecraft_status/minecraft_status.js
@@ -16,30 +16,32 @@
             var name = Object.keys(service)[0];
 
             switch(status) {
-                case "green":
+                case 'green':
                     green.push(name);
                     break;
-                case "yellow":
+                case 'yellow':
                     yellow.push(name);
                     break;
-                case "red":
+                case 'red':
                     red.push(name);
                     break;
             }
         } 
         
-        var final = {status: "good"}
+        var status = good;
         
         if(red.length >= 1) {
-            final.status = "major";
+            status = 'major';
         } else if(yellow.length >= 1) {
-            final.status = "minor";
+            status = 'minor';
         }
 
         Spice.add({
             id: 'minecraft_status',
             name: 'Status',
-            data: final,
+            data: {
+                status: status
+            },
             meta: {
                 sourceName: 'Mojang Support',
                 sourceUrl: 'https://help.mojang.com/',


### PR DESCRIPTION
###### Description of changes

This will simply move from the API I created to the official one. I made my own because I wanted to include Minecraft Realms. However, recently it has gotten hard to check the status of Realms, so I decided to just revert back to the official one.
###### Related Issues or Discussions

Fixes #2774 

---

Instant Answer Page: https://duck.co/ia/view/minecraft_status

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @destruc7i0n
