### PR TITLE
Maps: revert relevance filtering back to 0.9

### DIFF
--- a/share/spice/maps/maps/maps_maps.js
+++ b/share/spice/maps/maps/maps_maps.js
@@ -8,21 +8,13 @@ DDG.require('maps',function(){
         if (DDG.duckbar.canShowIAModules()) {
             // if top result returned doesn't have high relevance,
             // the rest won't either so spice should fail.
-            if (response.features[0].relevance < 0.6) {
-                if ((response.features[0].place_name && DDG.isRelevant(response.features[0].place_name.toLowerCase(), skipArray))) {
-                    // if relevance < .6 but DDG.isRelevant returns true,
-                    // only allow first result through (since isRelevant
-                    // only looks at the first result)
-                    response.features = [response.features[0]];
-                } else {
-                    return Spice.failed('maps_maps');
-                }
-            } else {
-                // filter out results with < 0.6 relevance
-                response.features = response.features.filter(function(el) {
-                    return el.relevance > 0.6;
-                });
+            if (response.features[0].relevance < 0.9 && !( response.features[0].place_name && DDG.isRelevant(response.features[0].place_name.toLowerCase(), skipArray))) {
+                return Spice.failed('maps_maps');
             }
+            // filter out disambiguations with < 0.6 relevance
+            response.features = response.features.filter(function(el) {
+                return el.relevance > 0.6;
+            });
 
             return Spice.add({
                 data: response.features,


### PR DESCRIPTION
## Related Issues and Discussions
This is an internal change to revert back to filtering on 0.9 relevancy.
https://app.asana.com/0/72649045549333/326981472128973

## People to notify
@bsstoner 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/maps_maps
<!-- FILL THIS IN:                           ^^^^ -->
