### PR TITLE
Forecast: Adds region checking for setting default units

### DIFF
--- a/share/spice/forecast/forecast.js
+++ b/share/spice/forecast/forecast.js
@@ -341,14 +341,17 @@
     };
 
     // If there is celsius or fahrenheit mentioned in the query, do use that
-    // unit of measurement. If the metric setting is enabled and the API
-    // returned temps in F, switch to 'C':
+    // unit of measurement. If the metric setting is enabled or the user's
+    // region is not USA and the API returned temps in F, switch to 'C':
     var uom_in_query = DDG.get_query().match(/\b(celsius|fahrenheit)\b/);
     if (uom_in_query) {
         uom = (uom_in_query[1] === 'celsius') ? 'C' : 'F';
         updateUnitOfMeasure();
     } else if (!DDG.settings.isDefault('kaj')) {
         uom = DDG.settings.get('kaj') === 'm' ? 'C' : 'F';
+        updateUnitOfMeasure();
+    } else if (!DDG.settings.isDefault('kl')) {
+        uom = DDG.settings.get('kl') !== 'us-en' ? 'C' : 'F';
         updateUnitOfMeasure();
     } else {
         updateTempSwitch(uom);


### PR DESCRIPTION
<!-- Use the appropriate format for your Pull Request title above ^^^^^:

If this is a bug fix:
{IA Name}: {Description of change}

If this is a New Instant Answer:
New {IA Name} Spice

If this is something else:
{Tests/Docs/Other}: {Short Description}

-->


## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
Checks user's region in setting for determining default setting for units.

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->
Fixes #3107 

## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@himanshu0113 @bsstoner 
<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/forecast
<!-- FILL THIS IN:                           ^^^^ -->