### PR TITLE
Prevent triggering on two fiat currencies, properly handle queries with a value of "1"

### DIFF
--- a/lib/DDG/Spice/Cryptocurrency.pm
+++ b/lib/DDG/Spice/Cryptocurrency.pm
@@ -1,7 +1,7 @@
 package DDG::Spice::Cryptocurrency;
 # ABSTRACT: Cryptocurrency converter and exchange rate lookup provided by cryptonator.com
 # Borrows from DDG::Spice:Currency
- 
+
 use DDG::Spice;
 with 'DDG::SpiceRole::NumberStyler';
 
@@ -103,15 +103,15 @@ sub checkCurrencyCode {
     my $endpoint = '';
     my $query = '';
     my $query2 = '';
-    
+
     # Check if it's a valid number.
     # If it isn't, return early.
     $amount =~ s/\s+$//;
     my $styler = number_style_for($amount);
     return unless $styler;
-    
+
     my $normalized_number = $styler->for_computation($amount);
-    
+
     # Handles queries of the form '1 <cryptocurrency>'
     # Avoids triggering on common queries like '1 gig' or '1 electron'
     # If the cryptocurrency is not in the top currencies list, the query does not include a 'to' currency,
@@ -119,27 +119,27 @@ sub checkCurrencyCode {
     if ($normalized_number == 1 && $to eq '' && !exists($topCurrencies{getCode($from)}) && index($from, 'coin') == -1) {
         return;
     }
-    
+
     # There are cases where people type in "2016 bitcoin", so we don't want to trigger on those queries.
     # The first cryptocoins appeared in 2008, so dates before that could be valid amounts.
     if($normalized_number >= 2008 && $normalized_number < 2100 && (length($from) == 0 || length($to) == 0)) {
         return;
     }
-    
+
     # Currency values are standardized
     $from = getCode($from) || '';
     $to = getCode($to) || '';
-    
+
     # Return early if we get a query like "btc to btc".
     if($from eq $to) {
         return;
     }
-    
+
     # Return early if we don't get a currency to convert from.
     if($from eq '') {
         return;
     }
-    
+
     # If both currencies are available, use the ticker endpoint
     if (length($from) && length($to)) {
         # Return early if both currencies are in the excluded list
@@ -163,7 +163,7 @@ sub checkCurrencyCode {
         if($to eq '' && exists($availableLocalCurrencies{$local_currency})) {
             # use local currency if we support it in the ui
             $to = $local_currency;
-        } 
+        }
         else {
             # default to btc
             $to = 'btc';

--- a/t/Cryptocurrency.t
+++ b/t/Cryptocurrency.t
@@ -172,12 +172,13 @@ ddg_spice_test(
     # Things that should probably work but it doesn't at the moment.
     'ppc ftc 400' => undef,
     '499 nmc = ? usd' => undef,
+    # Irellevant queries
     'convert religion' => undef,
     'what is a cow' => undef,
     'usda loans' => undef,
 
     # Handled by the Currency Spice.
-    'usd to aud' => undef,
+    'usd to cad' => undef,
     'btc' => undef,
     '500 btc in usd' => undef,
     'canada dollar' => undef,
@@ -185,6 +186,8 @@ ddg_spice_test(
     '499 us dollar to btc' => undef,
     '25 php to gbp' => undef,
     'convert 1021 gbp to cny'  => undef,
+    '1 usd' => undef,
+    '1 usd to cad' => undef,
 
     # We don't want to trigger on date-looking things.
     '2016 feathercoin' => undef,


### PR DESCRIPTION
## Description of new Instant Answer, or changes
These changes should ensure the IA only triggers on queries that involve at least 1 cryptocurrency. Currently, it is capable of triggering on conversions between two of the accepted fiat currencies (e.g. "usd to cad") which the Currency Spice already handles.

Also, this fixes a bug that prevents a conversion of 1 unit from a currency that isn't in the top-10 most popular. E.g. "1 zec to usd"

## People to notify
@pjhampton 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/cryptocurrency
<!-- FILL THIS IN:                           ^^^^ -->
