### PR TITLE
ISBN: Ignore phone numbers, update tests accordingly

### DIFF
--- a/lib/DDG/Spice/ISBN.pm
+++ b/lib/DDG/Spice/ISBN.pm
@@ -12,11 +12,15 @@ spice to            =>      'https://duckduckgo.com/m.js?q=$1&cb={{callback}}';
 spice is_cached     =>      1;
 
 # Look for at least 9 digits, spaces and dashes in a row, possibly ending with an X.
-triggers query_raw => qr/[0-9\s-]{9,}[Xx]?/;
+triggers query_lc => qr/[0-9\s-]{9,}x?/;
 
 my %skip_words = map { uc $_ => 1 } qw( isbn number lookup );    # Appreciate if they tried to give us more context.
 
-handle query_raw => sub {
+handle query_lc => sub {
+
+    #ignore phone numbers
+    return if m/^\d{3}(-|\s)\d{3}(-|\s)\d{4}$/;
+
     my $query_cleaned = join '', (grep { !$skip_words{$_} } map { uc $_ } grep { defined } split /[\s-]/);
 
     return unless (looks_like_isbn($query_cleaned));

--- a/t/ISBN.t
+++ b/t/ISBN.t
@@ -101,6 +101,12 @@ ddg_spice_test(
     'isbn lookup 42' => undef,
     # not triggered (because remainder after cleanup is not purely a number)
     'isbn lookup Germany 7-1 Brazil' => undef,
+
+    # phone numbers
+    '951-383-4565' => undef,
+    '302-212-1326' => undef,
+    '210 294 2260' => undef,
+    '971 208 9355' => undef,
 );
 
 done_testing;


### PR DESCRIPTION
## Description of new Instant Answer, or changes
- Updated logic to ignore queries that match a phone number lookup
- Added appropriate tests

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/isbn
<!-- FILL THIS IN:                           ^^^^ -->
