### PR TITLE
Currency: Fixes #3214 Support 'Currency' trigger

### DIFF
--- a/lib/DDG/Spice/Currency.pm
+++ b/lib/DDG/Spice/Currency.pm
@@ -31,9 +31,10 @@ my $vs_qr = qr/\sv(?:ersu|)s\.?\s/i;
 my $question_prefix = qr/(?:convert|what (?:is|are|does)|how (?:much|many) (?:is|are))?\s?/;
 my $number_re = number_style_regex();
 my $cardinal_re = join(' |', qw(hundred thousand k million m billion b trillion)).' ';
+my $keyword_qr = qr/\scurrency\s*/i;
 
 
-my $guard = qr/^$question_prefix(\p{Currency_Symbol})?\s?($number_re*)\s?(\p{Currency_Symbol})?\s?($cardinal_re)?\s?($currency_qr)?(?:s)?(?:$into_qr|$vs_qr|\/|\s)?($number_re*)\s?($currency_qr)?(\p{Currency_Symbol})?(?:s)?\??$/i;
+my $guard = qr/^$question_prefix(\p{Currency_Symbol})?\s?($number_re*)\s?(\p{Currency_Symbol})?\s?($cardinal_re)?\s?($currency_qr)?(?:s)?($keyword_qr)?(?:$into_qr|$vs_qr|\/|\s)?($number_re*)\s?($currency_qr)?(\p{Currency_Symbol})?(?:s)?($keyword_qr)?\??$/i;
 
 triggers query_lc => qr/\p{Currency_Symbol}|$currency_qr/;
 
@@ -134,7 +135,7 @@ handle query_lc => sub {
 
     if(/$guard/) {
 
-        my ($fromSymbol, $amount, $cardinal, $from, $alt_amount, $to, $toSymbol) = ($1 || $3 || '', $2, $4 || '', $5 || '', $6 || '' , $7 || '', $8 || '');
+	my ($fromSymbol, $amount, $cardinal, $from, $currencyKeyword, $alt_amount, $to, $toSymbol) = ($1 || $3 || '', $2, $4 || '', $5 || '', $6 || '', $7 || '', $8 || '', $9 || '');
 
 
         if ($from eq '' && $fromSymbol) {
@@ -145,8 +146,8 @@ handle query_lc => sub {
             $to = $currencyCodes->{ord($toSymbol)};
         }
         
-        # if only a currency symbol is present, then bail.
-        return if ($amount eq '' && $to eq '' && exists($currHash{$from}));
+        # if only a currency symbol is present without "currency" keyword, then bail.
+	return if ($amount eq '' && $to eq '' && $currencyKeyword eq '' && exists($currHash{$from}));
 
         my $styler = number_style_for($amount);
         return unless $styler;

--- a/lib/DDG/Spice/Currency.pm
+++ b/lib/DDG/Spice/Currency.pm
@@ -31,7 +31,7 @@ my $vs_qr = qr/\sv(?:ersu|)s\.?\s/i;
 my $question_prefix = qr/(?:convert|what (?:is|are|does)|how (?:much|many) (?:is|are))?\s?/;
 my $number_re = number_style_regex();
 my $cardinal_re = join(' |', qw(hundred thousand k million m billion b trillion)).' ';
-my $keyword_qr = qr/\scurrency\s*/i;
+my $keyword_qr = qr/\s?currency\s?/i;
 
 
 my $guard = qr/^$question_prefix(\p{Currency_Symbol})?\s?($number_re*)\s?(\p{Currency_Symbol})?\s?($cardinal_re)?\s?($currency_qr)?(?:s)?($keyword_qr)?(?:$into_qr|$vs_qr|\/|\s)?($number_re*)\s?($currency_qr)?(\p{Currency_Symbol})?(?:s)?($keyword_qr)?\??$/i;
@@ -135,7 +135,7 @@ handle query_lc => sub {
 
     if(/$guard/) {
 
-	my ($fromSymbol, $amount, $cardinal, $from, $currencyKeyword, $alt_amount, $to, $toSymbol) = ($1 || $3 || '', $2, $4 || '', $5 || '', $6 || '', $7 || '', $8 || '', $9 || '');
+        my ($fromSymbol, $amount, $cardinal, $from, $currencyKeyword, $alt_amount, $to, $toSymbol) = ($1 || $3 || '', $2, $4 || '', $5 || '', $6 || '', $7 || '', $8 || '', $9 || '');
 
 
         if ($from eq '' && $fromSymbol) {

--- a/t/Currency.t
+++ b/t/Currency.t
@@ -68,6 +68,25 @@ ddg_spice_test(
         caller => 'DDG::Spice::Currency',
         is_cached => 0
     ),
+    # using currency keyword
+    'amd currency' => test_spice(
+        '/js/spice/currency/1/amd/amd',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
+    '2 ruble currency in yen' => test_spice(
+        '/js/spice/currency/2/rub/jpy',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
+    '20 usd currency in mexican peso currency' => test_spice(
+        '/js/spice/currency/20/usd/mxn',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
     # using cardinals instead of zeros
     '4.5 billion us dollar to euro' => test_spice(
         '/js/spice/currency/4500000000/usd/eur',


### PR DESCRIPTION
<!-- Use the appropriate format for your Pull Request title above ^^^^^:

If this is a bug fix:
{IA Name}: {Description of change}

If this is a New Instant Answer:
New {IA Name} Spice

If this is something else:
{Tests/Docs/Other}: {Short Description}

-->


## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
"currency" keyword will now trigger currency IA with or without an amount.  For ex: "usd currency", "1 usd currency", "20 usd currency in mexican peso currency", etc.  

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->
Fixes #3214 

## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@pjhampton 
<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/currency
<!-- FILL THIS IN:                           ^^^^ -->
