### PR TITLE
Package Tracking: Add Fedex, UPS, USPS Regex Triggers

### DIFF
--- a/lib/DDG/Spice/PackageTracking.pm
+++ b/lib/DDG/Spice/PackageTracking.pm
@@ -12,18 +12,17 @@ spice wrap_jsonp_callback => 1;
 
 spice to => 'https://api.packagetrackr.com/ddg/v1/track/simple?n=$1&api_key={{ENV{DDG_SPICE_PACKAGETRACKR_API_KEY}}}';
 
-my $carriers = LoadFile(share('carriers.yml'));
-my @triggers = ('package', 'track package', 'shipping status', 'package tracking', 'track');
-my $triggers_re = join "|", @triggers;
-my $carriers_re = join "|", @$carriers;
-my $tracking_re = qr/package|track(?:ing|)|num(?:ber|)|\#/i;
-my $strip_re = qr/$triggers_re|$carriers_re/;
+my $carriers_list = LoadFile(share('carriers.yml'));
+my @carriers = sort { length $b <=> length $a } @$carriers_list;
+my $triggers_re = qr/package|track(ing)?|num(ber)?|shipping status|\#/ix;
+my $carriers_re = join "|", @carriers;
+my $strip_re = qr/$triggers_re|$carriers_re/i;
 
 # Package words
-triggers query_lc => qr/^($triggers_re .+|.+ $triggers_re)$/;
+triggers query_nowhitespace_nodash => qr/$triggers_re/i;
 
 # Carrier names
-triggers query_lc => qr/^($carriers_re .+|.+ $carriers_re)$/;
+triggers query_nowhitespace_nodash => qr/$carriers_re/i;
 
 # UPS
 triggers query_nowhitespace_nodash => qr/(1Z[0-9A-Z]{16})/i;
@@ -40,18 +39,15 @@ triggers query_nowhitespace_nodash => qr/
                                          ^([\d]{20,30})$
                                         /xi;
 
