### PR TITLE
PackageTracking: Correct date handling, improve title and subtitles

### DIFF
--- a/share/spice/package_tracking/package_tracking.js
+++ b/share/spice/package_tracking/package_tracking.js
@@ -7,15 +7,11 @@
         }
 
         var logo = api_result.c;
-
-        switch (logo) {
-            case 'ups-packages':
-                logo = 'ups';
-                break;
-
-            case 'fedex-express':
-                logo = 'fedex';
-                break;
+        if (/^ups-.+/.test(logo)) {
+            logo = 'ups';
+        }
+        else if (/^fedex-.+/.test(logo)) {
+            logo = 'fedex';
         }
 
         var details_url = "https://www.packagetrackr.com/track/" + [api_result.c, api_result.n].join("/"),

--- a/share/spice/package_tracking/package_tracking.js
+++ b/share/spice/package_tracking/package_tracking.js
@@ -36,12 +36,12 @@
                 data: api_result,
                 normalize: function (data) {
 
+                    var status = statusCodes[data.status_code];
+
                     var obj = {
-                        url: carrierUrl || details_url,
-                        title: data.status_description.replace(/\.$/, ""),
-                        subtitle: [
-                            "Updated: " + moment(data.progress_at).fromNow(),
-                        ],
+                        url: details_url,
+                        title: status,
+                        subtitle: data.status_description === status ? false : data.status_description,
                         image: DDG.get_asset_path('package_tracking', logo + '.png'),
                         record_data: {
                             "Tracking number": data.n,
@@ -51,8 +51,15 @@
 
                     $.each(dates, function(property, text){
                         var value = data[property];
-                        if (value){
-                            obj.record_data[text] = moment(value).format('lll');
+                        var dateFormat = 'ddd, MMM D, YYYY';
+
+                        if (value) {
+                            if (text === "Delivered") {
+                                text = "Delivered on";
+                                dateFormat = 'ddd, MMM D, YYYY, h:mm A';
+                            }
+
+                            obj.record_data[text] = moment(value).utc().format(dateFormat);
                         }
                     });
 
@@ -81,6 +88,29 @@
         shipped_at: "Shipped on",
         est_delivery_at: "Scheduled delivery",
         act_delivery_at: "Delivered"
+    };
+
+    var statusCodes = {
+        NA: "N/A",
+        PD: "Pending",
+        IR: "Information Received",
+        AP: "At Pickup",
+        AF: "Arrived at Facility",
+        AC: "At Customs Clearance",
+        TP: "Tendered to Partner",
+        IT: "In Transit",
+        DS: "Delivery Scheduled",
+        OD: "Out for Delivery",
+        DA: "Delivery Attempt",
+        WP: "Will Pickup",
+        RS: "Return to Shipper",
+        DL: "Delivered",
+        DE: "Delivery Exception",
+        SU: "Stop Updating",
+        EX: "Expired",
+        IU: "Information Updated",
+        VD: "Voided",
+        TF: "Track Failed",
     };
 
     var carriers = {

--- a/share/spice/package_tracking/package_tracking.js
+++ b/share/spice/package_tracking/package_tracking.js
@@ -56,7 +56,7 @@
                         if (value) {
                             if (text === "Delivered") {
                                 text = "Delivered on";
-                                dateFormat = 'ddd, MMM D, YYYY, h:mm A';
+                                dateFormat += ', h:mm A';
                             }
 
                             obj.record_data[text] = moment(value).utc().format(dateFormat);


### PR DESCRIPTION
## Description of new Instant Answer, or changes
- Handles dates as UTC to ensure correct display (we were adjusting for user locale and misrepresenting the dates)
- Title is now the current status instead of the status description
- Subtitle is now the status description, provided from carrier unless it matches the title (e.g. "Delivered"
- Fixed handling of images for UPS and Fedex


<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/package_tracking
<!-- FILL THIS IN:                           ^^^^ -->
