### PR TITLE
REPO: Removed Prog Mission info from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ We're a community of open source developers from around the world, contributing 
 ## How to contribute
 - [**Create new Spice Instant Answers, and improve existing ones**](https://duckduckhack.com/issues)
     - **Note**: Spices are written in Perl (back-end) and JavaScript (front-end). They can also typically use CSS, and [Handlebars](http://handlebarsjs.com) Templates.
-- [**Visit DuckDuckGo**](https://duckduckhack.com/#get-help) to learn more about the Programming Mission, and how you can help!
+- [**Visit DuckDuckGo**](https://duckduckhack.com/#get-help) to learn more about how you can help!
 
 
 ### What are Spice Instant Answers?

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ We're a community of open source developers from around the world, contributing 
 
 
 ## How to contribute
-- [**Create new Spice Instant Answers, and improve existing ones**](https://github.com/duckduckgo/zeroclickinfo-spice/issues")
+- [**Create new Spice Instant Answers, and improve existing ones**](https://duckduckhack.com/issues)
     - **Note**: Spices are written in Perl (back-end) and JavaScript (front-end). They can also typically use CSS, and [Handlebars](http://handlebarsjs.com) Templates.
 - [**Visit DuckDuckGo**](https://duckduckhack.com/#get-help) to learn more about the Programming Mission, and how you can help!
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,6 @@
 We're a community of open source developers from around the world, contributing code to improve the DuckDuckGo search engine.
 
 
-### The Programming Mission
-We want every programming search to have great results, providing the information you need instantly. The Programming Mission empowers the community to create Instant Answers for reference, libraries, help, and tools.
-
-For now, we are **only accepting Pull Requests and Issues related to the Programming Mission**.
-
-
 ## How to contribute
 - [**Create new Spice Instant Answers, and improve existing ones**](https://github.com/duckduckgo/zeroclickinfo-spice/issues?q=is%3Aopen+is%3Aissue+label%3A"Mission%3A+Programming")
     - **Note**: Spices are written in Perl (back-end) and JavaScript (front-end). They can also typically use CSS, and [Handlebars](http://handlebarsjs.com) Templates.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ We're a community of open source developers from around the world, contributing 
 
 
 ## How to contribute
-- [**Create new Spice Instant Answers, and improve existing ones**](https://github.com/duckduckgo/zeroclickinfo-spice/issues?q=is%3Aopen+is%3Aissue+label%3A"Mission%3A+Programming")
+- [**Create new Spice Instant Answers, and improve existing ones**](https://github.com/duckduckgo/zeroclickinfo-spice/issues")
     - **Note**: Spices are written in Perl (back-end) and JavaScript (front-end). They can also typically use CSS, and [Handlebars](http://handlebarsjs.com) Templates.
 - [**Visit DuckDuckGo**](https://duckduckhack.com/#get-help) to learn more about the Programming Mission, and how you can help!
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ We're a community of open source developers from around the world, contributing 
 ## How to contribute
 - [**Create new Spice Instant Answers, and improve existing ones**](https://duckduckhack.com/issues)
     - **Note**: Spices are written in Perl (back-end) and JavaScript (front-end). They can also typically use CSS, and [Handlebars](http://handlebarsjs.com) Templates.
-- [**Visit DuckDuckGo**](https://duckduckhack.com/#get-help) to learn more about how you can help!
+- [**Visit DuckDuckHack**](https://duckduckhack.com/#get-help) to learn more about how you can help!
 
 
 ### What are Spice Instant Answers?


### PR DESCRIPTION
## Description of new Instant Answer, or changes

Removes the Programming Mission description on this ZCI repo's README. See related PRs:

Goodies: https://github.com/duckduckgo/zeroclickinfo-goodies/pull/3997
Spice: https://github.com/duckduckgo/zeroclickinfo-spice/pull/3186
Fathead: https://github.com/duckduckgo/zeroclickinfo-fathead/pull/861
Longtail: https://github.com/duckduckgo/zeroclickinfo-longtail/pull/105


<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: n/a
<!-- FILL THIS IN:                           ^^^^ -->
