### PR TITLE
moving map module future signal tab check internal

### DIFF
--- a/share/spice/maps/maps/maps_maps.js
+++ b/share/spice/maps/maps/maps_maps.js
@@ -3,7 +3,7 @@ DDG.require('maps',function(){
         if (!response || !response.features || !response.features.length) { return Spice.failed('maps_maps'); }
 
         // if user is in map module experiment, and signal is high
-        if (DDG.opensearch.installed.experiment === 'map_module' && DDG.opensearch.installed.variant === 'a' && DDG.duckbar.futureSignals[0].from === "maps_maps" && DDG.duckbar.futureSignals[0].signal === "high") {
+        if (DDG.opensearch.installed.experiment === 'map_module' && DDG.opensearch.installed.variant === 'a') {
             // if top result returned doesn't have high relevance,
             // the rest won't either so spice should fail.
             if (response.features[0].relevance < 0.7) {


### PR DESCRIPTION
<!-- Use the appropriate format for your Pull Request title above ^^^^^:

If this is a bug fix:
{IA Name}: maps_maps

-->


## Description of new Instant Answer, or changes
This PR moves the high future signal tab check out of the public repo. This only has to do with the map module experiment.


## Related Issues and Discussions
https://app.asana.com/0/72649045549333/304271607844297


## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@bsstoner 
<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/maps_maps
<!-- FILL THIS IN:                           ^^^^ -->
