### PR TITLE
Use translated token for the name of the maps IA in Spice.add()

### DIFF
--- a/share/spice/maps/maps/maps_maps.js
+++ b/share/spice/maps/maps/maps_maps.js
@@ -15,7 +15,7 @@ DDG.require('maps',function(){
         Spice.add({
             data: response,
             id: "maps_maps",
-            name: lp("feedback form", "Maps",
+            name: lp("feedback form", "Maps"),
             model: "Place"
         });
 

--- a/share/spice/maps/maps/maps_maps.js
+++ b/share/spice/maps/maps/maps_maps.js
@@ -15,7 +15,7 @@ DDG.require('maps',function(){
         Spice.add({
             data: response,
             id: "maps_maps",
-            name: "maps",
+            name: lp("feedback form", "Maps",
             model: "Place"
         });
 


### PR DESCRIPTION
The token is for "Maps", not "maps", and it unfortunately has a context of "feedback form". This will force it to use the existing translation for the Maps IA link.

https://duck.co/translate/token/1346

I wish we could just remove the context on the existing token, but this works. @andrey-p would removing the "feedback form" context break the feedback form? Does all the text there have that context?

/cc @bbraithwaite 