### PR TITLE
Currency: Add rouble spelling to Russian ruble

### DIFF
--- a/share/spice/currency/currencyNames.txt
+++ b/share/spice/currency/currencyNames.txt
@@ -117,7 +117,7 @@ pyg,paraguayan guarani,paraguay guarani,
 qar,qatari riyal,qatar riyal,
 ron,romanian new leu,romania new leu,
 rsd,serbian dinar,serbia dinar,
-rub,russia ruble,russian ruble,ruble
+rub,russia ruble,russia rouble,russian ruble,russian rouble,ruble,rouble,
 rwf,rwandan franc,rwanda franc,
 sar,saudi arabian riyal,saudi arabia riyal,
 sbd,solomon islander dollar,solomon islands dollar,

--- a/t/Currency.t
+++ b/t/Currency.t
@@ -128,6 +128,18 @@ ddg_spice_test(
         caller => 'DDG::Spice::Currency',
         is_cached => 0
     ),
+    '500 roubles in dollars' => test_spice(
+        '/js/spice/currency/500/rub/usd',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
+    '200 euros in rouble' => test_spice(
+        '/js/spice/currency/200/eur/rub',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
     # Queries that have "convert" in them.
     'convert 200 cad into usd' => test_spice(
         '/js/spice/currency/200/cad/usd',
@@ -395,7 +407,7 @@ ddg_spice_test(
     'm aud' => undef,
     'b aud' => undef,
     't aud' => undef,
-    
+
     # standalone symbols
     'Irl' => undef,
     'usd' => undef,


### PR DESCRIPTION
## Description of new Instant Answer, or changes
This adds the alternative "rouble" spelling to the Russian Ruble entry in `currencyNames.txt`.


<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/currency
