### PR TITLE
Maps: moving all location relevance checks external to keep them together.

### DIFF
--- a/share/spice/maps/maps/maps_maps.js
+++ b/share/spice/maps/maps/maps_maps.js
@@ -8,8 +8,20 @@ DDG.require('maps',function(){
         if (DDG.opensearch.installed.experiment === 'map_module' && DDG.opensearch.installed.variant === 'a') {
             // if top result returned doesn't have high relevance,
             // the rest won't either so spice should fail.
-            if (response.features[0].relevance < 0.6 && !(response.features[0].place_name && DDG.isRelevant(response.features[0].place_name.toLowerCase(), skipArray))) {
-                return Spice.failed('maps_maps');
+            if (response.features[0].relevance < 0.6) {
+                if ((response.features[0].place_name && DDG.isRelevant(response.features[0].place_name.toLowerCase(), skipArray))) {
+                    // if relevance < .6 but DDG.isRelevant returns true,
+                    // only allow first result through (since isRelevant
+                    // only looks at the first result)
+                    response.features = [response.features[0]];
+                } else {
+                    return Spice.failed('maps_maps');
+                }
+            } else {
+                // filter out results with < 0.6 relevance
+                response.features = response.features.filter(function(el) {
+                    return el.relevance > 0.6;
+                });
             }
 
             return Spice.add({


### PR DESCRIPTION
<!-- Use the appropriate format for your Pull Request title above ^^^^^:

If this is a bug fix:
{IA Name}: {Description of change}

If this is a New Instant Answer:
New {IA Name} Spice

If this is something else:
{Tests/Docs/Other}: {Short Description}

-->


## Description of new Instant Answer, or changes
This simply moves some location relevance checks externally. Basically, don't let anything with relevance < .6 through, unless DDG.isRelevant returns true. In that case, let the first item through.


## Related Issues and Discussions
https://app.asana.com/0/11984721910118/313553685693413


## People to notify
<!-- Please @mention any relevant people/organizations here: -->

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/maps_maps
<!-- FILL THIS IN:                           ^^^^ -->
