### PR TITLE
Change forecast endpoint to darksky.net

### DIFF
--- a/lib/DDG/Spice/Forecast.pm
+++ b/lib/DDG/Spice/Forecast.pm
@@ -8,7 +8,7 @@ use Text::Trim;
 triggers start => "weather", "forecast", "weather forecast";
 
 spice from => '([^/]*)/?([^/]*)';
-spice to => 'http://forecast.io/ddg?apikey={{ENV{DDG_SPICE_FORECAST_APIKEY}}}&q=$1&callback={{callback}}';
+spice to => 'https://darksky.net/ddg?apikey={{ENV{DDG_SPICE_FORECAST_APIKEY}}}&q=$1&callback={{callback}}';
 
 # cache DDG Rewrite for 24 hours and
 # API responses with return code 200 for 30 minutes

--- a/share/spice/forecast/forecast.js
+++ b/share/spice/forecast/forecast.js
@@ -239,8 +239,8 @@
           data: spiceData,
           signal: "high",
           meta: {
-              sourceUrl: 'http://forecast.io/#/f/'+api_result.latitude+','+api_result.longitude,
-              sourceName: 'Forecast.io',
+              sourceUrl: 'https://darksky.net/'+api_result.latitude+','+api_result.longitude,
+              sourceName: 'Dark Sky',
               primaryText: weatherData.header,
               secondaryText: altMeta,
 


### PR DESCRIPTION
Updating the forecast.io endpoint to darksky.net.

@tommytommytommy 
cc @bsstoner 
https://github.com/duckduckgo/zeroclickinfo-spice/issues/3008