### PR TITLE
New Repl.it REPL Spice

### DIFF
--- a/lib/DDG/Spice/Repl.pm
+++ b/lib/DDG/Spice/Repl.pm
@@ -35,11 +35,14 @@ my @langs = qw(
     fsharp
     go
     java
+    lua
     nodejs
     php
     python
     python3
     ruby
+    rust
+    swift
 );
 
 # More Languages Coming Soon...
@@ -50,11 +53,9 @@ my @langs = qw(
 # emoticon
 # jest
 # lolcode
-# lua
 # python_turtle
 # qbasic
 # roy
-# rust
 # scheme
 # unlambda
 

--- a/lib/DDG/Spice/Repl.pm
+++ b/lib/DDG/Spice/Repl.pm
@@ -6,8 +6,8 @@ use warnings;
 
 use MIME::Base64 qw(encode_base64);
 
-my $uname = $ENV{DDG_SPICE_REPL_UNAME};
-my $passw = $ENV{DDG_SPICE_REPL_PASSW};
+my $uname = $ENV{DDG_SPICE_REPL_UNAME} || '';
+my $passw = $ENV{DDG_SPICE_REPL_PASSW} || '';
 # Pass empty string as eol char
 my $encoded_uname_pw = encode_base64("$uname:$passw", '');
 
@@ -48,9 +48,6 @@ my @langs = qw(
 # brainf
 # coffeescript
 # emoticon
-# fsharp
-# go
-# java
 # jest
 # lolcode
 # lua
@@ -62,35 +59,39 @@ my @langs = qw(
 # unlambda
 
 
-my %aliases = (
-    'c plus plus' => 'cpp',
-    'c sharp' => 'csharp',
-    'c#' => 'csharp',
-    'c++' => 'cpp',
-    'c++11' => 'cpp11',
-    'cplusplus' => 'cpp',
-    'f sharp' => 'fsharp',
-    'f#' => 'fsharp',
-    'go lang' => 'go',
-    'golang' => 'go',
-    'java script' => 'nodejs',
-    'js es6' => 'babel',
-    'js' => 'node',
-    'node.js' => 'nodejs',
-    'node' => 'nodejs',
-    'python 2' => 'python',
-    'python 3' => 'python3',
-    'python2' => 'python',
-    # 'es6' => 'babel',
-    # 'javascript es6' => 'babel',
+my @aliases = (
+    'c plus plus',
+    'c sharp',
+    'c#',
+    'c++ 11',
+    'c++',
+    'c++11',
+    'cplusplus',
+    'es6',
+    'f sharp',
+    'f#',
+    'go lang',
+    'golang',
+    'java script',
+    'javascript es6',
+    'javascript',
+    'js es6',
+    'js',
+    'node.js',
+    'node',
+    'python 2',
+    'python 3',
+    'python2'
 );
 
-handle remainder => sub {
+my @allowed = (@langs, @aliases);
+
+handle remainder_lc => sub {
 
     return unless $_;
     # strip 'online ' from query
-    s/online //;
-    return unless $_ ~~ @langs || exists $aliases{$_};
+    s/(online|interpreter) //g;
+    return unless $_ ~~ @allowed;
     return '';
 };
 

--- a/lib/DDG/Spice/Repl.pm
+++ b/lib/DDG/Spice/Repl.pm
@@ -60,9 +60,9 @@ my @langs = qw(
     ruby
     rust
     scheme
-    swift
     unlambda
 );
+# swift
 # web_project
 
 my %aliases = (

--- a/lib/DDG/Spice/Repl.pm
+++ b/lib/DDG/Spice/Repl.pm
@@ -1,0 +1,104 @@
+package DDG::Spice::Repl;
+
+use DDG::Spice;
+use strict;
+use warnings;
+
+use MIME::Base64 ;
+use MIME::Base64 qw(encode_base64);
+
+spice is_cached => 1;
+spice proxy_cache_valid => '200 1d'; # defaults to this automatically
+
+spice wrap_jsonp_callback => 1;
+
+my $uname = $ENV{DDG_SPICE_REPL_UNAME};
+my $passw = $ENV{DDG_SPICE_REPL_PASSW};
+my $encoded_uname_pw = encode_base64("$uname:$passw");
+
+warn $encoded_uname_pw;
+
+# Use a garbage endpoint to spoof first API call so we can load JS
+spice to => 'https://api.duckduckgo.com?q=hello&format=json';
+spice alt_to => {
+    repl_eval => {
+        to => 'https://eval.repl.it/eval?language=$1&code=$2',
+        from => '([^/]+)(?:/(.*))?',
+        is_cached => 1,
+        proxy_cache_valid => '418 1d',
+        headers => {
+            Authorization => "Basic $encoded_uname_pw"
+        }
+    }
+};
+
+triggers end => 'repl';
+
+my @langs = qw(
+    apl
+    bloop
+    brainf
+    c
+    csharp
+    cpp
+    cpp11
+    coffeescript
+    emoticon
+    babel
+    fsharp
+    forth
+    go
+    java
+    javascript
+    jest
+    lolcode
+    lua
+    nodejs
+    php
+    python
+    python_turtle
+    python3
+    qbasic
+    roy
+    ruby
+    rust
+    scheme
+    swift
+    unlambda
+    web_project
+);
+
+my %aliases = (
+    'brain fuck' => 'brainf',
+    'brainfuck' => 'brainf',
+    'c#' => 'csharp',
+    'c++' => 'cpp',
+    'c++11' => 'cpp11',
+    'coffee script' => 'coffeescript',
+    'css' => 'web_project',
+    'es6' => 'babel',
+    'f#' => 'fsharp',
+    'html' => 'web_project',
+    'java script' => 'javascript',
+    'javascript es6' => 'babel',
+    'js es6' => 'babel',
+    'js' => 'javascript',
+    'node.js' => 'nodejs',
+    'node' => 'nodejs',
+    'python 2' => 'python',
+    'python 3' => 'python3',
+    'python turtle' => 'python_turtle',
+    'python with turtle' => 'python_turtle',
+    'python2' => 'python'
+);
+
+handle remainder => sub {
+
+    return unless $_;
+    warn $_;
+    return $_, "10*10" if $_ ~~ @langs;
+    warn $aliases{$_};
+    return $aliases{$_}, "5*5" if exists $aliases{$_};
+};
+
+1;

--- a/lib/DDG/Spice/Repl.pm
+++ b/lib/DDG/Spice/Repl.pm
@@ -13,7 +13,8 @@ spice wrap_jsonp_callback => 1;
 
 my $uname = $ENV{DDG_SPICE_REPL_UNAME};
 my $passw = $ENV{DDG_SPICE_REPL_PASSW};
-my $encoded_uname_pw = encode_base64("$uname:$passw");
+# Pass empty string as eol char
+my $encoded_uname_pw = encode_base64("$uname:$passw", '');
 
 # Use a garbage endpoint to spoof first API call so we can load JS
 spice to => 'https://api.duckduckgo.com?q=hello&format=json';

--- a/lib/DDG/Spice/Repl.pm
+++ b/lib/DDG/Spice/Repl.pm
@@ -15,8 +15,6 @@ my $uname = $ENV{DDG_SPICE_REPL_UNAME};
 my $passw = $ENV{DDG_SPICE_REPL_PASSW};
 my $encoded_uname_pw = encode_base64("$uname:$passw");
 
-warn $encoded_uname_pw;
-
 # Use a garbage endpoint to spoof first API call so we can load JS
 spice to => 'https://api.duckduckgo.com?q=hello&format=json';
 spice alt_to => {
@@ -31,7 +29,7 @@ spice alt_to => {
     }
 };
 
-triggers end => 'repl';
+triggers startend => 'repl', 'repl online', 'online repl', 'interpreter', 'interpreter online', 'online interpreter';
 
 my @langs = qw(
     apl
@@ -64,8 +62,8 @@ my @langs = qw(
     scheme
     swift
     unlambda
-    web_project
 );
+# web_project
 
 my %aliases = (
     'brain fuck' => 'brainf',
@@ -77,7 +75,7 @@ my %aliases = (
     'css' => 'web_project',
     'es6' => 'babel',
     'f#' => 'fsharp',
-    'html' => 'web_project',
+    # 'html' => 'web_project',
     'java script' => 'javascript',
     'javascript es6' => 'babel',
     'js es6' => 'babel',
@@ -85,19 +83,19 @@ my %aliases = (
     'node.js' => 'nodejs',
     'node' => 'nodejs',
     'python 2' => 'python',
+    'python2' => 'python',
     'python 3' => 'python3',
     'python turtle' => 'python_turtle',
     'python with turtle' => 'python_turtle',
-    'python2' => 'python'
 );
 
 handle remainder => sub {
 
     return unless $_;
-    warn $_;
-    return $_, "10*10" if $_ ~~ @langs;
-    warn $aliases{$_};
-    return $aliases{$_}, "5*5" if exists $aliases{$_};
+    # strip 'online ' from query
+    s/online //;
+    return unless $_ ~~ @langs || exists $aliases{$_};
+    return $aliases{$_} // $_;
 };
 
 1;

--- a/lib/DDG/Spice/Repl.pm
+++ b/lib/DDG/Spice/Repl.pm
@@ -6,22 +6,17 @@ use warnings;
 
 use MIME::Base64 qw(encode_base64);
 
-spice is_cached => 1;
-spice proxy_cache_valid => '200 1d'; # defaults to this automatically
-
-spice wrap_jsonp_callback => 1;
-
 my $uname = $ENV{DDG_SPICE_REPL_UNAME};
 my $passw = $ENV{DDG_SPICE_REPL_PASSW};
 # Pass empty string as eol char
 my $encoded_uname_pw = encode_base64("$uname:$passw", '');
 
-# Use a garbage endpoint to spoof first API call so we can load JS
-spice to => 'https://api.duckduckgo.com?q=hello&format=json';
+spice call_type => 'self';
+
 spice alt_to => {
     repl_eval => {
         to => 'https://eval.repl.it/eval?language=$1&code=$2',
-        from => '([^/]+)(?:/(.*))?',
+        from => '([^/]+)/([^/]+)',
         is_cached => 1,
         proxy_cache_valid => '418 1d',
         headers => {
@@ -96,7 +91,7 @@ handle remainder => sub {
     # strip 'online ' from query
     s/online //;
     return unless $_ ~~ @langs || exists $aliases{$_};
-    return $aliases{$_} // $_;
+    return '';
 };
 
 1;

--- a/lib/DDG/Spice/Repl.pm
+++ b/lib/DDG/Spice/Repl.pm
@@ -4,7 +4,6 @@ use DDG::Spice;
 use strict;
 use warnings;
 
-use MIME::Base64 ;
 use MIME::Base64 qw(encode_base64);
 
 spice is_cached => 1;

--- a/lib/DDG/Spice/Repl.pm
+++ b/lib/DDG/Spice/Repl.pm
@@ -33,61 +33,61 @@ spice alt_to => {
 triggers startend => 'repl', 'repl online', 'online repl', 'interpreter', 'interpreter online', 'online interpreter';
 
 my @langs = qw(
-    apl
-    bloop
-    brainf
     c
-    csharp
     cpp
     cpp11
-    coffeescript
-    emoticon
-    babel
+    csharp
     fsharp
-    forth
     go
     java
-    javascript
-    jest
-    lolcode
-    lua
     nodejs
     php
     python
-    python_turtle
     python3
-    qbasic
-    roy
     ruby
-    rust
-    scheme
-    unlambda
 );
-# swift
-# web_project
+
+# More Languages Coming Soon...
+# apl
+# bloop
+# brainf
+# coffeescript
+# emoticon
+# fsharp
+# go
+# java
+# jest
+# lolcode
+# lua
+# python_turtle
+# qbasic
+# roy
+# rust
+# scheme
+# unlambda
+
 
 my %aliases = (
-    'brain fuck' => 'brainf',
-    'brainfuck' => 'brainf',
+    'c plus plus' => 'cpp',
+    'c sharp' => 'csharp',
     'c#' => 'csharp',
     'c++' => 'cpp',
     'c++11' => 'cpp11',
-    'coffee script' => 'coffeescript',
-    'css' => 'web_project',
-    'es6' => 'babel',
+    'cplusplus' => 'cpp',
+    'f sharp' => 'fsharp',
     'f#' => 'fsharp',
-    # 'html' => 'web_project',
-    'java script' => 'javascript',
-    'javascript es6' => 'babel',
+    'go lang' => 'go',
+    'golang' => 'go',
+    'java script' => 'nodejs',
     'js es6' => 'babel',
-    'js' => 'javascript',
+    'js' => 'node',
     'node.js' => 'nodejs',
     'node' => 'nodejs',
     'python 2' => 'python',
-    'python2' => 'python',
     'python 3' => 'python3',
-    'python turtle' => 'python_turtle',
-    'python with turtle' => 'python_turtle',
+    'python2' => 'python',
+    # 'es6' => 'babel',
+    # 'javascript es6' => 'babel',
 );
 
 handle remainder => sub {

--- a/lib/DDG/Spice/Repl.pm
+++ b/lib/DDG/Spice/Repl.pm
@@ -15,13 +15,15 @@ spice call_type => 'self';
 
 spice alt_to => {
     repl_eval => {
-        to => 'https://eval.repl.it/eval?language=$1&code=$2',
+        to => 'http://eval.repl.it/eval',
         from => '([^/]+)/([^/]+)',
         is_cached => 1,
         proxy_cache_valid => '418 1d',
         headers => {
-            Authorization => "Basic $encoded_uname_pw"
-        }
+            Authorization => "Basic $encoded_uname_pw",
+            'Content-Type' => 'application/x-www-form-urlencoded'
+        },
+        post_body => 'language=$1&code=$2'
     },
     repl_samples => {
         to => 'https://syntaxdb.com/api/v1/languages/$1/concepts',

--- a/lib/DDG/Spice/Repl.pm
+++ b/lib/DDG/Spice/Repl.pm
@@ -22,6 +22,11 @@ spice alt_to => {
         headers => {
             Authorization => "Basic $encoded_uname_pw"
         }
+    },
+    repl_samples => {
+        to => 'https://syntaxdb.com/api/v1/languages/$1/concepts',
+        is_cached => 1,
+        proxy_cache_valid => '200 30d'
     }
 };
 

--- a/share/spice/repl/content.handlebars
+++ b/share/spice/repl/content.handlebars
@@ -22,7 +22,7 @@
     <div class="g half">
         <div class="frm frm--vrt">
             <label class="frm__label">Result</label>
-            <textarea id="repl__result" class="frm__text repl__code tx--15" name="repl__result" rows="8" ></textarea>
+            <textarea id="repl__result" class="frm__text repl__code tx--15" name="repl__result" rows="8" readonly="readonly"></textarea>
         </div>
     </div>
 </div>

--- a/share/spice/repl/content.handlebars
+++ b/share/spice/repl/content.handlebars
@@ -1,0 +1,28 @@
+<div class="gw">
+    <div class="g half">
+        <div class="frm frm--vrt">
+
+            <label class="frm__label">Code</label>
+            <div id="repl__editor"></div>
+
+            <div class="frm__field">
+                <label class="frm__label">Programming Language</label>
+                <div class="frm__select">
+                    <select id="repl__language" name="language">
+                        {{#each langs}}
+                        <option value="{{val}}" {{is_selected val ../selected}}>{{text}}</option>
+                        {{/each}}
+                    </select>
+                </div>
+                <button id="repl__submit" type="button" class="btn btn--primary pull-right">Execute Code</button>
+            </div>
+        </div>
+    </div>
+
+    <div class="g half">
+        <div class="frm frm--vrt">
+            <label class="frm__label">Result</label>
+            <textarea id="repl__result" class="frm__text repl__code tx--15" name="repl__result" rows="8" ></textarea>
+        </div>
+    </div>
+</div>

--- a/share/spice/repl/content.handlebars
+++ b/share/spice/repl/content.handlebars
@@ -8,11 +8,14 @@
             <div class="frm__field">
                 <label class="frm__label">Programming Language</label>
                 <div class="frm__select">
-                    <select id="repl__language" name="language">
+                    <select id="repl__language">
                         {{#each langs}}
                         <option value="{{val}}" {{is_selected val ../selected}}>{{text}}</option>
                         {{/each}}
                     </select>
+                </div>
+                <div id="repl__samples__container" class="frm__select hide">
+                    <select id="repl__samples"></select>
                 </div>
                 <button id="repl__submit" type="button" class="btn btn--primary pull-right">Execute Code</button>
             </div>

--- a/share/spice/repl/repl.css
+++ b/share/spice/repl/repl.css
@@ -18,3 +18,20 @@
 .zci--repl .frm__buttons {
     margin-bottom: 1em;
 }
+
+.is-mobile-device #repl__samples__container {
+    width: 45%;
+    float: right;
+    padding-right: 3em;
+}
+
+.is-mobile-device .frm__field .frm__select:first-of-type {
+    width: 50%;
+}
+.is-mobile-device #repl__samples {
+    width: 100% !important;
+}
+
+.is-mobile-device #repl__samples__container:not(.hide) + #repl__submit {
+    margin-top: 1em;
+}

--- a/share/spice/repl/repl.css
+++ b/share/spice/repl/repl.css
@@ -1,0 +1,20 @@
+.zci--repl #repl__editor {
+    position: relative;
+    width: 100%;
+    height: 14em;
+    border: 1px solid #ddd;
+}
+
+.zci--repl #repl__result {
+    height: 14em;
+    font-family: monospace;
+}
+
+.zci--repl .cw,
+.zci--repl .c-base {
+    max-width: none;
+}
+
+.zci--repl .frm__buttons {
+    margin-bottom: 1em;
+}

--- a/share/spice/repl/repl.js
+++ b/share/spice/repl/repl.js
@@ -116,6 +116,15 @@
         python3: "python"
     };
 
+    // Limit sample code to select langauges
+    // Other languages have sample code, however they produce errors for various reasons
+    var allowCodeSamples = {
+        javascript: true,
+        python: true,
+        python3: true,
+        ruby: true
+    };
+
     // Store generated HTML here for language code samples
     var sampleCodeCache = {};
 
@@ -145,7 +154,7 @@
             codeLang = query.replace(/repl|interpreter|online/g, "").toLowerCase().trim();
 
         codeLang = langAliases[codeLang] || codeLang;
-        var hasSamples = syntaxLangs[codeLang] !== undefined || syntaxAliases[codeLang] !== undefined;
+        var hasSamples = allowCodeSamples[ getSampleLang(codeLang) ] || false;
 
         DDG.require("/js/ace/ace.js", function() {
             Spice.add({
@@ -287,9 +296,11 @@
                         var mode = getMode(codeLang);
                         var sampleLang = getSampleLang(codeLang);
                         editor.getSession().setMode("ace/mode/" + mode);
-                        $.when( getSamples(sampleLang) ).then(function(){
-                            $samplesContainer.removeClass('hide');
-                        });
+                        if (allowCodeSamples[sampleLang]) {
+                            $.when( getSamples(sampleLang) ).then(function(){
+                                $samplesContainer.removeClass('hide');
+                            });
+                        }
                     });
 
                     // Stop DDG keybindings, when editor has focus

--- a/share/spice/repl/repl.js
+++ b/share/spice/repl/repl.js
@@ -229,6 +229,7 @@
 
                     // "Execute" button handler
                     $submit.click(function(){
+                        $result.removeClass('tx-clr--red');
                         $result.val("Executing code...");
                         var code = editor.getValue();
                         code = encodeURIComponent(code);
@@ -271,6 +272,10 @@
                             } else {
                                 $result.removeClass('tx-clr--red');
                             }
+                        })
+                        .fail(function(){
+                            $result.addClass('tx-clr--red');
+                            $result.val("Error: Unable to execute code");
                         });
                     });
 

--- a/share/spice/repl/repl.js
+++ b/share/spice/repl/repl.js
@@ -11,36 +11,38 @@
 
     // Use array to ensure order for <select>
     var select_langs = [
-        { val: "apl", text: "Apl" },
-        { val: "bloop", text: "Bloop" },
-        { val: "babel", text: "Babel" },
-        { val: "brainf", text: "Brainf" },
         { val: "c", text: "C" },
-        { val: "csharp", text: "C#" },
         { val: "cpp", text: "C++" },
         { val: "cpp11", text: "C++11" },
-        { val: "coffeescript", text: "CoffeeScript" },
-        { val: "emoticon", text: "Emoticon" },
+        { val: "csharp", text: "C#" },
         { val: "fsharp", text: "F#" },
-        { val: "forth", text: "Forth" },
         { val: "go", text: "Go" },
         { val: "java", text: "Java" },
-        { val: "javascript", text: "JavaScript" },
-        { val: "jest", text: "Jest" },
-        { val: "lolcode", text: "LOLCODE" },
-        { val: "lua", text: "Lua" },
-        { val: "nodejs", text: "Node.js" },
+        { val: "nodejs", text: "JavaScript (Node.js)" },
         { val: "php", text: "PHP" },
         { val: "python", text: "Python" },
-        { val: "python_turtle", text: "Python (Turtle)" },
         { val: "python3", text: "Python 3" },
-        { val: "qbasic", text: "Qbasic" },
-        { val: "roy", text: "Roy" },
-        { val: "ruby", text: "Ruby" },
-        { val: "rust", text: "Rust" },
-        { val: "scheme", text: "Scheme" },
+        { val: "ruby", text: "Ruby" }
+
+        // Coming Soon
+        // { val: "apl", text: "Apl" },
+        // { val: "babel", text: "Babel" },
+        // { val: "bloop", text: "Bloop" },
+        // { val: "brainf", text: "Brainf" },
+        // { val: "coffeescript", text: "CoffeeScript" },
+        // { val: "emoticon", text: "Emoticon" },
+        // { val: "forth", text: "Forth" },
+        // { val: "javascript", text: "JavaScript" },
+        // { val: "jest", text: "Jest" },
+        // { val: "lolcode", text: "LOLCODE" },
+        // { val: "lua", text: "Lua" },
+        // { val: "python_turtle", text: "Python (Turtle)" },
+        // { val: "qbasic", text: "Qbasic" },
+        // { val: "roy", text: "Roy" },
+        // { val: "rust", text: "Rust" },
+        // { val: "scheme", text: "Scheme" },
         // { val: "swift", text: "Swift" },
-        { val: "unlambda", text: "Unlambda" },
+        // { val: "unlambda", text: "Unlambda" },
         // { val: "web_project", text: "HTML, CSS" }
     ];
 
@@ -53,24 +55,26 @@
     // Remap languages to appropriate editing mode name
     // use "text" mode for unsupported languages
     var modes = {
-        apl: "text",
-        bloop: "text",
-        brainf: "text",
         c: "c_cpp",
+        coffeescript: "coffee",
         cpp: "c_cpp",
         cpp11: "c_cpp",
-        coffeescript: "coffee",
-        emoticon: "text",
         fsharp: "text",
         go: "golang",
-        jest: "text",
-        lolcode: "text",
         nodejs: "javascript",
-        python_turtle: "python",
-        python3: "python",
-        qbasic: "text",
-        roy: "text",
-        unlambda: "text"
+        python3: "python"
+
+        // Coming Soon
+        // apl: "text",
+        // bloop: "text",
+        // brainf: "text",
+        // emoticon: "text",
+        // jest: "text",
+        // lolcode: "text",
+        // python_turtle: "python",
+        // qbasic: "text",
+        // roy: "text",
+        // unlambda: "text"
     };
 
     function getMode(lang) {

--- a/share/spice/repl/repl.js
+++ b/share/spice/repl/repl.js
@@ -168,11 +168,12 @@
                             if (!res) {
                                 return false;
                             }
-                            if (res && res.length > 1) {
+                            if (res && res.length > 0) {
                                 // Iterate over array of data
                                 $.each(res, function(key, obj){
+
                                     // If any errors, return error message as output
-                                    if (obj.command === "result" && obj.error.length) {
+                                    if (obj.command === "result" && obj.error !== '') {
                                         output = obj.error;
                                         hasError = true;
                                         return false;

--- a/share/spice/repl/repl.js
+++ b/share/spice/repl/repl.js
@@ -18,11 +18,14 @@
         { val: "fsharp", text: "F#" },
         { val: "go", text: "Go" },
         { val: "java", text: "Java" },
+        { val: "lua", text: "Lua" },
         { val: "nodejs", text: "JavaScript (Node.js)" },
         { val: "php", text: "PHP" },
         { val: "python", text: "Python" },
         { val: "python3", text: "Python 3" },
-        { val: "ruby", text: "Ruby" }
+        { val: "ruby", text: "Ruby" },
+        { val: "rust", text: "Rust" },
+        { val: "swift", text: "Swift" }
 
         // Coming Soon
         // { val: "apl", text: "Apl" },
@@ -35,13 +38,10 @@
         // { val: "javascript", text: "JavaScript" },
         // { val: "jest", text: "Jest" },
         // { val: "lolcode", text: "LOLCODE" },
-        // { val: "lua", text: "Lua" },
         // { val: "python_turtle", text: "Python (Turtle)" },
         // { val: "qbasic", text: "Qbasic" },
         // { val: "roy", text: "Roy" },
-        // { val: "rust", text: "Rust" },
         // { val: "scheme", text: "Scheme" },
-        // { val: "swift", text: "Swift" },
         // { val: "unlambda", text: "Unlambda" },
         // { val: "web_project", text: "HTML, CSS" }
     ];

--- a/share/spice/repl/repl.js
+++ b/share/spice/repl/repl.js
@@ -64,6 +64,7 @@
         'go lang': 'go',
         'golang': 'go',
         'java script': 'nodejs',
+        'javascript': 'nodejs',
         'js es6': 'babel',
         'js': 'nodejs',
         'node.js': 'nodejs',
@@ -134,8 +135,8 @@
         fsharp: "System.Console.WriteLine(\"hello world\")",
         go: "package main\n\nimport \"fmt\"\n\nfunc main() {\n  fmt.Println(\"Hello, World\")\n}",
         java: "class Main {\n  public static void main(String[] args) {\n  System.out.println(\"hello world\");\n}",
-        javascript: "console.log('Hello world!');",
         lua: "print(\"Hello World!\")",
+        nodejs: "console.log('Hello world!');",
         php: "echo \"Hello World!\";",
         python: "print('Hello World!')",
         python3: "print('Hello World!')",
@@ -156,7 +157,7 @@
     }
 
     function setPrefillText(lang) {
-        var text = prefillText[ getSampleLang(lang) ] || "";
+        var text = prefillText[lang] || "";
         editor.setValue(text);
     }
 

--- a/share/spice/repl/repl.js
+++ b/share/spice/repl/repl.js
@@ -1,0 +1,169 @@
+(function (env) {
+    "use strict";
+
+    Spice.registerHelper('is_selected', function(option, value){
+        if (option === value) {
+            return ' selected';
+        } else {
+            return '';
+        }
+    });
+
+    var langs = [
+        { val: "apl", text: "Apl" },
+        { val: "bloop", text: "Bloop" },
+        { val: "babel", text: "Babel" },
+        { val: "brainf", text: "Brainf" },
+        { val: "c", text: "C" },
+        { val: "csharp", text: "C#" },
+        { val: "cpp", text: "C++" },
+        { val: "cpp11", text: "C++11" },
+        { val: "coffeescript", text: "CoffeeScript" },
+        { val: "emoticon", text: "Emoticon" },
+        { val: "fsharp", text: "F#" },
+        { val: "forth", text: "Forth" },
+        { val: "go", text: "Go" },
+        { val: "java", text: "Java" },
+        { val: "javascript", text: "JavaScript" },
+        { val: "jest", text: "Jest" },
+        { val: "lolcode", text: "Lolcode" },
+        { val: "lua", text: "Lua" },
+        { val: "nodejs", text: "Node.js" },
+        { val: "php", text: "Php" },
+        { val: "python", text: "Python" },
+        { val: "python_turtle", text: "Python (Turtle)" },
+        { val: "python3", text: "Python 3" },
+        { val: "qbasic", text: "Qbasic" },
+        { val: "roy", text: "Roy" },
+        { val: "ruby", text: "Ruby" },
+        { val: "rust", text: "Rust" },
+        { val: "scheme", text: "Scheme" },
+        { val: "swift", text: "Swift" },
+        { val: "unlambda", text: "Unlambda" },
+        { val: "web_project", text: "HTML, CSS" }
+    ];
+
+    // Remap languages to appropriate editing mode name
+    // use "text" mode for unsupported languages
+    var modes = {
+        apl: "text",
+        bloop: "text",
+        brainf: "text",
+        c: "c_cpp",
+        cpp: "c_cpp",
+        cpp11: "c_cpp",
+        coffeescript: "coffee",
+        emoticon: "text",
+        fsharp: "text",
+        go: "golang",
+        jest: "text",
+        lolcode: "text",
+        nodejs: "javascript",
+        python_turtle: "python",
+        python3: "python",
+        qbasic: "text",
+        roy: "text",
+        unlambda: "text"
+    };
+
+    function getMode(lang) {
+        return modes[lang] || lang;
+    }
+
+    var editorOptions = {
+        showPrintMargin: false,
+        showInvisibles: true,
+    };
+
+    var hasShown = false,
+        editor_id = "repl__editor",
+        endpoint  = "/js/spice/repl_eval/";
+
+    env.ddg_spice_repl = function(api_result) {
+
+        var query = DDG.get_query(),
+            codeLang = query.replace("repl", "").toLowerCase().trim();
+
+        DDG.require("/js/ace/ace.js", function() {
+            Spice.add({
+                id: 'repl',
+                name: 'REPL',
+                data: api_result,
+                meta: {
+                    sourceName: 'repl.it',
+                    sourceUrl: 'https://repl.it/languages/'
+                },
+                normalize: function() {
+                    return {
+                        langs: langs,
+                        selected: codeLang
+                    };
+                },
+                onShow: function () {
+                    if (hasShown) {
+                        console.log("ALREADY SHOWN");
+                        return;
+                    } else {
+                        hasShown = true;
+                    }
+
+                    // Ace editor setup
+                    ace.config.set("basePath", "/js/ace/");
+                    var editor = ace.edit(editor_id);
+                    var mode =  getMode(codeLang);
+                    editor.setOptions(editorOptions);
+                    editor.getSession().setMode("ace/mode/" + mode);
+
+                    // Check for DDG dark theme
+                    var theme = (DDG.settings.get('kae') === 'd') ? "tomorrow_night" : "tomorrow";
+                    editor.setTheme("ace/theme/" + theme);
+
+                    // Cache selectors
+                    var $result = $("#repl__result"),
+                        $submit = $("#repl__submit"),
+                        $select = $("#repl__language"),
+                        $editor = $("#" + editor_id);
+
+                    // "Execute" button handler
+                    $submit.click(function(){
+                        var code = editor.getValue();
+                        code = encodeURIComponent(code);
+                        console.log("CODE: ", code);
+                        var url = [endpoint, codeLang, code].join("/");
+                        $.getJSON( url , function(data){
+                            var output;
+                            if (data && data[0]) {
+                                output = data[0].error || data[0].data;
+                            } else {
+                                output = "Error: Unable to evaluate result";
+                            }
+                            $result.val(output);
+                        });
+                    });
+
+                    // Select element handler
+                    $select.change(function(){
+                        codeLang = $select.find("option:selected").text().toLowerCase();
+                        console.log("CODE LANGE: ", codeLang);
+                        var mode = getMode(codeLang);
+                        console.log("MODE: ", mode);
+                        editor.getSession().setMode("ace/mode/" + mode);
+                    });
+
+                    // Stop DDG keybindings, when editor has focus
+                    $editor.keydown(function(e) {
+                        e.stopPropagation();
+                    });
+                },
+                templates: {
+                    group: 'base',
+                    options: {
+                        content: Spice.repl.content,
+                        moreAt: true
+                    }
+                }
+            });
+        });
+    };
+
+}(this));

--- a/share/spice/repl/repl.js
+++ b/share/spice/repl/repl.js
@@ -107,23 +107,42 @@
         javascript: "JavaScript",
         python: "Python",
         ruby: "Ruby",
-        swift: "Swift",
+        swift: "Swift"
     };
 
     var syntaxAliases = {
-        nodejs: "javascript",
         cpp11: "cpp",
+        nodejs: "javascript",
         python3: "python"
     };
 
     // Limit sample code to select langauges
     // Other languages have sample code, however they produce errors for various reasons
     var allowCodeSamples = {
+        go: true,
         javascript: true,
         python: true,
         python3: true,
         ruby: true
     };
+
+    var prefillText = {
+        c: "#include \"stdio.h\"\nint main(void) {\n  printf(\"Hello World\\n\");\n  return 0;\n}",
+        cpp: "#include <iostream>\nint main() {\n  std::cout << \"Hello World!\\n\";\n}",
+        cpp11: "#include <iostream>\nint main() {\n  std::cout << \"Hello World!\\n\";\n}",
+        csharp: "using System;\nclass MainClass {\n  public static void Main (string[] args) {\n    Console.WriteLine (\"Hello World\");\n  }\n}",
+        fsharp: "System.Console.WriteLine(\"hello world\")",
+        go: "package main\n\nimport \"fmt\"\n\nfunc main() {\n  fmt.Println(\"Hello, World\")\n}",
+        java: "class Main {\n  public static void main(String[] args) {\n  System.out.println(\"hello world\");\n}",
+        javascript: "console.log('Hello world!');",
+        lua: "print(\"Hello World!\")",
+        php: "echo \"Hello World!\";",
+        python: "print('Hello World!')",
+        python3: "print('Hello World!')",
+        ruby: "puts 'Hello World!'",
+        rust: "fn main() {\n  println!(\"Hello World!\");\n}",
+        swift: "print(\"Hello World!\")"
+    }
 
     // Store generated HTML here for language code samples
     var sampleCodeCache = {};
@@ -136,14 +155,35 @@
         return syntaxAliases[lang] || lang;
     }
 
+    function setPrefillText(lang) {
+        var text = prefillText[ getSampleLang(lang) ] || "";
+        editor.setValue(text);
+    }
+
+    // Wrap sample code for proper execution
+    // Commenting out because some code snippets don't need wrapping... (e.g. Golang)
+    // function wrapSampleCode(lang, sampleCode) {
+    //     var wrapText = prefillText[lang] || false;
+    //     if (wrapText) {
+    //         editor.setValue(wrapText);
+    //         editor.find('CODE_HERE', { backwards: true });
+    //         editor.replace(sampleCode);
+    //     } else {
+    //         editor.setValue(sampleCode)
+    //     }
+    // }
+
     var editorOptions = {
         showPrintMargin: false,
         showInvisibles: true,
+        tabSize: 2
     };
+
 
     var hasShown = false,
         editor_id = "repl__editor",
-        endpoint  = "/js/spice/repl_eval/";
+        endpoint  = "/js/spice/repl_eval/",
+        editor;
 
     env.ddg_spice_repl = function() {
 
@@ -181,7 +221,7 @@
 
                     // Ace editor setup
                     ace.config.set("basePath", "/js/ace/");
-                    var editor = ace.edit(editor_id);
+                    editor = ace.edit(editor_id);
                     var mode = getMode(codeLang);
                     editor.setOptions(editorOptions);
                     editor.getSession().setMode("ace/mode/" + mode);
@@ -197,6 +237,9 @@
                         $samplesContainer = $("#repl__samples__container"),
                         $samples = $("#repl__samples"),
                         $editor = $("#" + editor_id);
+
+                    // Prefill textbox
+                    setPrefillText(codeLang);
 
                     // Call SyntaxDB API to get sample code snippets
                     // -> then pass response to Handlebars template
@@ -301,6 +344,7 @@
                                 $samplesContainer.removeClass('hide');
                             });
                         }
+                        setPrefillText(codeLang);
                     });
 
                     // Stop DDG keybindings, when editor has focus

--- a/share/spice/repl/repl.js
+++ b/share/spice/repl/repl.js
@@ -161,6 +161,7 @@
                 },
                 onShow: function () {
 
+                    // Ensure this only runs once
                     if (hasShown) {
                         return;
                     } else {
@@ -178,7 +179,7 @@
                     var theme = (DDG.settings.get('kae') === 'd') ? "tomorrow_night" : "tomorrow";
                     editor.setTheme("ace/theme/" + theme);
 
-                    // Cache selectors
+                    // Cache jQuery selectors
                     var $result = $("#repl__result"),
                         $submit = $("#repl__submit"),
                         $select = $("#repl__language"),
@@ -186,6 +187,9 @@
                         $samples = $("#repl__samples"),
                         $editor = $("#" + editor_id);
 
+                    // Call SyntaxDB API to get sample code snippets
+                    // -> then pass response to Handlebars template
+                    // -> then store HTML output in local cache
                     function getSamples(sampleLang) {
                         var cachedHTML = sampleCodeCache[sampleLang] || null;
                         if (cachedHTML) {
@@ -211,7 +215,6 @@
                             });
                             $samplesContainer.removeClass('hide');
                         });
-
                     }
 
                     // "Execute" button handler

--- a/share/spice/repl/repl.js
+++ b/share/spice/repl/repl.js
@@ -98,7 +98,7 @@
                 data: api_result,
                 meta: {
                     sourceName: 'repl.it',
-                    sourceUrl: 'https://repl.it/languages/'
+                    sourceUrl: 'https://repl.it/languages/' + codeLang
                 },
                 normalize: function() {
                     return {

--- a/share/spice/repl/repl.js
+++ b/share/spice/repl/repl.js
@@ -90,7 +90,7 @@
         editor_id = "repl__editor",
         endpoint  = "/js/spice/repl_eval/";
 
-    env.ddg_spice_repl = function(api_result) {
+    env.ddg_spice_repl = function() {
 
         // Prevent jQuery from appending "_={timestamp}" in our url when we use $.getJSON
         $.ajaxSetup({ cache: true });
@@ -102,16 +102,13 @@
             Spice.add({
                 id: 'repl',
                 name: 'REPL',
-                data: api_result,
+                data: {
+                    langs: select_langs,
+                    selected: codeLang
+                },
                 meta: {
                     sourceName: 'repl.it',
                     sourceUrl: 'https://repl.it/languages/' + codeLang
-                },
-                normalize: function() {
-                    return {
-                        langs: select_langs,
-                        selected: codeLang
-                    };
                 },
                 onShow: function () {
                     if (hasShown) {
@@ -205,5 +202,7 @@
             });
         });
     };
-
 }(this));
+
+// Call self
+ddg_spice_repl();

--- a/share/spice/repl/repl.js
+++ b/share/spice/repl/repl.js
@@ -112,6 +112,8 @@
 
     var syntaxAliases = {
         nodejs: "javascript",
+        cpp11: "cpp",
+        python3: "python"
     };
 
     // Store generated HTML here for language code samples

--- a/share/spice/repl/repl.js
+++ b/share/spice/repl/repl.js
@@ -213,15 +213,19 @@
                     if (hasSamples) {
                         var sampleLang = getSampleLang(codeLang);
                         $.when( getSamples(sampleLang) ).then(function(){
-                            $samples.change(function() {
-                                var code = $samples.find("option:selected").data('text') || null;
-                                if (code) {
-                                    editor.setValue(code);
-                                }
-                            });
                             $samplesContainer.removeClass('hide');
                         });
                     }
+
+                    // Event Handlers
+                    // //////////////
+
+                    $samples.change(function() {
+                        var code = $samples.find("option:selected").data('text') || null;
+                        if (code) {
+                            editor.setValue(code);
+                        }
+                    });
 
                     // "Execute" button handler
                     $submit.click(function(){

--- a/share/spice/repl/repl.js
+++ b/share/spice/repl/repl.js
@@ -9,7 +9,8 @@
         }
     });
 
-    var langs = [
+    // Use array to ensure order for <select>
+    var select_langs = [
         { val: "apl", text: "Apl" },
         { val: "bloop", text: "Bloop" },
         { val: "babel", text: "Babel" },
@@ -26,10 +27,10 @@
         { val: "java", text: "Java" },
         { val: "javascript", text: "JavaScript" },
         { val: "jest", text: "Jest" },
-        { val: "lolcode", text: "Lolcode" },
+        { val: "lolcode", text: "LOLCODE" },
         { val: "lua", text: "Lua" },
         { val: "nodejs", text: "Node.js" },
-        { val: "php", text: "Php" },
+        { val: "php", text: "PHP" },
         { val: "python", text: "Python" },
         { val: "python_turtle", text: "Python (Turtle)" },
         { val: "python3", text: "Python 3" },
@@ -38,10 +39,16 @@
         { val: "ruby", text: "Ruby" },
         { val: "rust", text: "Rust" },
         { val: "scheme", text: "Scheme" },
-        { val: "swift", text: "Swift" },
+        // { val: "swift", text: "Swift" },
         { val: "unlambda", text: "Unlambda" },
-        { val: "web_project", text: "HTML, CSS" }
+        // { val: "web_project", text: "HTML, CSS" }
     ];
+
+    // build map of "Select" text to API
+    var langs = {};
+    $.each(select_langs, function(index, obj){
+        langs[obj.text] = obj.val;
+    });
 
     // Remap languages to appropriate editing mode name
     // use "text" mode for unsupported languages
@@ -82,7 +89,7 @@
     env.ddg_spice_repl = function(api_result) {
 
         var query = DDG.get_query(),
-            codeLang = query.replace("repl", "").toLowerCase().trim();
+            codeLang = query.replace(/repl|interpreter|online/g, "").toLowerCase().trim();
 
         DDG.require("/js/ace/ace.js", function() {
             Spice.add({
@@ -95,13 +102,12 @@
                 },
                 normalize: function() {
                     return {
-                        langs: langs,
+                        langs: select_langs,
                         selected: codeLang
                     };
                 },
                 onShow: function () {
                     if (hasShown) {
-                        console.log("ALREADY SHOWN");
                         return;
                     } else {
                         hasShown = true;
@@ -128,7 +134,6 @@
                     $submit.click(function(){
                         var code = editor.getValue();
                         code = encodeURIComponent(code);
-                        console.log("CODE: ", code);
                         var url = [endpoint, codeLang, code].join("/");
                         $.getJSON( url , function(data){
                             var output;
@@ -143,10 +148,11 @@
 
                     // Select element handler
                     $select.change(function(){
-                        codeLang = $select.find("option:selected").text().toLowerCase();
-                        console.log("CODE LANGE: ", codeLang);
+                        var selectText = $select.find("option:selected").text();
+                        console.log('SELECT TEXT: ', selectText);
+                        codeLang = langs[selectText];
+                        console.log('CODE LANG: ', codeLang);
                         var mode = getMode(codeLang);
-                        console.log("MODE: ", mode);
                         editor.getSession().setMode("ace/mode/" + mode);
                     });
 

--- a/share/spice/repl/repl.js
+++ b/share/spice/repl/repl.js
@@ -10,7 +10,7 @@
     });
 
     // Use array to ensure order for <select>
-    var select_langs = [
+    var selectLangs = [
         { val: "c", text: "C" },
         { val: "cpp", text: "C++" },
         { val: "cpp11", text: "C++11" },
@@ -48,9 +48,30 @@
 
     // build map of "Select" text to API
     var langs = {};
-    $.each(select_langs, function(index, obj){
+    $.each(selectLangs, function(index, obj){
         langs[obj.text] = obj.val;
     });
+
+    var langAliases = {
+        'c plus plus': 'cpp',
+        'c sharp': 'csharp',
+        'c#': 'csharp',
+        'c++': 'cpp',
+        'c++11': 'cpp11',
+        'cplusplus': 'cpp',
+        'f sharp': 'fsharp',
+        'f#': 'fsharp',
+        'go lang': 'go',
+        'golang': 'go',
+        'java script': 'nodejs',
+        'js es6': 'babel',
+        'js': 'nodejs',
+        'node.js': 'nodejs',
+        'node': 'nodejs',
+        'python 2': 'python',
+        'python 3': 'python3',
+        'python2': 'python',
+    };
 
     // Remap languages to appropriate editing mode name
     // use "text" mode for unsupported languages
@@ -98,12 +119,14 @@
         var query = DDG.get_query(),
             codeLang = query.replace(/repl|interpreter|online/g, "").toLowerCase().trim();
 
+        codeLang = langAliases[codeLang] || codeLang;
+
         DDG.require("/js/ace/ace.js", function() {
             Spice.add({
                 id: 'repl',
                 name: 'REPL',
                 data: {
-                    langs: select_langs,
+                    langs: selectLangs,
                     selected: codeLang
                 },
                 meta: {

--- a/share/spice/repl/repl.js
+++ b/share/spice/repl/repl.js
@@ -296,7 +296,11 @@
                     group: 'base',
                     options: {
                         content: Spice.repl.content,
-                        moreAt: true
+                        moreAt: true,
+                        moreText: {
+                            href: 'https://syntaxdb.com',
+                            text: 'Samples from SyntaxDB'
+                        }
                     }
                 }
             });

--- a/share/spice/repl/repl.js
+++ b/share/spice/repl/repl.js
@@ -200,7 +200,11 @@
                             return $.getJSON('/js/spice/repl_samples/' + sampleLang, function(json) {
                                 var html = DDH.repl.samples_select(json);
                                 $samples.html(DDH.repl.samples_select(json));
-                                sampleCodeCache[sampleLang] = html;
+                                // only cache HTML that contains sample codes
+                                // failed api call returns object
+                                if (Array.isArray(json)){
+                                    sampleCodeCache[sampleLang] = html;
+                                }
                             });
                         }
                     }

--- a/share/spice/repl/samples_select.handlebars
+++ b/share/spice/repl/samples_select.handlebars
@@ -1,0 +1,8 @@
+{{#unless this.code}}
+    <option>Sample Code</option>
+    {{#each this}}
+    <option data-text="{{example}}">{{concept_name}}</option>
+    {{/each}}
+{{else}}
+    <option>None</option>
+{{/unless}}

--- a/t/Repl.t
+++ b/t/Repl.t
@@ -23,9 +23,9 @@ ddg_spice_test(
     ),
 
     'online python repl' => test_spice(
-    '',
-    call_type => 'self',
-    caller => 'DDG::Spice::Repl'
+        '',
+        call_type => 'self',
+        caller => 'DDG::Spice::Repl'
     ),
 
     'c++ repl' => test_spice(
@@ -53,9 +53,9 @@ ddg_spice_test(
     ),
 
     'online python interpreter' => test_spice(
-    '',
-    call_type => 'self',
-    caller => 'DDG::Spice::Repl'
+        '',
+        call_type => 'self',
+        caller => 'DDG::Spice::Repl'
     ),
 
     'c++ interpreter' => test_spice(

--- a/t/Repl.t
+++ b/t/Repl.t
@@ -9,18 +9,69 @@ spice is_cached => 1;
 
 ddg_spice_test(
     [qw( DDG::Spice::Repl)],
-    # At a minimum, be sure to include tests for all:
-    # - primary_example_queries
-    # - secondary_example_queries
-    'example query' => test_spice(
-        '/js/spice/repl/query',
+
+    'python repl' => test_spice(
+        '/js/spice/repl/python',
         call_type => 'include',
         caller => 'DDG::Spice::Repl'
     ),
-    # Try to include some examples of queries on which it might
-    # appear that your answer will trigger, but does not.
-    'bad example query' => undef,
+
+    'python repl online' => test_spice(
+        '/js/spice/repl/python',
+        call_type => 'include',
+        caller => 'DDG::Spice::Repl'
+    ),
+
+    'online python repl' => test_spice(
+    '/js/spice/repl/python',
+    call_type => 'include',
+    caller => 'DDG::Spice::Repl'
+    ),
+
+    'c++ repl' => test_spice(
+        '/js/spice/repl/cpp',
+        call_type => 'include',
+        caller => 'DDG::Spice::Repl'
+    ),
+
+    'repl python' => test_spice(
+        '/js/spice/repl/python',
+        call_type => 'include',
+        caller => 'DDG::Spice::Repl'
+    ),
+
+    'python interpreter' => test_spice(
+        '/js/spice/repl/python',
+        call_type => 'include',
+        caller => 'DDG::Spice::Repl'
+    ),
+
+    'python interpreter online' => test_spice(
+        '/js/spice/repl/python',
+        call_type => 'include',
+        caller => 'DDG::Spice::Repl'
+    ),
+
+    'online python interpreter' => test_spice(
+    '/js/spice/repl/python',
+    call_type => 'include',
+    caller => 'DDG::Spice::Repl'
+    ),
+
+    'c++ interpreter' => test_spice(
+        '/js/spice/repl/cpp',
+        call_type => 'include',
+        caller => 'DDG::Spice::Repl'
+    ),
+
+    'interpreter python' => test_spice(
+        '/js/spice/repl/python',
+        call_type => 'include',
+        caller => 'DDG::Spice::Repl'
+    ),
+
+    'perl repl' => undef,
+    'perl interpreter' => undef,
 );
 
 done_testing;
-

--- a/t/Repl.t
+++ b/t/Repl.t
@@ -1,0 +1,26 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+spice is_cached => 1;
+
+ddg_spice_test(
+    [qw( DDG::Spice::Repl)],
+    # At a minimum, be sure to include tests for all:
+    # - primary_example_queries
+    # - secondary_example_queries
+    'example query' => test_spice(
+        '/js/spice/repl/query',
+        call_type => 'include',
+        caller => 'DDG::Spice::Repl'
+    ),
+    # Try to include some examples of queries on which it might
+    # appear that your answer will trigger, but does not.
+    'bad example query' => undef,
+);
+
+done_testing;
+

--- a/t/Repl.t
+++ b/t/Repl.t
@@ -11,62 +11,62 @@ ddg_spice_test(
     [qw( DDG::Spice::Repl)],
 
     'python repl' => test_spice(
-        '/js/spice/repl/python',
-        call_type => 'include',
+        '',
+        call_type => 'self',
         caller => 'DDG::Spice::Repl'
     ),
 
     'python repl online' => test_spice(
-        '/js/spice/repl/python',
-        call_type => 'include',
+        '',
+        call_type => 'self',
         caller => 'DDG::Spice::Repl'
     ),
 
     'online python repl' => test_spice(
-    '/js/spice/repl/python',
-    call_type => 'include',
+    '',
+    call_type => 'self',
     caller => 'DDG::Spice::Repl'
     ),
 
     'c++ repl' => test_spice(
-        '/js/spice/repl/cpp',
-        call_type => 'include',
+        '',
+        call_type => 'self',
         caller => 'DDG::Spice::Repl'
     ),
 
     'repl python' => test_spice(
-        '/js/spice/repl/python',
-        call_type => 'include',
+        '',
+        call_type => 'self',
         caller => 'DDG::Spice::Repl'
     ),
 
     'python interpreter' => test_spice(
-        '/js/spice/repl/python',
-        call_type => 'include',
+        '',
+        call_type => 'self',
         caller => 'DDG::Spice::Repl'
     ),
 
     'python interpreter online' => test_spice(
-        '/js/spice/repl/python',
-        call_type => 'include',
+        '',
+        call_type => 'self',
         caller => 'DDG::Spice::Repl'
     ),
 
     'online python interpreter' => test_spice(
-    '/js/spice/repl/python',
-    call_type => 'include',
+    '',
+    call_type => 'self',
     caller => 'DDG::Spice::Repl'
     ),
 
     'c++ interpreter' => test_spice(
-        '/js/spice/repl/cpp',
-        call_type => 'include',
+        '',
+        call_type => 'self',
         caller => 'DDG::Spice::Repl'
     ),
 
     'interpreter python' => test_spice(
-        '/js/spice/repl/python',
-        call_type => 'include',
+        '',
+        call_type => 'self',
         caller => 'DDG::Spice::Repl'
     ),
 


### PR DESCRIPTION
## Description of new Instant Answer, or changes

This Instant Answer provides a single-session REPL using the Repl.it API. It supports ~ 30 languages.

### TODO:
- [x] Prefill `#include <iostream>\n int main() { ... }` for C, C++, C++11
  - [ ] Wrap code samples accordingly
- [x] Prefill `class Main {\n  public static void main(String[] args) { ... }` for Java
  - [ ] Wrap code samples accordingly
- [x] Prefill `using System;\n class MainClass {\n   public static void Main (string[] args) { ... }` for C#
  - [ ] Wrap code samples accordingly
- [x] Prefill `package main\n\nimport "fmt"\n\nfunc main() { ... }` for Go
  - [ ] Wrap code samples accordingly
- [x] Prefill `fn main() {` for Rust
- [ ] Ensure all code samples work
- [ ] POST to `/js/spice/repl_eval` to preserve newlines

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/repl
<!-- FILL THIS IN:                           ^^^^ -->
