### PR TITLE
New Docker Hub Spice

### DIFF
--- a/lib/DDG/Spice/Dockerhub.pm
+++ b/lib/DDG/Spice/Dockerhub.pm
@@ -1,0 +1,32 @@
+package DDG::Spice::Dockerhub;
+
+# ABSTRACT: Write an abstract here
+
+# Start at http://docs.duckduckhack.com/walkthroughs/forum-lookup.html if you are new
+# to instant answer development
+
+use DDG::Spice;
+use strict;
+use warnings;
+
+# Caching - http://docs.duckduckhack.com/backend-reference/api-reference.html#caching
+spice is_cached => 1;
+spice proxy_cache_valid => '200 1d'; # defaults to this automatically
+
+spice wrap_jsonp_callback => 0; # only enable for non-JSONP APIs (i.e. no &callback= parameter)
+
+# API endpoint - http://docs.duckduckhack.com/walkthroughs/forum-lookup.html#api-endpoint
+spice to => 'http://example.com/search/$1';
+
+# Triggers - https://duck.co/duckduckhack/spice_triggers
+triggers any => 'triggerword', 'trigger phrase';
+
+# Handle statement
+handle remainder => sub {
+
+    # Query is in $_ or @_, depending on the handle you chose...if you
+    # need to do something with it before returning
+    return \$_;
+};
+
+1;

--- a/lib/DDG/Spice/Dockerhub.pm
+++ b/lib/DDG/Spice/Dockerhub.pm
@@ -1,31 +1,29 @@
 package DDG::Spice::Dockerhub;
-
-# ABSTRACT: Write an abstract here
-
-# Start at http://docs.duckduckhack.com/walkthroughs/forum-lookup.html if you are new
-# to instant answer development
+# ABSTRACT: Search for Docker Hub images
 
 use DDG::Spice;
 use strict;
 use warnings;
 
-# Caching - http://docs.duckduckhack.com/backend-reference/api-reference.html#caching
 spice is_cached => 1;
-spice proxy_cache_valid => '200 1d'; # defaults to this automatically
+spice proxy_cache_valid => '200 1d';
+spice wrap_jsonp_callback => 1;
+spice to => 'https://index.docker.io/v1/search?q=$1';
 
-spice wrap_jsonp_callback => 0; # only enable for non-JSONP APIs (i.e. no &callback= parameter)
+triggers startend => [
+    'docker', 
+    'docker.com', 
+    'dockerhub', 
+    'docker hub', 
+    'docker image', 
+    'docker images',
+    'docker container',
+    'docker containers'
+];
 
-# API endpoint - http://docs.duckduckhack.com/walkthroughs/forum-lookup.html#api-endpoint
-spice to => 'http://example.com/search/$1';
-
-# Triggers - https://duck.co/duckduckhack/spice_triggers
-triggers any => 'triggerword', 'trigger phrase';
-
-# Handle statement
 handle remainder => sub {
-
-    # Query is in $_ or @_, depending on the handle you chose...if you
-    # need to do something with it before returning
+    
+    return $_ if $_;
     return \$_;
 };
 

--- a/lib/DDG/Spice/Dockerhub.pm
+++ b/lib/DDG/Spice/Dockerhub.pm
@@ -6,25 +6,16 @@ use strict;
 use warnings;
 
 spice is_cached => 1;
-spice proxy_cache_valid => '200 1d';
+spice proxy_cache_valid => '200 1h';
 spice wrap_jsonp_callback => 1;
 spice to => 'https://index.docker.io/v1/search?q=$1';
 
-triggers startend => [
-    'docker', 
-    'docker.com', 
-    'dockerhub', 
-    'docker hub', 
-    'docker image', 
-    'docker images',
-    'docker container',
-    'docker containers'
-];
+triggers startend => 'docker', 'dockerhub', 'docker hub';
+triggers end => 'docker image';
 
 handle remainder => sub {
-    
-    return $_ if $_;
-    return \$_;
+    return unless $_;
+    return $_;
 };
 
 1;

--- a/share/spice/dockerhub/dockerhub.css
+++ b/share/spice/dockerhub/dockerhub.css
@@ -1,0 +1,4 @@
+.zci--dockerhub {
+
+}
+

