### PR TITLE
MetaCPAN: Fixes #3060 - strip second form of query from Javascript query var if

### DIFF
--- a/share/spice/meta_cpan/meta_cpan.js
+++ b/share/spice/meta_cpan/meta_cpan.js
@@ -2,13 +2,20 @@
     env.ddg_spice_meta_cpan = function(api_result) {
         "use strict";
 
+        if ( !api_result || api_result.hits.hits.length < 1 ) {
+            return DDH.failed('meta_cpan');
+        }
+
+
         var script = $('[src*="/js/spice/meta_cpan/"]')[0];
         var source = $(script).attr("src");
         var query = source.match(/meta_cpan\/([^\/]*)/)[1];
 
-        if ( !api_result || api_result.hits.hits.length < 1 ) {
-            return DDH.failed('meta_cpan');
+        // if query still has both items from handle remainder, remove $clean version
+        if (query.indexOf('/' !== -1)) {
+            query = query.split('/')[0];
         }
+
 
         DDG.require('moment.js', function() {
             Spice.add({


### PR DESCRIPTION
## Description of new Instant Answer, or changes
Fix up Javascript query var to contain correct module name for link to MetaCPAN, also moves no results check to earliest point.


## Related Issues and Discussions
Fixes #3060 


## People to notify
@sahildua2305 @GuiltyDolphin 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/meta_cpan
<!-- FILL THIS IN:                           ^^^^ -->