### PR TITLE
Skyscanner Flight Search: API key typo fix

### DIFF
--- a/share/spice/skyscanner_flight_search/skyscanner_flight_search.js
+++ b/share/spice/skyscanner_flight_search/skyscanner_flight_search.js
@@ -149,7 +149,7 @@
                         price: (currency_symbol_left) ? "from " + currency_symbol + item.flight_price : "from " + item.flight_price + " " + currency_symbol,
                         priceAge: moment(item.flight_price_age).fromNow(),
                         url: "http://partners.api.skyscanner.net/apiservices/referral/v1.0/GB/" + currency_code + "/en-GB/" + item.flight_origin_code + "/" + item.flight_destination_code + "/" 
-                            + moment(item.flight_outbound_date).format("YYYY-MM-DD") + "/" + moment(item.flight_return_date).format("YYYY-MM-DD") + "?apiKey=te1561648834359",
+                            + moment(item.flight_outbound_date).format("YYYY-MM-DD") + "/" + moment(item.flight_return_date).format("YYYY-MM-DD") + "?apiKey=te15616488343591",
                     };
                 },
             }); 


### PR DESCRIPTION
fixing the short api key for the referral service, missing one character causing the associateId to not be found when referring to Skyscanner website

## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->


## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->


## People to notify
<!-- Please @mention any relevant people/organizations here: -->

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/skyscanner_flight_search
<!-- FILL THIS IN:                           ^^^^ -->
