### PR TITLE
Package Tracking: Tighten up triggers

### DIFF
--- a/lib/DDG/Spice/PackageTracking.pm
+++ b/lib/DDG/Spice/PackageTracking.pm
@@ -13,72 +13,99 @@ spice wrap_jsonp_callback => 1;
 spice to => 'https://api.packagetrackr.com/ddg/v1/track/simple?n=$1&api_key={{ENV{DDG_SPICE_PACKAGETRACKR_API_KEY}}}';
 
 my @carriers = sort { length $b <=> length $a } @{LoadFile(share('carriers.yml'))};
-my $triggers_re = qr/package|parcel|track(ing)?|num(ber)?|shipping status|\#/ix;
+my $triggers_re = qr/(package|parcel)|track(ing)?( num(ber)?)?|shipping status/i;
 my $carriers_re = join "|", @carriers;
-my $strip_re = qr/$carriers_re|$triggers_re/ix;
+# allow carrier names without spaces (e.g royal mail OR royalmail)
+$carriers_re =~ s/ /\\s*/g;
+my $strip_re = qr/\b(?:$carriers_re|$triggers_re)\b/i;
 
+### Regex triggers for queries containing carrier names
+### or words related to pacakge tracking
 
-### Regex triggers for queries containing carrier names or words related to pacakge tracking
 # Carrier names
-triggers query_nowhitespace_nodash => qr/$carriers_re/ix;
+triggers query_lc => qr/\b(?:$carriers_re)\b/i;
 
 # Package words
-triggers query_nowhitespace_nodash => qr/$triggers_re/i;
+triggers query_lc => qr/^$triggers_re .+|.+ $triggers_re$/i;
 
 ### Regex triggers for queries only containing a tracking number
 
-# UPS
+## UPS
 # Soure: https://www.ups.com/content/ca/en/tracking/help/tracking/tnh.html
 # To Do: Some additional formats exist
-triggers query_nowhitespace_nodash => qr/
-                                        ^1Z[0-9A-Z]{16}$|
-                                        ^\d{9,12}$|
-                                        ^T\d{10}$
-                                        /xi;
+triggers query_nowhitespace => qr/^
+                                (?:
+                                    1Z[0-9A-Z]{16} |
+                                    \d{9,12} |
+                                    T\d{10}
+                                )
+                                $/xi;
 
-# Fedex
+## Fedex
 # Source: https://www.trackingex.com/fedex-tracking.html
 #         https://www.trackingex.com/fedexuk-tracking.html
 #         https://www.trackingex.com/fedex-poland-domestic-tracking.html
-triggers query_nowhitespace_nodash => qr/
-                                        ^\d{12,22}$
-                                        /xi;
+triggers query_nowhitespace => qr/^
+                                \d{12,22}
+                                $/xi;
 
-# USPS
-triggers query_nowhitespace_nodash => qr/
-                                        ^\d{9,30}$|
-                                        ^[A-Z]{2}\d{9}US$|
-                                        ^\d{20,30}$
-                                        /xi;
+## USPS
+# Source: https://tools.usps.com/go/TrackConfirmAction!input.action
+triggers query_nowhitespace => qr/^
+                                (?:
+                                    (94001|92055|94073|93033|92701|92088|92021)\d{17} |
+                                    82\d{8} |
+                                    [A-Z]\d{9}US
+                                )
+                                $/xi;
 
-# Parcelforce
+## Parcelforce
 # Source: http://www.parcelforce.com/help-and-advice/sending-worldwide/tracking-number-formats
 # Note:   May need to restrict pattern #3 if overtriggering
 #         https://github.com/duckduckgo/zeroclickinfo-goodies/issues/3900
-triggers query_nowhitespace_nodash => qr/
-                                        ^[A-Z]{2}\d{7}$|
-                                        ^[A-Z]{4}\d{10}$|
-                                        ^[A-Z]{2}\d{9}[A-Z]{2}$|
-                                        ^\d{12}$
-                                        /xi;
+triggers query_nowhitespace => qr/^
+                                (?:
+                                    [A-Z]{2}\d{7} |
+                                    [A-Z]{4}\d{10} |
+                                    [A-Z]{2}\d{9}[A-Z]{2} |
+                                    \d{12}
+                                )
+                                $/xi;
 
