### PR TITLE
For the Rain IA, change forecast endpoint to darksky.net

### DIFF
--- a/lib/DDG/Spice/Rain.pm
+++ b/lib/DDG/Spice/Rain.pm
@@ -3,7 +3,7 @@ package DDG::Spice::Rain;
 use strict;
 use DDG::Spice;
 
-spice to => 'http://forecast.io/ddg?apikey={{ENV{DDG_SPICE_FORECAST_APIKEY}}}&q=$1&callback={{callback}}';
+spice to => 'https://darksky.net/ddg?apikey={{ENV{DDG_SPICE_FORECAST_APIKEY}}}&q=$1&callback={{callback}}';
 
 triggers start => "is it raining";
 triggers end => "raining here", "raining now", "raining yet";

--- a/share/spice/rain/rain.js
+++ b/share/spice/rain/rain.js
@@ -11,8 +11,8 @@
             name: 'Rain',
             data: api_result,
             meta: {
-                sourceName: "Forecast.io",
-                sourceUrl: "http://forecast.io/#/f/" + api_result.latitude + "," + api_result.longitude,
+                sourceName: "Dark Sky",
+                sourceUrl: "https://darksky.net/" + api_result.latitude + "," + api_result.longitude,
             },
             normalize: function(item) {
                 var is_raining = ["hail", "thunderstorm", "tornado", "sleet", "rain"].indexOf(item.currently.icon) >= 0;


### PR DESCRIPTION
Updating the forecast.io endpoint to darksky.net.

@tommytommytommy
cc @bsstoner
#3008
