### PR TITLE
Currency: Prevents Triggering on Single Currency

### DIFF
--- a/lib/DDG/Spice/Currency.pm
+++ b/lib/DDG/Spice/Currency.pm
@@ -146,9 +146,7 @@ handle query_lc => sub {
         }
         
         # if only a currency symbol is present, then bail.
-        if ($amount eq '' && $to eq '' && exists($currHash{$from})) {
-            return;
-        }
+        return if ($amount eq '' && $to eq '' && exists($currHash{$from}));
 
         my $styler = number_style_for($amount);
         return unless $styler;

--- a/lib/DDG/Spice/Currency.pm
+++ b/lib/DDG/Spice/Currency.pm
@@ -144,6 +144,11 @@ handle query_lc => sub {
         if ($to eq '' && $toSymbol) {
             $to = $currencyCodes->{ord($toSymbol)};
         }
+        
+        # if only a currency symbol is present, then bail.
+        if ($amount eq '' && $to eq '') {
+            return;
+        }
 
         my $styler = number_style_for($amount);
         return unless $styler;

--- a/lib/DDG/Spice/Currency.pm
+++ b/lib/DDG/Spice/Currency.pm
@@ -146,7 +146,7 @@ handle query_lc => sub {
         }
         
         # if only a currency symbol is present, then bail.
-        if ($amount eq '' && $to eq '') {
+        if ($amount eq '' && $to eq '' && exists($currHash{$from})) {
             return;
         }
 

--- a/t/Currency.t
+++ b/t/Currency.t
@@ -13,6 +13,12 @@ ddg_spice_test(
     [
         'DDG::Spice::Currency'
     ],
+    'canada dollar' => test_spice(
+        '/js/spice/currency/1/cad/cad',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
     '400 euro' => test_spice(
         '/js/spice/currency/400/eur/usd',
         call_type => 'include',
@@ -345,9 +351,7 @@ ddg_spice_test(
     'b aud' => undef,
     't aud' => undef,
     
-    # standalone currencys
-    'canadian dollar' => undef,
-    'US dollar' => undef,
+    # standalone symbols
     'Irl' => undef,
     'usd' => undef,
     'gbp' => undef,

--- a/t/Currency.t
+++ b/t/Currency.t
@@ -13,12 +13,6 @@ ddg_spice_test(
     [
         'DDG::Spice::Currency'
     ],
-    'canada dollar' => test_spice(
-        '/js/spice/currency/1/cad/cad',
-        call_type => 'include',
-        caller => 'DDG::Spice::Currency',
-        is_cached => 0
-    ),
     '400 euro' => test_spice(
         '/js/spice/currency/400/eur/usd',
         call_type => 'include',
@@ -350,6 +344,15 @@ ddg_spice_test(
     'm aud' => undef,
     'b aud' => undef,
     't aud' => undef,
+    
+    # standalone currencys
+    'canadian dollar' => undef,
+    'US dollar' => undef,
+    'Irl' => undef,
+    'usd' => undef,
+    'gbp' => undef,
+    'EUR' => undef,
+    'CaD' => undef,
 
     # Things that should probably work but it doesn't at the moment.
     'cny jpy 400' => undef,


### PR DESCRIPTION
## Description of new Instant Answer, or changes

This PR prevents the Currency IA triggering on a single currency, ie. `usd`, `eur`, etc.

## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@moollaza 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/currency
<!-- FILL THIS IN:                           ^^^^ -->
