### PR TITLE
Forecast: Prepare for translated forecasts

### DIFF
--- a/lib/DDG/Spice/Forecast.pm
+++ b/lib/DDG/Spice/Forecast.pm
@@ -23,10 +23,11 @@ handle remainder => sub {
 
     my $loc_str = join " ", map { $loc->{$_} } @locs;
 
+    my ($parsed_locale) = $lang->locale =~ /_([A-Z]{2})$/;
     # Default to English
-    my $parsed_locale = lc ($lang->locale =~ /_[A-Z]{2}$/);
-    my $local_lang = $parsed_locale // 'en';
-    return $loc_str, $local_lang, {is_cached => 0};
+    $parsed_locale ||= 'en';
+    $parsed_locale = lc $parsed_locale;
+    return $loc_str, $parsed_locale, {is_cached => 0};
 };
 
 # 2015.03.17 tommytommytommy:

--- a/lib/DDG/Spice/Forecast.pm
+++ b/lib/DDG/Spice/Forecast.pm
@@ -8,7 +8,7 @@ use Text::Trim;
 triggers start => "weather", "forecast", "weather forecast";
 
 spice from => '([^/]*)/?([^/]*)';
-spice to => 'https://darksky.net/ddg?apikey={{ENV{DDG_SPICE_FORECAST_APIKEY}}}&q=$1&callback={{callback}}';
+spice to => 'https://darksky.net/ddg?apikey={{ENV{DDG_SPICE_FORECAST_APIKEY}}}&q=$1&callback={{callback}}&lang=$2';
 
 # cache DDG Rewrite for 24 hours and
 # API responses with return code 200 for 30 minutes
@@ -22,7 +22,10 @@ handle remainder => sub {
     return if $_;
 
     my $loc_str = join " ", map { $loc->{$_} } @locs;
-    return $loc_str, 'current', {is_cached => 0};
+
+    # Default to English
+    my $local_lang = $lang->{flagicon} || 'en';
+    return $loc_str, $local_lang, {is_cached => 0};
 };
 
 # 2015.03.17 tommytommytommy:

--- a/lib/DDG/Spice/Forecast.pm
+++ b/lib/DDG/Spice/Forecast.pm
@@ -24,7 +24,8 @@ handle remainder => sub {
     my $loc_str = join " ", map { $loc->{$_} } @locs;
 
     # Default to English
-    my $local_lang = $lang->{flagicon} || 'en';
+    my $parsed_locale = lc ($lang->locale =~ /_[A-Z]{2}$/);
+    my $local_lang = $parsed_locale // 'en';
     return $loc_str, $local_lang, {is_cached => 0};
 };
 

--- a/lib/DDG/Spice/Forecast.pm
+++ b/lib/DDG/Spice/Forecast.pm
@@ -23,11 +23,14 @@ handle remainder => sub {
 
     my $loc_str = join " ", map { $loc->{$_} } @locs;
 
-    my ($parsed_locale) = $lang->locale =~ /_([A-Z]{2})$/;
     # Default to English
-    $parsed_locale ||= 'en';
-    $parsed_locale = lc $parsed_locale;
-    return $loc_str, $parsed_locale, {is_cached => 0};
+    my $parsed_lang = 'en';
+    # And try to extract language from locale
+    if ($lang && $lang->locale) {
+        ($parsed_lang) = $lang->locale =~ /_([A-Z]{2})$/;
+        $parsed_lang = lc $parsed_lang;
+    }
+    return $loc_str, $parsed_lang, {is_cached => 0};
 };
 
 # 2015.03.17 tommytommytommy:

--- a/t/Forecast.t
+++ b/t/Forecast.t
@@ -5,6 +5,7 @@ use warnings;
 use Test::More;
 use URI::Escape;
 use DDG::Test::Location;
+use DDG::Test::Language;
 use DDG::Test::Spice;
 use DDG::Request;
 
@@ -14,8 +15,9 @@ ddg_spice_test(
     DDG::Request->new(
         query_raw => 'weather',
         location => test_location('de'),
+        language => test_language('de'),
     ) => test_spice(
-        "/js/spice/forecast/M%C3%B6nchengladbach%20Nordrhein-Westfalen%20Germany/current",
+        "/js/spice/forecast/M%C3%B6nchengladbach%20Nordrhein-Westfalen%20Germany/de",
         call_type => 'include',
         caller => 'DDG::Spice::Forecast',
         is_cached => 0
@@ -25,7 +27,7 @@ ddg_spice_test(
         query_raw => 'weather',
         location => test_location('us'),
     ) => test_spice(
-        "/js/spice/forecast/Phoenixville%20Pennsylvania%20United%20States/current",
+        "/js/spice/forecast/Phoenixville%20Pennsylvania%20United%20States/en",
         call_type => 'include',
         caller => 'DDG::Spice::Forecast',
         is_cached => 0
@@ -35,7 +37,7 @@ ddg_spice_test(
         query_raw => 'weather',
         location => test_location('my'),
     ) => test_spice(
-        "/js/spice/forecast/Kuala%20Lumpur%20Kuala%20Lumpur%20Malaysia/current",
+        "/js/spice/forecast/Kuala%20Lumpur%20Kuala%20Lumpur%20Malaysia/en",
         call_type => 'include',
         caller => 'DDG::Spice::Forecast',
         is_cached => 0


### PR DESCRIPTION
## Description of new Instant Answer, or changes
* Prepare for translated forecasts from DarkSky by passing the `$lang` parameter.


<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/forecast
<!-- FILL THIS IN:                           ^^^^ -->
