### PR TITLE
SoundCloud: Remove deprecated Audio view reference

### DIFF
--- a/share/spice/sound_cloud/sound_cloud.js
+++ b/share/spice/sound_cloud/sound_cloud.js
@@ -37,6 +37,7 @@
                     footer: Spice.sound_cloud.footer
                 }
             },
+            view: 'GridTiles',
             relevancy: {
                 dup: 'url'
             },

--- a/share/spice/sound_cloud/sound_cloud.js
+++ b/share/spice/sound_cloud/sound_cloud.js
@@ -37,7 +37,6 @@
                     footer: Spice.sound_cloud.footer
                 }
             },
-            view: 'Audio',
             relevancy: {
                 dup: 'url'
             },


### PR DESCRIPTION
SoundCloud

## Description of new Instant Answer, or changes
The Audio view was deprecated internally and it's been redirecting to 'GridTiles'. This allows us to remove internal code.

## People to notify
@bbraithwaite 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/{ID}
<!-- FILL THIS IN:                           ^^^^ -->
