### PR TITLE
Currency: Adds alias 'uae dirham'

### DIFF
--- a/share/spice/currency/currencyNames.txt
+++ b/share/spice/currency/currencyNames.txt
@@ -1,4 +1,4 @@
-aed,emirati dirham,united arab emirates dirham,
+aed,emirati dirham,united arab emirates dirham,uae dirham,
 afn,afghan afghani,afghanistan afghani,
 all,albanian lek,albania lek,
 amd,armenian dram,armenia dram,

--- a/t/Currency.t
+++ b/t/Currency.t
@@ -398,6 +398,13 @@ ddg_spice_test(
         caller => 'DDG::Spice::Currency',
         is_cached => 0
     ),
+				#check for uae dirham aliases
+    '1m usd in uae dirham' => test_spice(
+        '/js/spice/currency/1000000/usd/aed',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),				
     # when you don't specify the target Currency
     # check for placing currency type before amount
     'CHF 2.95 in eur' => test_spice(


### PR DESCRIPTION
**Improvement**

## Description of new Instant Answer, or changes
This PR adds an alias for `aed currency`

## People to notify
@moollaza @mintsoft 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/currency
<!-- FILL THIS IN:                           ^^^^ -->
