### PR TITLE
hackage: return query as typed in search bar

### DIFF
--- a/share/spice/hackage/hackage.js
+++ b/share/spice/hackage/hackage.js
@@ -42,9 +42,7 @@
         var results = api_result.results;
 
         // Get the original query
-        var script = $('[src*="/js/spice/hackage/"]')[0];
-        var source = $(script).attr("src");
-        var query = source.match(/hackage\/([^\/]*)/)[1];
+        var query = DDG.get_query().replace(/\s*(hoogle|haskell|hackage)\s*/gi, '');
         Spice.add({
             id: "hackage",
             name: "Software",
@@ -52,7 +50,7 @@
             meta: {
                 searchTerm: query,
                 sourceName: "Hoogle",
-                sourceUrl: "https://www.haskell.org/hoogle/?hoogle=" + query,
+                sourceUrl: "https://www.haskell.org/hoogle/?hoogle=" + encodeURIComponent(query),
                 snippetChars: 170
             },
             templates: {


### PR DESCRIPTION
<!-- Use the appropriate format for your Pull Request title above ^^^^^:

If this is a bug fix:
{IA Name}: {Description of change}

If this is a New Instant Answer:
New {IA Name} Spice

If this is something else:
{Tests/Docs/Other}: {Short Description}

-->


## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
Returns the original query (as typed in search bar), with the IA-triggering phrases (haskell, hoogle, or hackage) removed. The previous behaviour returned a uri-encoded string eg "monad%20transformer"

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/hackage
<!-- FILL THIS IN:                           ^^^^ -->
