### PR TITLE
NPM: Added back text view, drops back to tile view

### DIFF
--- a/lib/DDG/Spice/Npm.pm
+++ b/lib/DDG/Spice/Npm.pm
@@ -8,7 +8,7 @@ use warnings;
 spice is_cached => 1;
 spice proxy_cache_valid => '200 1d';
 
-triggers startend => 'npm', 'npm node', 'node npm', 'nodejs', 'node js', 'node package';
+triggers startend => 'npm', 'npm node', 'node npm', 'node package';
 triggers start => 'npm install', 'node install';
 
 spice to => 'https://api.npms.io/v2/search?q=$1';

--- a/share/spice/npm/content.handlebars
+++ b/share/spice/npm/content.handlebars
@@ -1,0 +1,1 @@
+<pre>$ npm install {{title}}</pre>

--- a/t/Npm.t
+++ b/t/Npm.t
@@ -12,11 +12,6 @@ ddg_spice_test(
         call_type => 'include',
         caller => 'DDG::Spice::Npm',
     ),
-    'nodejs underscore' => test_spice(
-        '/js/spice/npm/underscore',
-        call_type => 'include',
-        caller => 'DDG::Spice::Npm',
-    ),
     'npm install underscore' => test_spice(
         '/js/spice/npm/underscore',
         call_type => 'include',
@@ -28,16 +23,6 @@ ddg_spice_test(
         caller => 'DDG::Spice::Npm',
     ),
     'underscore node package' => test_spice(
-        '/js/spice/npm/underscore',
-        call_type => 'include',
-        caller => 'DDG::Spice::Npm',
-    ),
-    'underscore node js' => test_spice(
-        '/js/spice/npm/underscore',
-        call_type => 'include',
-        caller => 'DDG::Spice::Npm',
-    ),
-    'node js underscore' => test_spice(
         '/js/spice/npm/underscore',
         call_type => 'include',
         caller => 'DDG::Spice::Npm',


### PR DESCRIPTION
## Description of new Instant Answer, or changes

Currently this IA is falling back big time! This was the result of an experiment in the programming mission. This PR tries to address this by keeping the tile view, but if the first result if an exact match, then it shows the old content view. See screenshots below:

**Old Content View (Restored)**
![screen shot 2017-04-21 at 8 40 49 pm](https://cloud.githubusercontent.com/assets/8960296/25293556/530d5328-26d3-11e7-8836-5c35b66593e1.png)

**Tile view (still there)** 😉 
![screen shot 2017-04-21 at 8 40 57 pm](https://cloud.githubusercontent.com/assets/8960296/25293555/530a8134-26d3-11e7-9371-f21a9eef8c3f.png)

## Future Changes

Allow user to swap to tile view from text view. For example, `npm buttons` gives a very narrow answer.

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->
https://app.asana.com/0/186344451334986/320438475277974


## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@moollaza 
cc @bsstoner 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/npm
<!-- FILL THIS IN:                           ^^^^ -->
