### PR TITLE
Expand URL: Replacing Malicious API

### DIFF
--- a/lib/DDG/Spice/ExpandURL.pm
+++ b/lib/DDG/Spice/ExpandURL.pm
@@ -5,7 +5,7 @@ use DDG::Spice;
 
 triggers start => "http", "https", "expand", "expandurl", "unshorten", "untiny";
 
-spice to => 'http://untiny.me/api/1.0/extract/?url=$1&format=json';
+spice to => 'https://unshorten.me/json/$1?key={{ENV{DDG_SPICE_UNSHORTEN_ME_KEY}}}';
 spice wrap_jsonp_callback => 1;
 
 handle query => sub {

--- a/share/spice/expand_url/expand_url.js
+++ b/share/spice/expand_url/expand_url.js
@@ -9,7 +9,7 @@
             query = source.match(/expand_url\/([^\/]+)/)[1];
 
         // Check if there are any errors.
-        if (!api_result.org_url || api_result.error) {
+        if (!api_result.success) {
             return Spice.failed('expand_url');
         }
 
@@ -21,8 +21,8 @@
             name: "Answer",
             data: api_result,
             meta: {
-                sourceUrl: "http://untiny.me/",
-                sourceName: "Untiny"
+                sourceUrl: "https://unshorten.me",
+                sourceName: "unshorten.me"
             },
             templates: {
                 group: 'text',

--- a/share/spice/expand_url/title_content.handlebars
+++ b/share/spice/expand_url/title_content.handlebars
@@ -1,3 +1,3 @@
 <h3 class="c-base__title text--primary">
-    <a href='{{org_url}}'>{{org_url}}</a>
+    <a href='{{resolved_url}}'>{{resolved_url}}</a>
 </h3>


### PR DESCRIPTION
## Description of new Instant Answer, or changes
Since untiny.me was being flagged as a malicious site by browsers, the IA now uses unshorten.me

**Please note** this change requires an API key.  I have it, just let me know where it needs to go.  I followed the convention I saw used in the repo and put `{{ENV{DDG_SPICE_UNSHORTEN_ME_KEY}}}` where it needs to be inserted.

## Related Issues and Discussions
Fixes #3164 


## People to notify
@moollaza 
@pjhampton 

<!-- DO NOT REMOVE -->
---

Instant Answer Page: https://duck.co/ia/view/expand_url