--- a/share/spice/dockerhub/dockerhub.css
+++ b/share/spice/dockerhub/dockerhub.css
@@ -1,4 +1,4 @@
-.zci--dockerhub {
-
+.tile--dockerhub .star.starIcon {
+    font-size: 1.3em;
+    margin-top: -5px;
 }
-

--- a/share/spice/dockerhub/dockerhub.js
+++ b/share/spice/dockerhub/dockerhub.js
@@ -4,34 +4,43 @@
     env.ddg_spice_dockerhub = function(api_result) {
 
         // Validate the response (customize for your Spice)
-        if (!api_result || api_result.error) {
+        if (!api_result || api_result.error || api_result.results === 0) {
             return Spice.failed('dockerhub');
         }
+        
+        console.log(api_result.results);
 
         // Render the response
         Spice.add({
             id: 'dockerhub',
-
-            // Customize these properties
-            name: 'AnswerBar title',
-            data: api_result,
+            name: 'Docker Images',
+            data: api_result.results,
             meta: {
-                sourceName: 'Example.com',
-                sourceUrl: 'http://example.com/url/to/details/' + api_result.name
+                sourceName: 'Docker Hub',
+                sourceUrl: 'hub.docker.com',
+                total: api_result.results.length
             },
             normalize: function(item) {
                 return {
-                    // customize as needed for your chosen template
-                    title: item.title,
-                    subtitle: item.subtitle,
-                    image: item.icon
+                    title: item.name,
+                    description: item.description,
+                    url: (item.is_official ?
+                          "https://hub.docker.com/_/" + item.name :
+                          "https://hub.docker.com/r/" + item.name),
+                    stars: item.star_count
                 };
-            },
+            }, 
             templates: {
-                group: 'your-template-group',
+                group: 'text',
+                detail: false,
+                item_detail: false,
                 options: {
                     content: Spice.dockerhub.content,
+                    footer: Spice.dockerhub.footer,
                     moreAt: true
+                },
+                variants: {
+                    tile: 'basic4'
                 }
             }
         });

--- a/share/spice/dockerhub/dockerhub.js
+++ b/share/spice/dockerhub/dockerhub.js
@@ -1,0 +1,39 @@
+(function (env) {
+    "use strict";
+
+    env.ddg_spice_dockerhub = function(api_result) {
+
+        // Validate the response (customize for your Spice)
+        if (!api_result || api_result.error) {
+            return Spice.failed('dockerhub');
+        }
+
+        // Render the response
+        Spice.add({
+            id: 'dockerhub',
+
+            // Customize these properties
+            name: 'AnswerBar title',
+            data: api_result,
+            meta: {
+                sourceName: 'Example.com',
+                sourceUrl: 'http://example.com/url/to/details/' + api_result.name
+            },
+            normalize: function(item) {
+                return {
+                    // customize as needed for your chosen template
+                    title: item.title,
+                    subtitle: item.subtitle,
+                    image: item.icon
+                };
+            },
+            templates: {
+                group: 'your-template-group',
+                options: {
+                    content: Spice.dockerhub.content,
+                    moreAt: true
+                }
+            }
+        });
+    };
+}(this));

--- a/share/spice/dockerhub/dockerhub.js
+++ b/share/spice/dockerhub/dockerhub.js
@@ -7,8 +7,6 @@
         if (!api_result || api_result.error || api_result.results === 0) {
             return Spice.failed('dockerhub');
         }
-        
-        console.log(api_result.results);
 
         // Render the response
         Spice.add({

--- a/share/spice/dockerhub/footer.handlebars
+++ b/share/spice/dockerhub/footer.handlebars
@@ -1,0 +1,3 @@
+<div class="tile__update__info one-line">
+  <i class="star starIcon"></i> {{ stars }}
+</div>

--- a/t/Dockerhub.t
+++ b/t/Dockerhub.t
@@ -1,0 +1,26 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+spice is_cached => 1;
+
+ddg_spice_test(
+    [qw( DDG::Spice::Dockerhub)],
+    # At a minimum, be sure to include tests for all:
+    # - primary_example_queries
+    # - secondary_example_queries
+    'example query' => test_spice(
+        '/js/spice/dockerhub/query',
+        call_type => 'include',
+        caller => 'DDG::Spice::Dockerhub'
+    ),
+    # Try to include some examples of queries on which it might
+    # appear that your answer will trigger, but does not.
+    'bad example query' => undef,
+);
+
+done_testing;
+

--- a/t/Dockerhub.t
+++ b/t/Dockerhub.t
@@ -9,17 +9,23 @@ spice is_cached => 1;
 
 ddg_spice_test(
     [qw( DDG::Spice::Dockerhub)],
-    # At a minimum, be sure to include tests for all:
-    # - primary_example_queries
-    # - secondary_example_queries
-    'example query' => test_spice(
-        '/js/spice/dockerhub/query',
+
+    'docker redis' => test_spice(
+        '/js/spice/dockerhub/redis',
         call_type => 'include',
         caller => 'DDG::Spice::Dockerhub'
     ),
-    # Try to include some examples of queries on which it might
-    # appear that your answer will trigger, but does not.
-    'bad example query' => undef,
+    'wordpress dockerhub' => test_spice(
+        '/js/spice/dockerhub/wordpress',
+        call_type => 'include',
+        caller => 'DDG::Spice::Dockerhub'
+    ),
+    'docker hub duckpan' => test_spice(
+        '/js/spice/dockerhub/duckpan',
+        call_type => 'include',
+        caller => 'DDG::Spice::Dockerhub'
+    )
+    
 );
 
 done_testing;


### PR DESCRIPTION
## Description of new Instant Answer, or changes

Based on old query data, this IA aims to plug the gap in the search space regarding the search for docker images. This IA searches for docker images over the v1 Docker API. 

**Screenshot 1**: _docker redis_
![screen shot 2017-03-18 at 10 20 41 pm](https://cloud.githubusercontent.com/assets/8960296/24076464/65c3e438-0c29-11e7-9715-a6f6ab0c239b.png)

**Screenshot 2**: _wordpress docker containers_
![screen shot 2017-03-18 at 10 21 10 pm](https://cloud.githubusercontent.com/assets/8960296/24076465/6a54e5c4-0c29-11e7-8665-19f9743f71f7.png)

**Screenshot 3**: _duckpan docker hub_
![screen shot 2017-03-18 at 10 21 50 pm](https://cloud.githubusercontent.com/assets/8960296/24076466/6d991458-0c29-11e7-89aa-5aff1d653c8f.png)

**Screenshot 4**: _duckpan docker hub_
![screen shot 2017-03-18 at 10 22 19 pm](https://cloud.githubusercontent.com/assets/8960296/24076467/75af2e20-0c29-11e7-8774-97f58ed0e5a2.png)

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->
n/a

## People to notify
@moollaza [Please push to beta at some stage]
@duckduckgo/community-leaders

<!-- DO NOT REMOVE -->
---

Instant Answer Page: https://duck.co/ia/view/dockerhub