### PR TITLE
What3Words: Use latLng array so directions points to lat,lon instead of address

### DIFF
--- a/share/spice/what3words/what3words.js
+++ b/share/spice/what3words/what3words.js
@@ -38,8 +38,7 @@
                     data: {
                         showDirections: true,
                         name: api_result.words,
-                        lat: api_result.geometry.lat,
-                        lon: api_result.geometry.lng,
+                        latLng: [ api_result.geometry.lat, api_result.geometry.lng ],
                         displayLatLon: api_result.geometry.lat + ", " + api_result.geometry.lng,
                         address: address_string
                     },


### PR DESCRIPTION
## Description of new Instant Answer, or changes
Use `latLng` array instead of separate `lat` and `lon` properties. This enables the internal directions code to work as expected, ensuring the directions URL points to a Lat/Lon pair, instead of the named address string.


<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/what3words
<!-- FILL THIS IN:                           ^^^^ -->

