### PR TITLE
Skyscanner Flight Search : Update accept headers call

### DIFF
--- a/lib/DDG/Spice/SkyscannerFlightSearch.pm
+++ b/lib/DDG/Spice/SkyscannerFlightSearch.pm
@@ -21,7 +21,7 @@ spice alt_to => {
     }
 };
 
-spice accept_header => 'application/json';
+spice headers => { Accept => 'application/json' };
 
 triggers startend => 'skyscanner';
 


### PR DESCRIPTION
## Skyscanner Flight Search : Update accept headers call

In preparation for https://github.com/duckduckgo/duckduckgo/pull/208 where `accept_header` has been deprecated, the `accept_header` call has been replaced with a `headers` hashref.

This commit should go live alongside the DDG Spice changes.

## Related Issues and Discussions

https://github.com/duckduckgo/duckduckgo/pull/208

## People to notify

@moollaza 

---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/skyscanner_flight_search
<!-- FILL THIS IN:                           ^^^^ -->

