### PR TITLE
enable showDirections option for what3words spice

### DIFF
--- a/share/spice/what3words/what3words.js
+++ b/share/spice/what3words/what3words.js
@@ -36,6 +36,7 @@
                     id: "what3words",
                     name: "Map",
                     data: {
+                        showDirections: true,
                         name: api_result.words,
                         lat: api_result.geometry.lat,
                         lon: api_result.geometry.lng,


### PR DESCRIPTION
## Description of new Instant Answer, or changes
This PR enables the What3Words Spice to provide a link to directions to the 3-word address the user has searched.

The W3W team reached out to me directly with this suggestion, and because it is a trivial change I decided to do it.

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/what3words
<!-- FILL THIS IN:                           ^^^^ -->

