### PR TITLE
PackageTracking: Added remaining regexes

### DIFF
--- a/lib/DDG/Spice/PackageTracking.pm
+++ b/lib/DDG/Spice/PackageTracking.pm
@@ -78,15 +78,16 @@ triggers query_nowhitespace => qr/^
 triggers query_nowhitespace_nodash => qr/^
                                 (?:
                                     [\d]{9,} |
-                                    [A-Z]{2}\d{9}CA)
+                                    [A-Z]{2}\d{9}CA
                                 )
                                 $/xi;
 
 ## DHL
 triggers query_nowhitespace_nodash => qr/^
                                 (?:
-                                    \d{9,} |
                                     \d{10} |
+                                    \[a-zA-Z]{5}d{10} |
+                                    \[a-zA-Z]{3}d{20}
                                 )
                                 $/xi;
 

--- a/lib/DDG/Spice/PackageTracking.pm
+++ b/lib/DDG/Spice/PackageTracking.pm
@@ -75,9 +75,11 @@ triggers query_nowhitespace => qr/^
                                 $/xi;
 
 ## CanadaPost
+# Source: https://www.canadapost.ca/web/en/kb/details.page?article=learn_about_tracking&cattype=kb&cat=receiving&subcat=tracking
 triggers query_nowhitespace_nodash => qr/^
                                 (?:
-                                    [\d]{9,} |
+                                    [\d]{12} |
+                                    [\d]{16} |
                                     [A-Z]{2}\d{9}CA
                                 )
                                 $/xi;

--- a/lib/DDG/Spice/PackageTracking.pm
+++ b/lib/DDG/Spice/PackageTracking.pm
@@ -74,6 +74,43 @@ triggers query_nowhitespace => qr/^
                                 )
                                 $/xi;
 
+## CanadaPost
+triggers query_nowhitespace_nodash => qr/^
+                                (?:
+                                    [\d]{9,} |
+                                    [A-Z]{2}\d{9}CA)
+                                )
+                                $/xi;
+
+## DHL
+triggers query_nowhitespace_nodash => qr/^
+                                (?:
+                                    \d{9,} |
+                                    \d{10} |
+                                )
+                                $/xi;
+
+##HKDK
+triggers query_nowhitespace_nodash => qr/^
+                                (?:
+                                    [a-z]{2}\d{9}(?:hk|dk)
+                                )
+                                $/xi;
+
+## IPS
+triggers query_nowhitespace_nodash => qr/^
+                                (?:
+                                    E[MA]\d{9}(?:IN|HR)
+                                )
+                                $/xi;
+
+## LaserShip
+triggers query_nowhitespace_nodash => qr/^
+                                (?:
+                                    l[a-z]\d{8}
+                                )
+                                $/xi;
+
 handle query => sub {
 
     # remove trigger words & carrier names

--- a/t/PackageTracking.t
+++ b/t/PackageTracking.t
@@ -121,7 +121,6 @@ ddg_spice_test(
     '800-781-2677' => undef,
     '800 781-2677' => undef,
     '518 407 5448' => undef,
-    '1234567890' => undef,
     'ups building 2 worldport' => undef,
     'ups building 2 worldport address' => undef,
 

--- a/t/PackageTracking.t
+++ b/t/PackageTracking.t
@@ -104,6 +104,75 @@ ddg_spice_test(
         call_type => 'include',
         caller => 'DDG::Spice::PackageTracking'
     ),
+    
+    # CanadaPost
+    '7316971234436767' => test_spice(
+        "/js/spice/package_tracking/7316971234436767",
+        call_type => 'include',
+        caller => 'DDG::Spice::PackageTracking'
+    ),
+    '2005706113805288' => test_spice(
+        "/js/spice/package_tracking/2005706113805288",
+        call_type => 'include',
+        caller => 'DDG::Spice::PackageTracking'
+    ),
+    '4007693052785226' => test_spice(
+        "/js/spice/package_tracking/4007693052785226",
+        call_type => 'include',
+        caller => 'DDG::Spice::PackageTracking'
+    ),
+    '3129144101026356' => test_spice(
+        "/js/spice/package_tracking/3129144101026356",
+        call_type => 'include',
+        caller => 'DDG::Spice::PackageTracking'
+    ),
+
+    # HKDK
+    'CU123456789DK' => test_spice(
+        "/js/spice/package_tracking/CU123456789DK",
+        call_type => 'include',
+        caller => 'DDG::Spice::PackageTracking'
+    ),
+    'EE123456789HK' => test_spice(
+        "/js/spice/package_tracking/EE123456789HK",
+        call_type => 'include',
+        caller => 'DDG::Spice::PackageTracking'
+    ),
+
+    # IPS
+    'EM999999999IN' => test_spice(
+        "/js/spice/package_tracking/EM999999999IN",
+        call_type => 'include',
+        caller => 'DDG::Spice::PackageTracking'
+
+    ),
+    'em123456789hr' => test_spice(
+        "/js/spice/package_tracking/em123456789hr",
+        call_type => 'include',
+        caller => 'DDG::Spice::PackageTracking'
+
+    ),
+    'EM 999 999 999 IN' => test_spice(
+        "/js/spice/package_tracking/EM999999999IN",
+        call_type => 'include',
+        caller => 'DDG::Spice::PackageTracking'
+
+    ),
+
+    # LaserShip
+    'LL12345678' => test_spice(
+        "/js/spice/package_tracking/LL12345678",
+        call_type => 'include',
+        caller => 'DDG::Spice::PackageTracking'
+
+    ),
+    'LL 12345678' => test_spice(
+        "/js/spice/package_tracking/LL12345678",
+        call_type => 'include',
+        caller => 'DDG::Spice::PackageTracking'
+
+    ),
+
 
     # Bad Queries
     70000000000000000001 => undef,
@@ -123,6 +192,7 @@ ddg_spice_test(
     '518 407 5448' => undef,
     'ups building 2 worldport' => undef,
     'ups building 2 worldport address' => undef,
+    '1LS12345678999999999' => undef,
 
     # Too long
     'fedex 123456789 123456789 123456789 1234' => undef,


### PR DESCRIPTION
## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
Adds the regexes from the remaining tracking goodies to the package tracking spice.

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->

Fixes https://github.com/duckduckgo/zeroclickinfo-goodies/issues/3973

## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@moollaza 
<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/package_tracking
<!-- FILL THIS IN:                           ^^^^ -->