### PR TITLE
Maps: add 'latitude' and 'longitude' to skip word array

### DIFF
--- a/share/spice/maps/maps/maps_maps.js
+++ b/share/spice/maps/maps/maps_maps.js
@@ -1,6 +1,6 @@
 DDG.require('maps',function(){
     ddg_spice_maps_maps = function(response) {
-        var skipArray = [ "directions", "map", "maps", "st", "street", "ave", "avenue", "dr", "drive", "pl", "place", "apt", "suite" ];
+        var skipArray = [ "directions", "map", "maps", "st", "street", "ave", "avenue", "dr", "drive", "pl", "place", "apt", "suite", "latitude", "longitude" ];
 
         if (!response || !response.features || !response.features.length) { return Spice.failed('maps_maps'); }
 


### PR DESCRIPTION

## Description of new Instant Answer, or changes
Internal: https://app.asana.com/0/0/324431312180291

## People to notify
<!-- Please @mention any relevant people/organizations here: -->

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/maps_maps
<!-- FILL THIS IN:                           ^^^^ -->
