### PR TITLE
RubyGems: Updated Trigger

### DIFF
--- a/lib/DDG/Spice/RubyGems.pm
+++ b/lib/DDG/Spice/RubyGems.pm
@@ -4,7 +4,7 @@ package DDG::Spice::RubyGems;
 use strict;
 use DDG::Spice;
 
-triggers startend => 'rubygem', 'rubygems', 'ruby gems', 'ruby gem', 'gem install', 'gem';
+triggers startend => 'rubygem', 'rubygems', 'ruby gems', 'ruby gem', 'ruby install', 'gem install', 'gem';
 spice to => 'https://rubygems.org/api/v1/search.json?query=$1';
 spice wrap_jsonp_callback => 1;
 


### PR DESCRIPTION
## Description of new Instant Answer, or changes

It seems from the unanswered query data that some people have been searching for `ruby install <package_name>`, such as `ruby install compass`. As this is pretty unambigious I have added it to the triggers. 

## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@moollaza 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/ruby_gems
<!-- FILL THIS IN:                           ^^^^ -->
