### PR TITLE
Geometry: Add hemisphere shape

### DIFF
--- a/share/spice/geometry/geometry.js
+++ b/share/spice/geometry/geometry.js
@@ -350,6 +350,46 @@
             },
             parameterNames: ["a", "b", "c"]
         },
+        hemisphere : {
+            formulas: [{
+                name: "volume",
+                html: "2/3&pi;r<sup>3</sup>",
+                calc: function(r){
+                    return 2 / 3 * Math.PI * r * r * r;
+                }
+            }, {
+                name: "surface",
+                html: "3&pi;r<sup>2</sup>",
+                calc: function(r){
+                    return 3 * Math.PI * r * r;
+                }
+            }],
+            svg: [{
+                path: "M 0,80 a 30 10 0 0 0 120,0 a 25 25 0 0 0 -120,0 ",
+                class: "fill"
+            }, {
+                path: "M 0,80 a 30 10 0 0 1 120,0 ",
+                class: "stroke backface"
+            }, {
+                path: "M 0,80 a 30 10 0 1 0 120,0 a 25 25 0 0 0 -120,0 ",
+                class: "fill"
+            }, {
+                path: "M 0,80 a 30 10 0 1 0 120,0 a 25 25 0 0 0 -120,0 ",
+                class: "stroke"
+            }],
+            pairs: {
+                volume: [0, 2],
+                surface: [1, 0]
+            },
+            getParameter: function(query){
+                var r = getParameter(query, "radius|r");
+                if(r !== null) return r;
+                r = getParameter(query, "diameter|d");
+                if(r !== null) return r / 2;
+                return null;
+            },
+            parameterNames: ["r"]
+        },
         sphere : {
             formulas: [{
                 name: "volume",


### PR DESCRIPTION
<!-- Use the appropriate format for your Pull Request title above ^^^^^:

If this is a bug fix:
{IA Name}: {Description of change}

If this is a New Instant Answer:
New {IA Name} Spice

If this is something else:
{Tests/Docs/Other}: {Short Description}

-->

## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
Search queries for hemisphere (e.g. "geometry of hemisphere") was displaying results for sphere. This PR adds the shape hemisphere to return correct formulas, calculations and visual.

Screenshots for proposed changes:

Without highlighting
![geometry-1](https://cloud.githubusercontent.com/assets/15639955/24096638/5f917af8-0d5a-11e7-9a80-aaf54fdb92bc.png)
With volume highlighting
![geometry-2](https://cloud.githubusercontent.com/assets/15639955/24096646/68e2d55c-0d5a-11e7-8bbc-a51a7a779ab4.png)
With surface area highlighting
![geometry-3](https://cloud.githubusercontent.com/assets/15639955/24096648/6b98bbc2-0d5a-11e7-9225-45b42f21923a.png)


## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->
Fixes first bug from #3194

## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@moollaza @pjhampton @pixunil @adityatandon007 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/geometry
<!-- FILL THIS IN:                           ^^^^ -->
