### PR TITLE
New Minecraft UUID Converter Spice

### DIFF
--- a/lib/DDG/Spice/MinecraftUUID.pm
+++ b/lib/DDG/Spice/MinecraftUUID.pm
@@ -2,23 +2,21 @@ package DDG::Spice::MinecraftUUID;
 
 # ABSTRACT: Converts the name of a Minecraft account into a unique id
 
-# Start at http://docs.duckduckhack.com/walkthroughs/forum-lookup.html if you are new
-# to instant answer development
-
 use DDG::Spice;
 use strict;
 use warnings;
 
-# Caching - http://docs.duckduckhack.com/backend-reference/api-reference.html#caching
+# Caching - We cache the response, because the account name can only be changed every 30 days
 spice is_cached => 1;
 spice proxy_cache_valid => '200 204 1d';
 
+# The Mojang API does not provide a JSONP support, that's why we activate this
 spice wrap_jsonp_callback => 1;
 
-# API endpoint - http://docs.duckduckhack.com/walkthroughs/forum-lookup.html#api-endpoint
+# More information about the API: http://wiki.vg/Mojang_API#Username_-.3E_UUID_at_time
 spice to => 'https://api.mojang.com/users/profiles/minecraft/$1';
 
-# Triggers - https://duck.co/duckduckhack/spice_triggers
+# Triggers
 triggers any => 'minecraft uuid', 'mcuuid';
 
 # Handle statement

--- a/lib/DDG/Spice/MinecraftUUID.pm
+++ b/lib/DDG/Spice/MinecraftUUID.pm
@@ -32,6 +32,9 @@ handle remainder => sub {
     # We return here, because a name must consist of 3-16 characters
     return if length($_) < 3 || length($_) > 16;
     
+    # We return here, because no special characters are allowed except the underscore
+    return if $_ =~ /[^A-Za-z0-9_]/g;
+    
     return $_;
 };
 

--- a/lib/DDG/Spice/MinecraftUUID.pm
+++ b/lib/DDG/Spice/MinecraftUUID.pm
@@ -1,0 +1,38 @@
+package DDG::Spice::MinecraftUUID;
+
+# ABSTRACT: Converts the name of a Minecraft account into a unique id
+
+# Start at http://docs.duckduckhack.com/walkthroughs/forum-lookup.html if you are new
+# to instant answer development
+
+use DDG::Spice;
+use strict;
+use warnings;
+
+# Caching - http://docs.duckduckhack.com/backend-reference/api-reference.html#caching
+spice is_cached => 1;
+spice proxy_cache_valid => '200 204 1d';
+
+spice wrap_jsonp_callback => 1;
+
+# API endpoint - http://docs.duckduckhack.com/walkthroughs/forum-lookup.html#api-endpoint
+spice to => 'https://api.mojang.com/users/profiles/minecraft/$1';
+
+# Triggers - https://duck.co/duckduckhack/spice_triggers
+triggers any => 'minecraft uuid', 'mcuuid';
+
+# Handle statement
+handle remainder => sub {
+    
+    return if !$_;
+    
+    # We return here, because a name may not contain a whitespace
+    return if index($_, ' ') >= 0;
+    
+    # We return here, because a name must consist of 3-16 characters
+    return if length($_) < 3 || length($_) > 16;
+    
+    return $_;
+};
+
+1;

--- a/share/spice/minecraft_uuid/minecraft_uuid.css
+++ b/share/spice/minecraft_uuid/minecraft_uuid.css
@@ -1,0 +1,4 @@
+.zci--minecraft_uuid {
+
+}
+

--- a/share/spice/minecraft_uuid/minecraft_uuid.handlebars
+++ b/share/spice/minecraft_uuid/minecraft_uuid.handlebars
@@ -1,0 +1,6 @@
+<span>{{name}}</span>
+<a href="http://some.url/profile/data1">
+   <img src="/iu/?u=Place a image url here">
+</a>
+<h5>{{uuid}}</h5>
+<span>of the player {{name}}</span>

