### PR TITLE
Maps: Allow Multiple Calls

### DIFF
--- a/share/spice/maps/maps/maps_maps.js
+++ b/share/spice/maps/maps/maps_maps.js
@@ -8,8 +8,20 @@ DDG.require('maps',function(){
         if (DDG.opensearch.installed.experiment === 'map_module' && DDG.opensearch.installed.variant === 'a') {
             // if top result returned doesn't have high relevance,
             // the rest won't either so spice should fail.
-            if (response.features[0].relevance < 0.6 && !(response.features[0].place_name && DDG.isRelevant(response.features[0].place_name.toLowerCase(), skipArray))) {
-                return Spice.failed('maps_maps');
+            if (response.features[0].relevance < 0.6) {
+                if ((response.features[0].place_name && DDG.isRelevant(response.features[0].place_name.toLowerCase(), skipArray))) {
+                    // if relevance < .6 but DDG.isRelevant returns true,
+                    // only allow first result through (since isRelevant
+                    // only looks at the first result)
+                    response.features = [response.features[0]];
+                } else {
+                    return Spice.failed('maps_maps');
+                }
+            } else {
+                // filter out results with < 0.6 relevance
+                response.features = response.features.filter(function(el) {
+                    return el.relevance > 0.6;
+                });
             }
 
             return Spice.add({

--- a/share/spice/maps/maps/maps_maps.js
+++ b/share/spice/maps/maps/maps_maps.js
@@ -11,7 +11,7 @@ DDG.require('maps',function(){
             if (response.features[0].relevance < 0.6 && !(response.features[0].place_name && DDG.isRelevant(response.features[0].place_name.toLowerCase(), skipArray))) {
                 return Spice.failed('maps_maps');
             }
-            console.log("spice.add");
+
             return Spice.add({
                 data: response.features,
                 id: 'maps_maps',

--- a/share/spice/maps/maps/maps_maps.js
+++ b/share/spice/maps/maps/maps_maps.js
@@ -11,12 +11,13 @@ DDG.require('maps',function(){
             if (response.features[0].relevance < 0.6 && !(response.features[0].place_name && DDG.isRelevant(response.features[0].place_name.toLowerCase(), skipArray))) {
                 return Spice.failed('maps_maps');
             }
-
+            console.log("spice.add");
             return Spice.add({
                 data: response.features,
                 id: 'maps_maps',
                 name: 'maps',
-                model: 'Place'
+                model: 'Place',
+                allowMultipleCalls: true
             });
         }
 

--- a/share/spice/maps/maps/maps_maps.js
+++ b/share/spice/maps/maps/maps_maps.js
@@ -8,20 +8,8 @@ DDG.require('maps',function(){
         if (DDG.opensearch.installed.experiment === 'map_module' && DDG.opensearch.installed.variant === 'a') {
             // if top result returned doesn't have high relevance,
             // the rest won't either so spice should fail.
-            if (response.features[0].relevance < 0.6) {
-                if ((response.features[0].place_name && DDG.isRelevant(response.features[0].place_name.toLowerCase(), skipArray))) {
-                    // if relevance < .6 but DDG.isRelevant returns true,
-                    // only allow first result through (since isRelevant
-                    // only looks at the first result)
-                    response.features = [response.features[0]];
-                } else {
-                    return Spice.failed('maps_maps');
-                }
-            } else {
-                // filter out results with < 0.6 relevance
-                response.features = response.features.filter(function(el) {
-                    return el.relevance > 0.6;
-                });
+            if (response.features[0].relevance < 0.6 && !(response.features[0].place_name && DDG.isRelevant(response.features[0].place_name.toLowerCase(), skipArray))) {
+                return Spice.failed('maps_maps');
             }
 
             return Spice.add({


### PR DESCRIPTION

## Description of new Instant Answer, or changes
This change allows multiple calls to come through from the upstream provider. We are using this internally to pick out the best response if there are multiple.


## Related Issues and Discussions
This is a part of these:
https://dub.duckduckgo.com/core/ddg/pull/9117
https://app.asana.com/0/11984721910118/309824711142306

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/maps_maps
<!-- FILL THIS IN:                           ^^^^ -->
