### PR TITLE
Forecast: Detect and use UoM from the query

### DIFF
--- a/share/spice/forecast/forecast.js
+++ b/share/spice/forecast/forecast.js
@@ -157,7 +157,7 @@
         day = days[i];
 
         tmp_date = moment(today).add(i, 'days');
-        dailyObj[i].date = tmp_date.format("MMM D");        
+        dailyObj[i].date = tmp_date.format("MMM D");
         dailyObj[i].highTemp = Math.round(day.temperatureMax)+'&deg;';
         dailyObj[i].lowTemp = Math.round(day.temperatureMin)+'&deg;';
         dailyObj[i].icon = getIcon(getIconType(days[i].icon));
@@ -165,8 +165,8 @@
           height: max_temp_height * (day.temperatureMax - day.temperatureMin) / temp_span,
           top: max_temp_height * (high_temp - day.temperatureMax) / temp_span
         };
-        
-        if (i == 0) { 
+
+        if (i == 0) {
             dailyObj[i].day = 'Today';
         } else if (is_mobile) {
             dailyObj[i].day = tmp_date.format("ddd").toUpperCase();
@@ -340,8 +340,14 @@
       updateTempSwitch(uom);
     };
 
-    // if the metric setting is enabled and the API returned temps in F, switch to 'C':
-    if (!DDG.settings.isDefault('kaj')) {
+    // If there is celsius or fahrenheit mentioned in the query, do use that
+    // unit of measurement. If the metric setting is enabled and the API
+    // returned temps in F, switch to 'C':
+    var uom_in_query = DDG.get_query().match(/\b(celsius|fahrenheit)\b/);
+    if (uom_in_query) {
+        uom = (uom_in_query[1] === 'celsius') ? 'C' : 'F';
+        updateUnitOfMeasure();
+    } else if (!DDG.settings.isDefault('kaj')) {
         uom = DDG.settings.get('kaj') === 'm' ? 'C' : 'F';
         updateUnitOfMeasure();
     } else {


### PR DESCRIPTION
<!-- Use the appropriate format for your Pull Request title:

    For a Bug Fix:
    {IA Name}: {Description of change}

    For a New Instant Answer:
    New {IA Name} Spice

    For anything else:
    {Tests/Docs/Other}: {Short Description} -->


## Type of Change
<!-- Place and 'X' in the correct box (E.g `[X] Improvement`) -->

- [ ] New Instant Answer
    - [ ] Cheat Sheet
- [x] Improvement
    - [ ] Bug fix
    - [x] Enhancement
- [ ] Non–Instant Answer
    - [ ] Other (Role, Template, Test, Documentation, etc.)


## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
Currently we only show the UoM using the defaults (i.e. browser preferences). This commit checks the query for presence of 'celsius' or 'fahrenheit' and sets the displayed UoM appropriately.

---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->

IA Page: https://duck.co/ia/view/forecast

Signed-off-by: mr.Shu <mr@shu.io>