### PR TITLE
Dictionary::Definition: Add upstream timeouts.

### DIFF
--- a/lib/DDG/Spice/Dictionary/Definition.pm
+++ b/lib/DDG/Spice/Dictionary/Definition.pm
@@ -24,6 +24,10 @@ spice alt_to => {
 	}
 };
 
+spice upstream_timeouts => +{ connect => '100ms',
+                              send => '100ms',
+                              read => '500ms' };
+
 triggers startend => (
     "define",
     "define:",


### PR DESCRIPTION
Reviewer: @bsstoner 
CC: @kablamo @malbin @marcantonio 
Description: Add upstream timeouts to the dictionary definition spice because Wordnik is timing out.

This PR *requires* https://github.com/duckduckgo/duckduckgo/pull/243/files.

https://duck.co/ia/view/dictionary_definition