### PR TITLE
Force SoundCloud stream urls to HTTP.

### DIFF
--- a/share/spice/sound_cloud/sound_cloud.js
+++ b/share/spice/sound_cloud/sound_cloud.js
@@ -65,7 +65,7 @@
                     return;
                 }
 
-                var streamURL = '/sc_audio/?u=' + o.stream_url;
+                var streamURL = '/sc_audio/?u=' + DDG.toHTTP(o.stream_url);
 
                 return {
                     image: image,


### PR DESCRIPTION
## Description of new Instant Answer, or changes
The HTTPS SoundCloud API urls stopped working with our NGINX Proxy, switching the urls to HTTP seems to get them working for now.

Live on Moollaza


## Related Issues and Discussions
Fixes #3149

## People to notify
@bsstoner 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/sound_cloud
<!-- FILL THIS IN:                           ^^^^ -->
