### PR TITLE
CocoaPods: Set empty referer header to make Cocoapoads API happy

### DIFF
--- a/lib/DDG/Spice/Cocoapods.pm
+++ b/lib/DDG/Spice/Cocoapods.pm
@@ -8,6 +8,7 @@ triggers startend => 'cocoapods';
 
 spice to => 'http://search.cocoapods.org/api/v1/pods.flat.hash.json?query=$1';
 spice wrap_jsonp_callback => 1;
+spice headers => { Referer => '' };
 
 handle remainder => sub {
 	return lc $_ if $_;


### PR DESCRIPTION
## Description of new Instant Answer, or changes
The Cocoapods Spice has never worked in production, since release because the Cocoapods API is confused by the headers we send.

After speaking with the Coacoapods Team, we found that the easiest solution is to send an empty Referer header.

We needed to add better support for Headers to Spice Instant Answers in order to achieve this and we are awaiting for that to be finalized and merged here: https://github.com/duckduckgo/duckduckgo/pull/208

**DO NOT MERGE, until the above PR has been merged**

## People to notify
@soleo @jbarrett @jdorweiler 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/cocoapods
<!-- FILL THIS IN:                           ^^^^ -->

