### PR TITLE
Maven: Add "package","library","repository" and "repo" to trigger words.

### DIFF
--- a/lib/DDG/Spice/Maven.pm
+++ b/lib/DDG/Spice/Maven.pm
@@ -4,15 +4,22 @@ package DDG::Spice::Maven;
 use strict;
 use DDG::Spice;
 
-triggers startend => "maven", "mvn","library","repository","repo","package";
-
+triggers any => "maven", "mvn","repository","repo","java library","package","library java","lib java","java lib","module java","java module";
+# triggers any=> "/([a-z].+)?.?(java|maven|mvn).+?([a-z].+)?.+?(repository|repo|library|package)/ig","/([a-z].+)?.+?(repository|repo|library|package).+?([a-z].+)?.+?(java|maven|mvn)/ig";
 spice to => 'http://search.maven.org/solrsearch/select?q=$1&rows=5&wt=json&callback={{callback}}';
 spice wrap_jsonp_callback => 1;
 spice proxy_cache_valid   => "418 1d";
 
 handle remainder => sub {
-    return $_ if $_;
-    return;
+if($req->matched_trigger=~ m/java (library|lib|module)/ |$req->matched_trigger=~ m/(lib|library|module) java/ )
+{
+return $req->matched_trigger
+}
+else
+{
+return $_ if $_;
+return;
+}
 };
 
 1;

--- a/lib/DDG/Spice/Maven.pm
+++ b/lib/DDG/Spice/Maven.pm
@@ -4,7 +4,7 @@ package DDG::Spice::Maven;
 use strict;
 use DDG::Spice;
 
-triggers startend => "maven", "mvn";
+triggers startend => "maven", "mvn","library","repository","repo","package";
 
 spice to => 'http://search.maven.org/solrsearch/select?q=$1&rows=5&wt=json&callback={{callback}}';
 spice wrap_jsonp_callback => 1;


### PR DESCRIPTION
## Description: Added Additional Triggers to the maven IA

Example Query: [java package](https://www.duckduckgo.com/?q=java+package), [perl package](https://www.duckduckgo.com/?q=perl+package)

Tab Name: Software

Source: search.maven.org


![image](https://cloud.githubusercontent.com/assets/18739869/20858269/42d1b02c-b968-11e6-86e6-3365e2cebd5d.png)

## Related Issues and Discussions

Fixes #3050 


## People to notify
@nicoulaj 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
https://duck.co/ia/view/maven
<!-- FILL THIS IN:                           ^^^^ -->