-handle query_lc => sub {
-
+handle query_nowhitespace_nodash => sub {
     # strip words
-    s/$strip_re//g;
+    s/$strip_re//ixg;
     trim($_);
     return unless $_;
     # remainder should be numeric or alphanumeric, not alpha
-    return if m/^[a-z\s]+$/;
-    # ignore us zipcodes
-    return if m/^[0-9]{5}+$/;
+    return if m/^[A-Z]+$/i;
     # remainder should be at least 6 characters long
-    return unless m/^[a-z0-9\-]{6,}$/;
+    return unless m/^[A-Z0-9]{6,}$/i;
     return $_;
 };
 

--- a/lib/DDG/Spice/PackageTracking.pm
+++ b/lib/DDG/Spice/PackageTracking.pm
@@ -20,22 +20,30 @@ my $strip_re = qr/$triggers_re|$carriers_re/i;
 # Package words
 triggers query_nowhitespace_nodash => qr/$triggers_re/i;
 
-# Carrier names
-triggers query_nowhitespace_nodash => qr/$carriers_re/i;
+### Regex triggers for queries only containing a tracking number
 
 # UPS
-triggers query_nowhitespace_nodash => qr/(1Z[0-9A-Z]{16})/i;
+# Soure: https://www.ups.com/content/ca/en/tracking/help/tracking/tnh.html
+# To Do: Some additional formats exist
+triggers query_nowhitespace_nodash => qr/
+                                        ^1Z[0-9A-Z]{16}$|
+                                        ^\d{9,12}$|
+                                        ^T\d{10}$
+                                        /xi;
 
 # Fedex
-triggers query_nowhitespace_nodash => qr/^([\d]{9,}).*?$|
-                                         ^(\d*?)([\d]{15})$
+# Source: https://www.trackingex.com/fedex-tracking.html
+#         https://www.trackingex.com/fedexuk-tracking.html
+#         https://www.trackingex.com/fedex-poland-domestic-tracking.html
+triggers query_nowhitespace_nodash => qr/
+                                        ^\d{12,22}$
                                         /xi;
 
 # USPS
 triggers query_nowhitespace_nodash => qr/
-                                         ^([\d]{9,})$|
-                                         ^([a-z]{2}\d{9}us)$|
-                                         ^([\d]{20,30})$
+                                        ^\d{9,30}$|
+                                        ^[A-Z]{2}\d{9}US$|
+                                        ^\d{20,30}$
                                         /xi;
 
 handle query_nowhitespace_nodash => sub {
@@ -45,8 +53,10 @@ handle query_nowhitespace_nodash => sub {
     return unless $_;
     # remainder should be numeric or alphanumeric, not alpha
     return if m/^[A-Z]+$/i;
-    # remainder should be at least 6 characters long
-    return unless m/^[A-Z0-9]{6,}$/i;
+
+    # remainder should be 6-30 characters long
+    return unless m/^[A-Z0-9]{6,30}$/i;
+
     return $_;
 };
 

--- a/lib/DDG/Spice/PackageTracking.pm
+++ b/lib/DDG/Spice/PackageTracking.pm
@@ -12,8 +12,7 @@ spice wrap_jsonp_callback => 1;
 
 spice to => 'https://api.packagetrackr.com/ddg/v1/track/simple?n=$1&api_key={{ENV{DDG_SPICE_PACKAGETRACKR_API_KEY}}}';
 
-my $carriers_list = LoadFile(share('carriers.yml'));
-my @carriers = sort { length $b <=> length $a } @$carriers_list;
+my @carriers = sort { length $b <=> length $a } @{LoadFile(share('carriers.yml'))};
 my $triggers_re = qr/package|track(ing)?|num(ber)?|shipping status|\#/ix;
 my $carriers_re = join "|", @carriers;
 my $strip_re = qr/$triggers_re|$carriers_re/i;

--- a/share/spice/package_tracking/carriers.yml
+++ b/share/spice/package_tracking/carriers.yml
@@ -11,6 +11,7 @@
 - dynamex
 - ensenda
 - fedex
+- federal express
 - gso
 - hongkong post
 - india post
@@ -29,6 +30,7 @@
 - tnt
 - toll
 - ups
+- united states postal service
 - universal postal union
 - usps
 - yodel

--- a/t/PackageTracking.t
+++ b/t/PackageTracking.t
@@ -87,14 +87,16 @@ ddg_spice_test(
     70000000000000000001 => undef,
     'what is 70000000000000000000' => undef,
 
+    # Too short
+    'usps 12345' => undef,
 
     # TODO: Display input form prompting for tracking number?
     'fedex package tracking' => undef,
+    'fedex package tracker' => undef,
     'package tracking' => undef,
     'package tracking online' => undef,
 
     'fedex' => undef,
-    'fedex website' => undef,
     'fedex website' => undef
 );
 

--- a/t/PackageTracking.t
+++ b/t/PackageTracking.t
@@ -83,9 +83,32 @@ ddg_spice_test(
         caller => 'DDG::Spice::PackageTracking'
     ),
 
+    # Parcelforce / Royal Mail
+    'parcelforce track PBTM8041434001' => test_spice(
+        '/js/spice/package_tracking/PBTM8041434001',
+        call_type => 'include',
+        caller => 'DDG::Spice::PackageTracking'
+    ),
+    'royal mail track parcel QE001331410GB' => test_spice(
+        '/js/spice/package_tracking/QE001331410GB',
+        call_type => 'include',
+        caller => 'DDG::Spice::PackageTracking'
+    ),
+    'PBTM8237263001' => test_spice(
+        '/js/spice/package_tracking/PBTM8237263001',
+        call_type => 'include',
+        caller => 'DDG::Spice::PackageTracking'
+    ),
+
     # Bad Queries
     70000000000000000001 => undef,
     'what is 70000000000000000000' => undef,
+    'luhn 1234554651' => undef,
+    'KB2553549' => undef,
+    '0000 0000 0000' => undef,
+
+    # Too long
+    'fedex 123456789 123456789 123456789 1234' => undef,
 
     # Too short
     'usps 12345' => undef,

--- a/t/PackageTracking.t
+++ b/t/PackageTracking.t
@@ -9,31 +9,84 @@ spice is_cached => 1;
 
 ddg_spice_test(
     [qw( DDG::Spice::PackageTracking)],
+
+    # Generic
     'shipping status C11422907783469' => test_spice(
-        '/js/spice/package_tracking/c11422907783469',
+        '/js/spice/package_tracking/C11422907783469',
         call_type => 'include',
         caller => 'DDG::Spice::PackageTracking'
     ),
     'package C11422907783469' => test_spice(
-        '/js/spice/package_tracking/c11422907783469',
+        '/js/spice/package_tracking/C11422907783469',
         call_type => 'include',
         caller => 'DDG::Spice::PackageTracking'
     ),
     'ontrac C11422907783469' => test_spice(
-        '/js/spice/package_tracking/c11422907783469',
+        '/js/spice/package_tracking/C11422907783469',
         call_type => 'include',
         caller => 'DDG::Spice::PackageTracking'
     ),
     'ontrac package C11422907783469' => test_spice(
-        '/js/spice/package_tracking/c11422907783469',
+        '/js/spice/package_tracking/C11422907783469',
         call_type => 'include',
         caller => 'DDG::Spice::PackageTracking'
     ),
     'C11422907783469 ontrac package' => test_spice(
-        '/js/spice/package_tracking/c11422907783469',
+        '/js/spice/package_tracking/C11422907783469',
         call_type => 'include',
         caller => 'DDG::Spice::PackageTracking'
     ),
+
+    # Fedex
+    'fedex 9241990100130206401644' => test_spice(
+        '/js/spice/package_tracking/9241990100130206401644',
+        call_type => 'include',
+        caller => 'DDG::Spice::PackageTracking'
+    ),
+    '178440515632684' => test_spice(
+        '/js/spice/package_tracking/178440515632684',
+        call_type => 'include',
+        caller => 'DDG::Spice::PackageTracking'
+    ),
+    '9612804882227378545377' => test_spice(
+        '/js/spice/package_tracking/9612804882227378545377',
+        call_type => 'include',
+        caller => 'DDG::Spice::PackageTracking'
+    ),
+
+    # UPS
+    'ups 1Z0884XV0399906189' => test_spice(
+        '/js/spice/package_tracking/1Z0884XV0399906189',
+        call_type => 'include',
+        caller => 'DDG::Spice::PackageTracking'
+    ),
+    '1Z0884XV0399906189' => test_spice(
+        '/js/spice/package_tracking/1Z0884XV0399906189',
+        call_type => 'include',
+        caller => 'DDG::Spice::PackageTracking'
+    ),
+
+    # USPS
+    'EA 000 000 000 US' => test_spice(
+        '/js/spice/package_tracking/EA000000000US',
+        call_type => 'include',
+        caller => 'DDG::Spice::PackageTracking'
+    ),
+    'usps 7000 0000 0000 0000 0000' => test_spice(
+        '/js/spice/package_tracking/70000000000000000000',
+        call_type => 'include',
+        caller => 'DDG::Spice::PackageTracking'
+    ),
+    'usps 37346365253153' => test_spice(
+        '/js/spice/package_tracking/37346365253153',
+        call_type => 'include',
+        caller => 'DDG::Spice::PackageTracking'
+    ),
+
+    # Bad Queries
+    70000000000000000001 => undef,
+    'what is 70000000000000000000' => undef,
+
 
     # TODO: Display input form prompting for tracking number?
     'fedex package tracking' => undef,


### PR DESCRIPTION
## Description of new Instant Answer, or changes
The existing Fedex, UPS, and USPS Goodies constantly return false-positive results because we rely on our regex to determine if a tracking code belong to one courier or another.

This PR migrates those triggers to the Package Spice so we can trigger on queries that only contain alphanumeric strings that match Fedex, USPS, and UPS tracking number patterns. The API will determine if the number is valid and which carrier it actually belongs to and provide us with the current package status.

This is way more reliable and will prevent us from sending the user to the wrong courier website.

This will also enable us to deprecate those 3 Goodies.

## Related Issues and Discussions
Partially resolve https://github.com/duckduckgo/zeroclickinfo-goodies/issues/3973

## People to notify
@Owlree @pjhampton 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/package_tracking
<!-- FILL THIS IN:                           ^^^^ -->
