### PR TITLE
Transit IAs: status icon colors correctly update

### DIFF
--- a/share/spice/transit/njt/transit_njt.js
+++ b/share/spice/transit/njt/transit_njt.js
@@ -27,12 +27,12 @@
             },
             normalize: function(item) {
                 var classes = {
-                        "Cancelled": "njt__cancelled",
-                        "Delayed": "njt__delayed",
-                        "All Aboard": "njt__boarding",
-                        "Boarding": "njt__boarding",
-                        "Stand By": "njt__boarding",
-                        "On Time": "njt__boarding"
+                        "Cancelled": "transit_njt__cancelled",
+                        "Delayed": "transit_njt__delayed",
+                        "All Aboard": "transit_njt__boarding",
+                        "Boarding": "transit_njt__boarding",
+                        "Stand By": "transit_njt__boarding",
+                        "On Time": "transit_njt__boarding"
                     };
 
                 if (!item.status) item.status = "On Time";
@@ -42,7 +42,7 @@
                     status: actualStatus(item, now),
                     line: item.line.replace('Line', ''),
                     cancelled: item.status === "Cancelled",
-                    status_class: delayedMins(item, now) > 0 ? "njt__delayed" : classes[item.status],
+                    status_class: delayedMins(item, now) > 0 ? "transit_njt__delayed" : classes[item.status],
                     bold_status_text: item.status === "Boarding" || item.status === "All Aboard",
                     url: 'http://dv.njtransit.com/mobile/train_stops.aspx?train=' + item.train
                 };
@@ -67,7 +67,7 @@
             },
             sort_default: 'time',
             onShow: function(){
-                $('.njt__cancelled').parents('.tile__body').addClass('njt__cancelled-tile');
+                $('.transit_njt__cancelled').parents('.tile__body').addClass('transit_njt__cancelled-tile');
             }
         });
     };

--- a/share/spice/transit/njt/transit_njt.js
+++ b/share/spice/transit/njt/transit_njt.js
@@ -2,7 +2,7 @@
     "use strict";
     env.ddg_spice_transit_njt = function(api_result) {
         if (!api_result || api_result.failed){
-            return Spice.failed('njt');
+            return Spice.failed('transit_njt');
         }
 
         var now = timeInMins(api_result.now);

--- a/share/spice/transit/septa/transit_septa.js
+++ b/share/spice/transit/septa/transit_septa.js
@@ -30,8 +30,8 @@
             },
             normalize: function(item) {
                 var classes = {
-                        "Suspended": "septa__cancelled",
-                        "Delayed": "septa__delayed"
+                        "Suspended": "transit_septa__cancelled",
+                        "Delayed": "transit_septa__delayed"
                     };
 
                 return {
@@ -40,7 +40,7 @@
                     line: item.orig_line.replace(' Line', '') + ' Line',
                     url: 'http://www.septa.org/schedules/rail/index.html',
                     status:  actualStatus(item),
-                    status_class: delayedMins(item.orig_delay) > 0 ? 'septa__delayed' : classes[item.orig_delay],
+                    status_class: delayedMins(item.orig_delay) > 0 ? 'transit_septa__delayed' : classes[item.orig_delay],
                     cancelled: (status === "Suspended")
                 };
             },

--- a/share/spice/transit/septa/transit_septa.js
+++ b/share/spice/transit/septa/transit_septa.js
@@ -7,7 +7,7 @@
                 !api_result[0].orig_line ||
                 !api_result[0].orig_departure_time ||
                 !api_result[0].orig_delay) {
-            return Spice.failed('septa');
+            return Spice.failed('transit_septa');
         }
 
         var script = $("[src*='js/spice/transit/septa/']")[0],

--- a/share/spice/transit/switzerland/transit_switzerland.js
+++ b/share/spice/transit/switzerland/transit_switzerland.js
@@ -3,7 +3,7 @@
     env.ddg_spice_transit_switzerland = function(api_result) {
 
         if (!api_result || api_result.error || !api_result.to || !api_result.from || !api_result.connections) {
-            return Spice.failed('switzerland');
+            return Spice.failed('transit_switzerland');
         }
         
         var to = api_result.to.name || '',

--- a/share/spice/transit/switzerland/transit_switzerland.js
+++ b/share/spice/transit/switzerland/transit_switzerland.js
@@ -34,7 +34,7 @@
                     name: item.sections[0].journey.name,
                     platform: item.from.platform,
                     status: (item.from.delay) ? 'Delayed' : 'On time',
-                    status_class: (item.from.delay) ? 'switzerland__delayed' : '',
+                    status_class: (item.from.delay) ? 'transit_switzerland__delayed' : '',
                     transfers: format_transfers(item.transfers),
                     url: 'http://transport.opendata.ch/examples/connections.php?from=' + from + '&to=' + to
                 }


### PR DESCRIPTION
## Type of Change
- [x] Improvement
    - [x] Bug fix

## Description of new Instant Answer, or changes
Patches a bug described in #3037, where status icon colors weren't updating when trains are delayed or cancelled. Class names in JavaScript files are updated to reflect those defined in CSS.

## Related Issues and Discussions
Fixes #3037

## People to notify
@moollaza 
Decided to do in a single commit/PR because the issue was related to what amounts to a template change for IAs of this type, but let me know if you'd rather this were split into 3.

---
Instant Answer Page: https://duck.co/ia/view/transit_septa
Instant Answer Page: https://duck.co/ia/view/transit_njt
Instant Answer Page: https://duck.co/ia/view/transit_switzerland


