### PR TITLE
ArXiV: Fixing js errors

### DIFF
--- a/share/spice/arxiv/arxiv.js
+++ b/share/spice/arxiv/arxiv.js
@@ -58,9 +58,11 @@
                         item.feed.entry.published.text.replace( /^(\d{4}).*/, "$1" )
                     ),
                     url: url,
-                    subtitle: item.feed.entry.author.map( function(e) {
-                        return e.name.text;
-                    } ).join(', '),
+                    subtitle: (item.feed.entry.author instanceof Array) ?
+                        item.feed.entry.author.map(function(e) {
+                            return e.name.text;
+                        }).join(', ') :
+                        item.feed.entry.author.name.text,
                     description: item.feed.entry.summary.text
                 };
             },

--- a/share/spice/arxiv/arxiv.js
+++ b/share/spice/arxiv/arxiv.js
@@ -34,7 +34,7 @@
 
     env.ddg_spice_arxiv = function(api_result){
 
-        if (!api_result) {
+        if (!api_result || !api_result.feed) {
             return Spice.failed('arxiv');
         }
 

--- a/share/spice/arxiv/arxiv.js
+++ b/share/spice/arxiv/arxiv.js
@@ -33,12 +33,14 @@
     }
 
     env.ddg_spice_arxiv = function(api_result){
-        var url = get_arxiv_rel_link( api_result.feed.entry.link );
-        var pdf_url = get_pdf_link( api_result.feed.entry.link );
 
         if (!api_result) {
             return Spice.failed('arxiv');
         }
+
+        var url = get_arxiv_rel_link( api_result.feed.entry.link );
+        var pdf_url = get_pdf_link( api_result.feed.entry.link );
+
 
         Spice.add({
             id: "arxiv",


### PR DESCRIPTION
## ArXiV: Fixing js errors

There were two potential js errors here which would result in images fallback being triggered:

- Accessing elements of `api_result` before ensuring it was populated
- In papers with a single author, `item.feed.entry.author` is an Object, not Array so `map` can't be applied.

## Related Issues and Discussions

Fixes: #3045

## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@bsstoner
<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/arxiv
<!-- FILL THIS IN:                           ^^^^ -->
