### PR TITLE
BrainyQuote: Update API call to HTTPS

### DIFF
--- a/lib/DDG/Spice/BrainyQuote.pm
+++ b/lib/DDG/Spice/BrainyQuote.pm
@@ -6,7 +6,7 @@ use DDG::Spice;
 
 triggers startend => 'quote', 'quotes', 'quotation', 'quotations';
 
-spice to => 'http://www.brainyquote.com/api/ddg?q=$1';
+spice to => 'https://www.brainyquote.com/api/ddg?q=$1';
 spice wrap_jsonp_callback => 1;
 
 handle remainder => sub {
@@ -15,9 +15,9 @@ handle remainder => sub {
     if(/^\w\.\w/) {
         s/\./\. /g;
     }
-    
+
     # Avoid triggering on 'stock' quotes; these are handled by Stocks IA
-    
+
     if ($req->query_lc =~ m/stock quote/) {
        return;
     }
@@ -27,7 +27,7 @@ handle remainder => sub {
             return;
         }
     }
-    
+
 
     return $_ if $_;
     return;


### PR DESCRIPTION
## Description of new Instant Answer, or changes

Updating API call as HTTP endpoint now redirects to HTTPS which has cause the IA to be disabled


<!-- DO NOT REMOVE -->
---

Instant Answer Page: https://duck.co/ia/view/brainy_quote


