### PR TITLE
MetaCPAN: Fixes #3051 - Fix up references in JS for MetaCPAN API

### DIFF
--- a/lib/DDG/Spice/MetaCPAN.pm
+++ b/lib/DDG/Spice/MetaCPAN.pm
@@ -14,7 +14,7 @@ triggers startend => "cpan", "cpanm", "metacpan", "mcpan", "meta cpan", "perl mo
 
 handle remainder => sub {
     if ($_) {
-        $_ =~ s/-/::/g;
+        $_ =~ s/(?!\s+)-/::/g;
         $_ = ( grep { /::/ } split /\s+/, $_ )[0] || $_;
         my $clean = $_ =~ s/::/ /gr;
         return $_, $clean;

--- a/share/spice/meta_cpan/meta_cpan.js
+++ b/share/spice/meta_cpan/meta_cpan.js
@@ -18,7 +18,7 @@
                 meta: {
                     itemType: 'Software',
                     sourceName: 'MetaCPAN',
-                    sourceUrl: 'https://metacpan.org/search?size=50&search_type=modules&q=' + encodeURIComponent(query)
+                    sourceUrl: 'https://metacpan.org/search?size=50&search_type=modules&q=' + query
                 },
                 normalize: function(item) {
                     if ( !item._source.module || !item._source.module[0] ||

--- a/share/spice/meta_cpan/meta_cpan.js
+++ b/share/spice/meta_cpan/meta_cpan.js
@@ -27,17 +27,17 @@
                         return null;
                     }
 
-                    var description = item.fields.description[0] || item.fields["abstract.analyzed"][0];
+                    var description = item.fields.description || item.fields["abstract.analyzed"];
                     var version = item._source.module[0].version;
-                    var date = ( item.fields.date && item.fields.date[0] )
-                        ? moment(item.fields.date[0]).format("DD MMM YYYY")
+                    var date = ( item.fields.date && item.fields.date )
+                        ? moment(item.fields.date).format("DD MMM YYYY")
                         : "";
 
                     return {
                         title: item._source.module[0].name,
                         url: 'https://metacpan.org/pod/' + item._source.module[0].name,
                         description: description,
-                        author: item.fields.author[0],
+                        author: item.fields.author,
                         version: version,
                         date: date
                     };


### PR DESCRIPTION
<!-- Use the appropriate format for your Pull Request title:

    For a Bug Fix:
    {IA Name}: {Description of change}

    For a New Instant Answer:
    New {IA Name} Spice

    For anything else:
    {Tests/Docs/Other}: {Short Description} -->


## Description of new Instant Answer, or changes
- Corrected references in meta_cpan.js to the returned data format for the MetaCPAN API
- Added exclusion rule to query regex to prevent a query with a space preceding hyphen - example: `cpan Mojolicious - plugins`


## Related Issues and Discussions
Fixes #3051 


## People to notify
<!-- Please @mention any relevant people/organizations here: -->

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/meta_cpan
<!-- FILL THIS IN:                           ^^^^ -->

…ce first object in array for Author, description and date with named key only