### PR TITLE
Maps: add zip code skip words, allow low relevance results through when DDG.isRelevant is true.

### DIFF
--- a/share/spice/maps/maps/maps_maps.js
+++ b/share/spice/maps/maps/maps_maps.js
@@ -1,6 +1,7 @@
 DDG.require('maps',function(){
     ddg_spice_maps_maps = function(response) {
-        var skipArray = [ "directions", "map", "maps", "st", "street", "ave", "avenue", "dr", "drive", "pl", "place", "apt", "suite", "latitude", "longitude" ];
+        var skipArray = [ "directions", "map", "maps", "st", "street", "ave", "avenue", "dr", "drive", "pl", "place", "apt", "suite", "latitude", "longitude", "zip", "code", "postal" ],
+            primaryLocation;
 
         if (!response || !response.features || !response.features.length) { return Spice.failed('maps_maps'); }
 
@@ -12,9 +13,12 @@ DDG.require('maps',function(){
                 return Spice.failed('maps_maps');
             }
             // filter out disambiguations with < 0.6 relevance
+            primaryLocation = response.features.shift();
             response.features = response.features.filter(function(el) {
                 return el.relevance > 0.6;
             });
+
+            response.features.unshift(primaryLocation);
 
             return Spice.add({
                 data: response.features,


### PR DESCRIPTION
## Description of new Instant Answer, or changes
We needed to add a couple skip words to the array to improve results when users are searching by zip or postal code. I think the best way to explain is by example:

Searching '19087 zip code' gives a high level map signal. However, the top result from mapbox has place_name: "19087, Pennsylvania, United States" and relevance: 0.49, which is below our filtering threshold. This is where the DDG.isRelevant method comes into play: it compares the query (minus a selection of skip words) to the place name of the top result for similarity. By adding these skip words to that array, DDG.isRelevant will return true, which overrides the relevance # we get from mapbox.

We then need to make sure that the top result isn't filtered out due to its relevance being < 0.6, but that disambiguation items with low relevance are properly filtered out.


## Related Issues and Discussions
https://app.asana.com/0/0/334903345804983


## People to notify
@moollaza 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/maps_maps
<!-- FILL THIS IN:                           ^^^^ -->
