### PR TITLE
What3Words: remove trigger on word.word.word

### DIFF
--- a/lib/DDG/Spice/What3Words.pm
+++ b/lib/DDG/Spice/What3Words.pm
@@ -21,8 +21,7 @@ my $coord_re = qr/[+-]?[0-9]+(?:\.\d{1,6})?/;
 
 # Handles queries like:
 # what3words | w3w | what three words word.word.word
-# word.word.word
-triggers query_lc => qr/^(?:$w3w_re)?(\p{L}{4,}+\.\p{L}{4,}+\.\p{L}{1,}+)$/i;
+triggers query_lc => qr/^(?:$w3w_re)(\p{L}{4,}+\.\p{L}{4,}+\.\p{L}{1,}+)$/i;
 
 # Handles queries like:
 # what3words | w3w | what three words +/-##.####, +/-###.#####

--- a/t/What3Words.t
+++ b/t/What3Words.t
@@ -24,11 +24,6 @@ ddg_spice_test(
         call_type => 'include',
         caller => 'DDG::Spice::What3Words'
     ),
-    'veal.notion.loses' => test_spice(
-        '/js/spice/what3words/forward/addr/veal.notion.loses',
-        call_type => 'include',
-        caller => 'DDG::Spice::What3Words'
-    ),
     'w3w 40.74845, -73.985643' => test_spice(
         '/js/spice/what3words/reverse/coords/40.74845%2C-73.985643',
         call_type => 'include',
@@ -38,7 +33,8 @@ ddg_spice_test(
     'what3words veal notion loses' => undef,
     'w3w Empire State Building, New York' => undef,
     'www.facebook.com' => undef,
-    'images.facebook.com' => undef
+    'images.facebook.com' => undef,
+    'veal.notion.loses' => undef
 );
 
 done_testing;


### PR DESCRIPTION
## Description of new Instant Answer, or changes
The majority of the triggering of this IA is false positives on technical searches like:
string.prototype.length
system.diagnostics.process 


## Related Issues and Discussions
Fixes #2986

## People to notify
@moollaza 

---
https://duck.co/ia/view/what3words