--- a/share/spice/minecraft_uuid/minecraft_uuid.handlebars
+++ b/share/spice/minecraft_uuid/minecraft_uuid.handlebars
@@ -1,6 +1,0 @@
-<span>{{name}}</span>
-<a href="http://some.url/profile/data1">
-   <img src="/iu/?u=Place a image url here">
-</a>
-<h5>{{uuid}}</h5>
-<span>of the player {{name}}</span>

--- a/share/spice/minecraft_uuid/minecraft_uuid.js
+++ b/share/spice/minecraft_uuid/minecraft_uuid.js
@@ -11,29 +11,25 @@
         if (!api_result || api_result.error || !api_result.id) {
             return Spice.failed('minecraft_uuid');
         }
+        
+        console.log(api_result);
 
         // Render the response
         Spice.add({
             id: 'minecraft_uuid',
-
-            // Customize these properties
             name: 'Minecraft',
-            data: api_result,
             meta: {
-                sourceName: 'NameMC',
-                sourceUrl: 'https://namemc.com/profile/' + api_result.id
+                sourceName: 'Minecraft Username Converter',
+                sourceUrl: 'https://mcuuid.net/?q=' + api_result.id
             },
-            normalize: function(item) {
-                return {
-                    // customize as needed for your chosen template
-                    uuid: addHyphens(item.id),
-                    name: item.name
-                };
+            data: {
+                uuid: addHyphens(api_result.id),
+                name: api_result.name
             },
             templates: {
                 group: 'text',
                 options: {
-                    content: Spice.minecraft_uuid.content,
+                    title_content: Spice.minecraft_uuid.title_content,
                     moreAt: true
                 }
             }

--- a/share/spice/minecraft_uuid/minecraft_uuid.js
+++ b/share/spice/minecraft_uuid/minecraft_uuid.js
@@ -1,0 +1,42 @@
+(function (env) {
+    "use strict";
+    
+    var addHyphens = function (str) {
+        return str.substr(0, 8) + '-' + str.substr(8, 4) + '-' + str.substr(12, 4) + '-' + str.substr(16, 4) + '-' + str.substr(20, 12);
+    }
+
+    env.ddg_spice_minecraft_uuid = function(api_result) {
+
+        // Validate the response (customize for your Spice)
+        if (!api_result || api_result.error || !api_result.id) {
+            return Spice.failed('minecraft_uuid');
+        }
+
+        // Render the response
+        Spice.add({
+            id: 'minecraft_uuid',
+
+            // Customize these properties
+            name: 'Minecraft',
+            data: api_result,
+            meta: {
+                sourceName: 'NameMC',
+                sourceUrl: 'https://namemc.com/profile/' + api_result.id
+            },
+            normalize: function(item) {
+                return {
+                    // customize as needed for your chosen template
+                    uuid: addHyphens(item.id),
+                    name: item.name
+                };
+            },
+            templates: {
+                group: 'text',
+                options: {
+                    content: Spice.minecraft_uuid.content,
+                    moreAt: true
+                }
+            }
+        });
+    };
+}(this));

--- a/share/spice/minecraft_uuid/minecraft_uuid.js
+++ b/share/spice/minecraft_uuid/minecraft_uuid.js
@@ -1,6 +1,7 @@
 (function (env) {
     "use strict";
     
+    // The functions adds hyphens to the string provided by Mojang to fulfil the requirements for a UUID
     var addHyphens = function (str) {
         return str.substr(0, 8) + '-' + str.substr(8, 4) + '-' + str.substr(12, 4) + '-' + str.substr(16, 4) + '-' + str.substr(20, 12);
     }
@@ -11,13 +12,12 @@
         if (!api_result || api_result.error || !api_result.id) {
             return Spice.failed('minecraft_uuid');
         }
-        
-        console.log(api_result);
 
         // Render the response
         Spice.add({
             id: 'minecraft_uuid',
             name: 'Minecraft',
+            // This refers to mcuuid.net, but it can be any other page, because we get the data directly from Mojang
             meta: {
                 sourceName: 'Minecraft Username Converter',
                 sourceUrl: 'https://mcuuid.net/?q=' + api_result.id

--- a/share/spice/minecraft_uuid/title_content.handlebars
+++ b/share/spice/minecraft_uuid/title_content.handlebars
@@ -1,0 +1,2 @@
+<h3 class="c-base__title text--primary">{{uuid}}</h3>
+<h4 class="c-base__sub">is the UUID of player {{name}}</h4>

--- a/t/MinecraftUUID.t
+++ b/t/MinecraftUUID.t
@@ -9,9 +9,6 @@ spice is_cached => 1;
 
 ddg_spice_test(
     [qw( DDG::Spice::MinecraftUUID)],
-    # At a minimum, be sure to include tests for all:
-    # - primary_example_queries
-    # - secondary_example_queries
     'mcuuid Notch' => test_spice(
         '/js/spice/minecraft_uuid/Notch',
         call_type => 'include',
@@ -34,6 +31,8 @@ ddg_spice_test(
     'mcuuid No' => undef,
     'mcuuid NotchNotchNotchNotch' => undef,
     'mcuuid Notch_ pls' => undef,
+    'mcuuid ###??##' => undef,
+    'mcuuid N?tc&' => undef,
     'mcuuid' => undef,
 );
 

--- a/t/MinecraftUUID.t
+++ b/t/MinecraftUUID.t
@@ -1,0 +1,41 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+spice is_cached => 1;
+
+ddg_spice_test(
+    [qw( DDG::Spice::MinecraftUUID)],
+    # At a minimum, be sure to include tests for all:
+    # - primary_example_queries
+    # - secondary_example_queries
+    'mcuuid Notch' => test_spice(
+        '/js/spice/minecraft_uuid/query',
+        call_type => 'include',
+        caller => 'DDG::Spice::MinecraftUUID'
+    ),
+    'minecraft uuid Notch' => test_spice(
+        '/js/spice/minecraft_uuid/query',
+        call_type => 'include',
+        caller => 'DDG::Spice::MinecraftUUID'
+    ),
+    'Minecraft UUID Notch' => test_spice(
+        '/js/spice/minecraft_uuid/query',
+        call_type => 'include',
+        caller => 'DDG::Spice::MinecraftUUID'
+    ),
+    'Minecraft UUID Jeb_' => test_spice(
+        '/js/spice/minecraft_uuid/query',
+        caller => 'DDG::Spice::MinecraftUUID'
+    ),
+    'mcuuid No' => undef,
+    'mcuuid NotchNotchNotchNotch' => undef,
+    'mcuuid Notch_ pls' => undef,
+    'mcuuid' => undef,
+);
+
+done_testing;
+

--- a/t/MinecraftUUID.t
+++ b/t/MinecraftUUID.t
@@ -13,22 +13,22 @@ ddg_spice_test(
     # - primary_example_queries
     # - secondary_example_queries
     'mcuuid Notch' => test_spice(
-        '/js/spice/minecraft_uuid/query',
+        '/js/spice/minecraft_uuid/Notch',
         call_type => 'include',
         caller => 'DDG::Spice::MinecraftUUID'
     ),
     'minecraft uuid Notch' => test_spice(
-        '/js/spice/minecraft_uuid/query',
+        '/js/spice/minecraft_uuid/Notch',
         call_type => 'include',
         caller => 'DDG::Spice::MinecraftUUID'
     ),
     'Minecraft UUID Notch' => test_spice(
-        '/js/spice/minecraft_uuid/query',
+        '/js/spice/minecraft_uuid/Notch',
         call_type => 'include',
         caller => 'DDG::Spice::MinecraftUUID'
     ),
     'Minecraft UUID Jeb_' => test_spice(
-        '/js/spice/minecraft_uuid/query',
+        '/js/spice/minecraft_uuid/Jeb_',
         caller => 'DDG::Spice::MinecraftUUID'
     ),
     'mcuuid No' => undef,


### PR DESCRIPTION
## Description of new Instant Answer, or changes
This type of Instant Answer allows users to simply query their unique id for their Minecraft account. It converts the account's name into a UUID which is persistent.


<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/minecraft_uuid_converter
<!-- FILL THIS IN:                           ^^^^ -->
