### PR TITLE
RxInfo: Remove trigger on tablet

### DIFF
--- a/lib/DDG/Spice/RxInfo.pm
+++ b/lib/DDG/Spice/RxInfo.pm
@@ -4,7 +4,7 @@ package DDG::Spice::RxInfo;
 use strict;
 use DDG::Spice;
 
-triggers startend => 'pill', 'rxinfo', 'capsule', 'tablet', 'softgel', 'caplets';
+triggers startend => 'pill', 'rxinfo', 'capsule', 'softgel', 'caplets';
 
 spice to => 'http://rximage.nlm.nih.gov/api/rximage/1/rxbase?resolution=300&includeIngredients=true&parse=$1';
 spice from => '(.*?)/(\d)';


### PR DESCRIPTION
## Description of new Instant Answer, or changes
Triggering way too much on tech-related tablet searches.

## Related Issues and Discussions
Fixes #3052  

@moollaza 

---
https://duck.co/ia/view/rx_info