+handle query => sub {
 
-handle query_nowhitespace_nodash => sub {
-    # strip words
-    s/$strip_re//ixg;
+    # remove trigger words & carrier names
+    s/\b$strip_re\b//ixg;
     trim($_);
-
     return unless $_;
-
-    # ignore Microsoft knowledge base codes and Luhn Check queries
-    # e.g. KB2553549
-    return if m/^kb|luhn/i;
-
-    # ignore strings of same number (e.g. 0000 0000 0000)
-    return if m/^(\d)\1+$/;
 
     # remainder should be numeric or alphanumeric, not alpha
     return if m/^[A-Z]+$/i;
+
+    # ignore remainder with 2+ words
+    return if m/\b[A-Z]+\s+[A-Z]+\b/i;
+
+    # ignore phone numbers
+    return if m/^(\d(-|\s))?\d{3}(-|\s)\d{3}(-|\s)\d{4}$/;
+    return if m/^\d{5} \d{7}$/;
+    return if m/^\d{4} \d{3} \d{3}$/;
+
+    # ignore address lookup
+    return if m/^#\d+ [A-Z\s]+$/i;
+
+    # ignore Microsoft knowledge base codes and Luhn Check queries
+    # e.g. KB2553549
+    return if m/^(kb|luhn)\s?\d+/i;
+
+    # ignore pattern: "word number word"
+    # e.g. ups building 2 worldport
+    return if m/\b[A-Z]+ \d{1,8} [A-Z]+\b/i;
+
+    # remove spaces/dashes
+    s/(\s|-)//g;
+
+    # ignore repeated strings of single digit (e.g. 0000 0000 0000)
+    return if m/^(\d)\1+$/;
 
     # remainder should be 6-30 characters long
     return unless m/^[A-Z0-9]{6,30}$/i;

--- a/t/PackageTracking.t
+++ b/t/PackageTracking.t
@@ -21,6 +21,11 @@ ddg_spice_test(
         call_type => 'include',
         caller => 'DDG::Spice::PackageTracking'
     ),
+    'C11422907783469 tracking number' => test_spice(
+        '/js/spice/package_tracking/C11422907783469',
+        call_type => 'include',
+        caller => 'DDG::Spice::PackageTracking'
+    ),
     'ontrac C11422907783469' => test_spice(
         '/js/spice/package_tracking/C11422907783469',
         call_type => 'include',
@@ -106,6 +111,18 @@ ddg_spice_test(
     'luhn 1234554651' => undef,
     'KB2553549' => undef,
     '0000 0000 0000' => undef,
+    '213-298-3781' => undef,
+    '1-989-560-5363' => undef,
+    '0409 427 893' => undef,
+    '04961 9424600' => undef,
+    '1-800-240-1371' => undef,
+    '1 800 539-2968' => undef,
+    '1 800 539 2968' => undef,
+    '800-781-2677' => undef,
+    '800 781-2677' => undef,
+    '518 407 5448' => undef,
+    'ups building 2 worldport' => undef,
+    'ups building 2 worldport address' => undef,
 
     # Too long
     'fedex 123456789 123456789 123456789 1234' => undef,


### PR DESCRIPTION
## Description of new Instant Answer, or changes
The updated package tracking IA is over triggering on irrelevant queries like phone numbers.

Changes include:
- Use `query_nowhitespace` instead of `query_nowhitespace_nodash`
    - After some internal analysis I couldn't find any legitimate tracking numbers for UPS, USPS or Fedex that use dashes, so the triggers for those should ignore queries containing dashes as they are more likely to be a phone number or possibly a product code
- Additional logic to ignore queries that are obviously a phone number
- Tighter USPS regex (based on USPS tracking number format docs)
- Tightened up and restricted the queries that trigger on generic terms to only trigger on queries that start or end with one of the terms

## People to notify
@bsstoner 


<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/package_tracking
