### PR TITLE
Maps: use internal function canShowIAModules() 

### DIFF
--- a/share/spice/maps/maps/maps_maps.js
+++ b/share/spice/maps/maps/maps_maps.js
@@ -5,7 +5,7 @@ DDG.require('maps',function(){
         if (!response || !response.features || !response.features.length) { return Spice.failed('maps_maps'); }
 
         // if user is in map module experiment, and signal is high
-        if (DDG.opensearch.installed.experiment === 'map_module' && DDG.opensearch.installed.variant === 'a') {
+        if (DDG.duckbar.canShowIAModules()) {
             // if top result returned doesn't have high relevance,
             // the rest won't either so spice should fail.
             if (response.features[0].relevance < 0.6) {


### PR DESCRIPTION



## Description of new Instant Answer, or changes
Use internal function so we can roll out the map module to a limited number of users.


## Related Issues and Discussions
https://app.asana.com/0/246491496396031/318152814646111


## People to notify
@bsstoner 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/maps_maps
<!-- FILL THIS IN:                           ^^^^ -->
