### PR TITLE
Package Tracking: Add DHL and UPS (9 & 10 digit) Validation

### DIFF
--- a/lib/DDG/Spice/PackageTracking.pm
+++ b/lib/DDG/Spice/PackageTracking.pm
@@ -88,8 +88,8 @@ triggers query_nowhitespace_nodash => qr/^
 triggers query_nowhitespace_nodash => qr/^
                                 (?:
                                     \d{10} |
-                                    \[a-zA-Z]{5}d{10} |
-                                    \[a-zA-Z]{3}d{20}
+                                    \[a-zA-Z]{5}\d{10} |
+                                    \[a-zA-Z]{3}\d{20}
                                 )
                                 $/xi;
 
@@ -122,7 +122,7 @@ handle query => sub {
     return unless $_;
 
     # remainder should be numeric or alphanumeric, not alpha
-    return if m/^[A-Z]+$/i;
+    return if m/^[A-Z\-\s]+$/i;
 
     # ignore remainder with 2+ words
     return if m/\b[A-Z]+\s+[A-Z]+\b/i;

--- a/lib/DDG/Spice/PackageTracking.pm
+++ b/lib/DDG/Spice/PackageTracking.pm
@@ -148,7 +148,7 @@ handle query => sub {
 
     # Validate likely UPS tracking numbers
     # Skipping \d{12} because that matches other carriers as well
-    if (m/^\d{9}|T\d{10}$/) {
+    if (m/^(\d{9}|T\d{10})$/) {
         return unless is_valid_ups($_);
     }
     # Validate DHL tracking numbers

--- a/lib/DDG/Spice/PackageTracking.pm
+++ b/lib/DDG/Spice/PackageTracking.pm
@@ -170,9 +170,7 @@ handle query => sub {
 
 
 sub is_valid_dhl {
-    # If a Canada Post package number (2 for exclusively).
     my $package_number = $_;
-
     my $checksum   = 0;
     my @chars      = split( //, $package_number );
     my $length     = scalar(@chars);
@@ -183,7 +181,6 @@ sub is_valid_dhl {
 
     foreach my $char (@chars) {
         $char_count++;
-
         if ($char_count % 2 == 0) {
             $even_sum += $char;
         }
@@ -191,15 +188,11 @@ sub is_valid_dhl {
             $odd_sum += $char;
         }
     }
+
     $even_sum *= 1;
     $odd_sum  *= 1;
-
     $checksum = join( '', @chars[ 0 .. $length - 2 ] ) % 7;
-
-    if ($checksum eq $chars[-1]) {
-        $is_valid = 1;
-    }
-
+    $is_valid = 1 if ($checksum eq $chars[-1]);
     return $is_valid;
 };
 
@@ -237,10 +230,8 @@ sub is_valid_ups {
     my $checksum = 0;
     my $is_valid = 0;
     my @chars = split(//, $package_number);
-
-    # Skip 1Z.
+    # Skip 1Z
     @chars = @chars[ 2 .. scalar(@chars) - 1 ];
-
     my $length     = scalar(@chars);
     my $char_count = 0;
     my $odd_sum    = 0;
@@ -263,10 +254,7 @@ sub is_valid_ups {
     }
     $even_sum *= 2;
     $checksum = ( $odd_sum + $even_sum ) % 10;
-
-    if ($checksum eq $chars[-1]) {
-        $is_valid = 1;
-    }
+    $is_valid = 1 if ($checksum eq $chars[-1]);
     return $is_valid;
 }
 

--- a/t/PackageTracking.t
+++ b/t/PackageTracking.t
@@ -196,7 +196,6 @@ ddg_spice_test(
     'hook-ups anime' => undef,
     'ubuntu-server package' => undef,
     'dhl-sendungsverfolgung' => undef,
-    'smart ups 1000 SUA1000 manual' => undef,
 
     ## Bad UPS
     '205495077' => undef,

--- a/t/PackageTracking.t
+++ b/t/PackageTracking.t
@@ -104,7 +104,7 @@ ddg_spice_test(
         call_type => 'include',
         caller => 'DDG::Spice::PackageTracking'
     ),
-    
+
     # CanadaPost
     '7316971234436767' => test_spice(
         "/js/spice/package_tracking/7316971234436767",
@@ -193,6 +193,24 @@ ddg_spice_test(
     'ups building 2 worldport' => undef,
     'ups building 2 worldport address' => undef,
     '1LS12345678999999999' => undef,
+    'hook-ups anime' => undef,
+    'ubuntu-server package' => undef,
+    'dhl-sendungsverfolgung' => undef,
+    'smart ups 1000 SUA1000 manual' => undef,
+
+    ## Bad UPS
+    '205495077' => undef,
+    '199151188' => undef,
+    '085911287' => undef,
+    'T9999999999' => undef,
+
+    ## Bad DHL
+    '8004045172' => undef,
+    '0957156239' => undef,
+    '8007776116' => undef,
+    '6311245247' => undef,
+    '6263467015' => undef,
+
 
     # Too long
     'fedex 123456789 123456789 123456789 1234' => undef,
@@ -208,7 +226,7 @@ ddg_spice_test(
 
     'fedex' => undef,
     'fedex website' => undef,
-    
+
     # Invalid query containing isbn
     'isbn 9780134494326' => undef,
     'Isbn9780073380957' => undef,


### PR DESCRIPTION
## Description of new Instant Answer, or changes
We're matching on many 9 and 10 digits numbers that are product numbers and phone numbers. I've added in the validation which was previously used by the Goodies to prevent the false positives.

## People to notify
@pjhampton 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/package_tracking
<!-- FILL THIS IN:                           ^^^^ -->
