### PR TITLE
Currency: Adding lev Alias

### DIFF
--- a/share/spice/currency/currencyNames.txt
+++ b/share/spice/currency/currencyNames.txt
@@ -11,7 +11,7 @@ azn,azerbaijani new manat,azerbaijan new manat,
 bam,bosnian convertible marka,bosnia and herzegovina convertible marka,
 bbd,barbadian dollar,bajan dollar,barbados dollar,
 bdt,bangladeshi taka,bangladesh taka,taka,
-bgn,bulgarian lev,bulgaria lev,
+bgn,bulgarian lev,bulgaria lev,lev
 bhd,bahraini dinar,bahrain dinar,
 bif,burundian franc,burundi franc,
 bmd,bermudian dollar,bermuda dollar,

--- a/t/Currency.t
+++ b/t/Currency.t
@@ -311,6 +311,19 @@ ddg_spice_test(
         caller => 'DDG::Spice::Currency',
         is_cached => 0
     ),
+    # Testing addition of shortened version of lev
+    '5m usd to lev' => test_spice(
+        '/js/spice/currency/5000000/usd/bgn',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
+    '600 levs in rubles' => test_spice(
+        '/js/spice/currency/600/bgn/rub',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
     # check if the currency is detected from the location
     # when you don't specify the target currency
     DDG::Request->new(


### PR DESCRIPTION
## Description of new Instant Answer, or changes
Adds the Alias "lev" for the Bulgarian Lev.

## Related Issues and Discussions
Fixes #3207 

## People to notify
@pjhampton 

<!-- DO NOT REMOVE -->
---
Instant Answer Page: https://duck.co/ia/view/currency