### PR TITLE
SoundCloud: Update JS/Perl to hide API Client ID

### DIFF
--- a/lib/DDG/Spice/SoundCloud.pm
+++ b/lib/DDG/Spice/SoundCloud.pm
@@ -9,9 +9,6 @@ spice call_type => 'self';
 spice alt_to => {
 	sound_cloud_result => {
 		to => 'https://api.soundcloud.com/tracks.json?client_id={{ENV{DDG_SPICE_SOUNDCLOUD_APIKEY}}}&q=$1&limit=35&filter=streamable'
-	},
-	sound_cloud_stream => {
-		to => 'https://duckduckgo.com/audio/?u=https://$1?client_id={{ENV{DDG_SPICE_SOUNDCLOUD_APIKEY}}}'
 	}
 };
 

--- a/lib/DDG/Spice/SoundCloud.pm
+++ b/lib/DDG/Spice/SoundCloud.pm
@@ -9,6 +9,9 @@ spice call_type => 'self';
 spice alt_to => {
 	sound_cloud_result => {
 		to => 'https://api.soundcloud.com/tracks.json?client_id={{ENV{DDG_SPICE_SOUNDCLOUD_APIKEY}}}&q=$1&limit=35&filter=streamable'
+	},
+	sound_cloud_stream => {
+		to => '/audio/$1?client_id={{ENV{DDG_SPICE_SOUNDCLOUD_APIKEY}}}'
 	}
 };
 

--- a/lib/DDG/Spice/SoundCloud.pm
+++ b/lib/DDG/Spice/SoundCloud.pm
@@ -11,7 +11,7 @@ spice alt_to => {
 		to => 'https://api.soundcloud.com/tracks.json?client_id={{ENV{DDG_SPICE_SOUNDCLOUD_APIKEY}}}&q=$1&limit=35&filter=streamable'
 	},
 	sound_cloud_stream => {
-		to => '/audio/$1?client_id={{ENV{DDG_SPICE_SOUNDCLOUD_APIKEY}}}'
+		to => 'https://duckduckgo.com/audio/?u=https://$1?client_id={{ENV{DDG_SPICE_SOUNDCLOUD_APIKEY}}}'
 	}
 };
 

--- a/share/spice/sound_cloud/sound_cloud.js
+++ b/share/spice/sound_cloud/sound_cloud.js
@@ -65,7 +65,7 @@
                     return;
                 }
 
-                var streamURL = '/js/spice/sound_cloud_stream/' + o.stream_url.replace(/https?:\/\//, '');
+                var streamURL = '/sc_audio/' + o.stream_url;
 
                 return {
                     image: image,

--- a/share/spice/sound_cloud/sound_cloud.js
+++ b/share/spice/sound_cloud/sound_cloud.js
@@ -67,8 +67,6 @@
 
                 var streamURL = '/js/spice/sound_cloud_stream/' + o.stream_url.replace(/https?:\/\//, '');
 
-                console.log(streamURL);
-
                 return {
                     image: image,
                     hearts: o.likes_count || 0,

--- a/share/spice/sound_cloud/sound_cloud.js
+++ b/share/spice/sound_cloud/sound_cloud.js
@@ -3,16 +3,15 @@
 
     var query = DDG.get_query();
     query = query.replace(/sound ?cloud/, "").replace(/\bsc\b/, ""); //replace trigger words from query
-    
-    env.ddg_spice_sound_cloud = function() {        
+
+    env.ddg_spice_sound_cloud = function() {
         $.getJSON("/js/spice/sound_cloud_result/" + encodeURIComponent(query), sound_cloud);
     }
-    
+
     function sound_cloud(api_result) {
-        var SOUNDCLOUD_CLIENT_ID = 'df14a65559c0e555d9f9fd950c2d5b17',
             // Blacklist some adult results.
             skip_ids = {
-                80320921: 1, 
+                80320921: 1,
                 75349402: 1
             };
 
@@ -44,7 +43,7 @@
             },
             normalize: function(o) {
                 if(!o) {
-                    return null;                       
+                    return null;
                 }
 
                 var image = o.artwork_url || o.user.avatar_url;
@@ -66,7 +65,7 @@
                     return;
                 }
 
-                var streamURL = '/audio/?u=' + o.stream_url + '?client_id=' + SOUNDCLOUD_CLIENT_ID;
+                var streamURL = '/js/spice/sound_cloud_stream/' + o.stream_url;
 
                 return {
                     image: image,
@@ -79,6 +78,6 @@
             }
         });
     };
-    
+
     ddg_spice_sound_cloud();
 }(this));

--- a/share/spice/sound_cloud/sound_cloud.js
+++ b/share/spice/sound_cloud/sound_cloud.js
@@ -2,18 +2,18 @@
     "use strict"
 
     var query = DDG.get_query();
-    query = query.replace(/sound ?cloud/, "").replace(/\bsc\b/, ""); //replace trigger words from query
+    query = query.replace(/\bsound ?cloud\b/, "").replace(/\bsc\b/, "").trim(); //replace trigger words from query
 
     env.ddg_spice_sound_cloud = function() {
         $.getJSON("/js/spice/sound_cloud_result/" + encodeURIComponent(query), sound_cloud);
     }
 
     function sound_cloud(api_result) {
-            // Blacklist some adult results.
-            skip_ids = {
-                80320921: 1,
-                75349402: 1
-            };
+        // Blacklist some adult results.
+        var skip_ids = {
+            80320921: 1,
+            75349402: 1
+        };
 
         if(!api_result){
             return Spice.failed("sound_cloud");
@@ -65,7 +65,9 @@
                     return;
                 }
 
-                var streamURL = '/js/spice/sound_cloud_stream/' + o.stream_url;
+                var streamURL = '/js/spice/sound_cloud_stream/' + o.stream_url.replace(/https?:\/\//, '');
+
+                console.log(streamURL);
 
                 return {
                     image: image,

--- a/share/spice/sound_cloud/sound_cloud.js
+++ b/share/spice/sound_cloud/sound_cloud.js
@@ -65,7 +65,7 @@
                     return;
                 }
 
-                var streamURL = '/sc_audio/' + o.stream_url;
+                var streamURL = '/sc_audio/?u=' + o.stream_url;
 
                 return {
                     image: image,


### PR DESCRIPTION
## Description of new Instant Answer, or changes
This PR adjusts the `streamURL` variable to use the new `/sc_audio/` proxy endpoint

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/sound_cloud
<!-- FILL THIS IN:                           ^^^^ -->
