### PR TITLE
Currency: Remove forced 100% width on select to allow custom dropdown arrow

### DIFF
--- a/share/spice/currency/currency.css
+++ b/share/spice/currency/currency.css
@@ -25,10 +25,6 @@
     width: 100%;
 }
 
-.zci--currency .frm--top .frm__select--bottom {
-    width: 100% !important;
-}
-
 .zci--currency .frm--top {
     margin-bottom: 1em;
 }
@@ -73,7 +69,6 @@
 }
 
 .zci--currency .frm--bottom .frm__select select {
-    width: 100% !important;
     height: 3em !important;
     padding-right: 1.5em;
 }


### PR DESCRIPTION
## Description of new Instant Answer, or changes
Remove forced 100% width on select to allow custom dropdown arrow


## People to notify
@pjhampton 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/currency
<!-- FILL THIS IN:                           ^^^^ -->
