### PR TITLE
Currency: Add ruble alias

### DIFF
--- a/share/spice/currency/currencyNames.txt
+++ b/share/spice/currency/currencyNames.txt
@@ -117,7 +117,7 @@ pyg,paraguayan guarani,paraguay guarani,
 qar,qatari riyal,qatar riyal,
 ron,romanian new leu,romania new leu,
 rsd,serbian dinar,serbia dinar,
-rub,russia ruble,russian ruble,
+rub,russia ruble,russian ruble,ruble
 rwf,rwandan franc,rwanda franc,
 sar,saudi arabian riyal,saudi arabia riyal,
 sbd,solomon islander dollar,solomon islands dollar,


### PR DESCRIPTION
## Description of new Instant Answer, or changes
Adds the alias ruble for the Russian Ruble.


## Related Issues and Discussions
Fixes #3168


## People to notify
@pjhampton 

<!-- DO NOT REMOVE -->
---

Instant Answer Page: https://duck.co/ia/view/currency