### PR TITLE
PackageTracking: Stops triggering PackageTracking IA if isbn is present in query.

### DIFF
--- a/lib/DDG/Spice/PackageTracking.pm
+++ b/lib/DDG/Spice/PackageTracking.pm
@@ -111,6 +111,9 @@ handle query => sub {
 
     # remainder should be 6-30 characters long
     return unless m/^[A-Z0-9]{6,30}$/i;
+    
+    # ignore if isbn is present
+    return if m/isbn/i;
 
     return $_;
 };

--- a/t/PackageTracking.t
+++ b/t/PackageTracking.t
@@ -138,13 +138,13 @@ ddg_spice_test(
     'package tracking online' => undef,
 
     'fedex' => undef,
-    'fedex website' => undef
+    'fedex website' => undef,
     
     # Invalid query containing isbn
-    'isbn 9780134494326' => undef
-    '9780073380957 Isbn' => undef
-    'ISBN 1490564098'  => undef
-    '0394800133 isbn' => undef
+    'isbn 9780134494326' => undef,
+    'Isbn9780073380957' => undef,
+    '1490564098 ISBN' => undef,
+    'isbn 0394800133' => undef
 );
 
 done_testing;

--- a/t/PackageTracking.t
+++ b/t/PackageTracking.t
@@ -139,6 +139,12 @@ ddg_spice_test(
 
     'fedex' => undef,
     'fedex website' => undef
+    
+    # Invalid query containing isbn
+    'isbn 9780134494326' => undef
+    '9780073380957 Isbn' => undef
+    'ISBN 1490564098'  => undef
+    '0394800133 isbn' => undef
 );
 
 done_testing;


### PR DESCRIPTION
<!-- Use the appropriate format for your Pull Request title above ^^^^^:

If this is a bug fix:
{IA Name}: {Description of change}

If this is a New Instant Answer:
New {IA Name} Spice

If this is something else:
{Tests/Docs/Other}: {Short Description}

-->


## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
Adds a check for queries containing 'isbn' so that Package Tracking Spice doesn't make an API call.

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->
Fixes #3269 

## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@moollaza 
<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/package_tracking
<!-- FILL THIS IN:                           ^^^^ -->
