### PR TITLE
IsItUp: Return if query does not match regex

### DIFF
--- a/lib/DDG/Spice/IsItUp.pm
+++ b/lib/DDG/Spice/IsItUp.pm
@@ -28,7 +28,7 @@ handle query_lc => sub {
 
     my $query = $_;
 
-    $query =~ $query_regex;
+    return unless $query =~ $query_regex;
 
     $root_url = $2;
 

--- a/lib/DDG/Spice/IsItUp.pm
+++ b/lib/DDG/Spice/IsItUp.pm
@@ -15,7 +15,7 @@ spice to => 'https://isitup.org/$1.json?callback={{callback}}';
 
 spice proxy_cache_valid => "418 1d";
 
-my $query_start_regex = qr/(?:is|isitup|isitdown|is it up|is it down|status of|)/;
+my $query_start_regex = qr/(?:is\s|isitup|isitdown|is it up|is it down|status of|)/;
 my $query_end_regex   = qr/(?:up|down|working|online|status|up right now|)/;
 my $url_regex         = qr/(?:https?:\/\/)?([\p{Alnum}\-]+(?:\.[\p{Alnum}\-]+)*?)(?:(\.\pL{2,})|)/;
 

--- a/lib/DDG/Spice/IsItUp.pm
+++ b/lib/DDG/Spice/IsItUp.pm
@@ -21,12 +21,14 @@ my $url_regex         = qr/(?:https?:\/\/)?([\p{Alnum}\-]+(?:\.[\p{Alnum}\-]+)*?
 
 my $query_regex = qr/^($query_start_regex)\s?$url_regex\s?($query_end_regex)\?*$/i;
 
-handle query_lc => sub {
+handle remainder => sub {
+
+    return unless $_;
 
     my ($domain, $ascii, $root_url);
     my $publicSuffix = Domain::PublicSuffix->new();
 
-    my $query = $_;
+    my $query = $req->query_lc;
 
     return unless $query =~ $query_regex;
 

--- a/t/IsItUp.t
+++ b/t/IsItUp.t
@@ -33,11 +33,15 @@ ddg_spice_test(
     'is it down duckduckgo.com'               => build_test('duckduckgo.com'),
     'is duckduckgo.com up right now'          => build_test('duckduckgo.com'),
     'status of duckduckgo.com'                => build_test('duckduckgo.com'),
+    'isitup t-online.de'                      => build_test('t-online.de'),
     'schema.org update time' => undef,
     'is it up?'              => undef,
     'is it down'             => undef,
     'is site up'             => undef,
     'is site down?'          => undef,
+    't-online.de'            => undef,
+    'isitdown'               => undef,
+    'isitup'                 => undef
 );
 done_testing;
 


### PR DESCRIPTION
<!-- Use the appropriate format for your Pull Request title above ^^^^^:

If this is a bug fix:
{IA Name}: {Description of change}

If this is a New Instant Answer:
New {IA Name} Spice

If this is something else:
{Tests/Docs/Other}: {Short Description}

-->


## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
Tiny change, return if query does not match the regex

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->
Please refer [comment](https://github.com/duckduckgo/zeroclickinfo-spice/pull/3122#discussion_r99644571)
Fix #3136 

## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@moollaza @GuiltyDolphin 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/is_it_up
<!-- FILL THIS IN:                           ^^^^ -->
