### PR TITLE
New Edrpou Spice

### DIFF
--- a/lib/DDG/Spice/Edrpou.pm
+++ b/lib/DDG/Spice/Edrpou.pm
@@ -20,7 +20,7 @@ triggers startend => "EDRPOU","ЄДРПОУ","ЄДР","edrpou", "єдрпоу", 
 # Handle statement
 handle remainder => sub {
     # Trigger if query includes an 8 digit number
-    return $_ if $_ =~ /\d{8}/i;
+    return $_ if $_ =~ /\d{8}/;
     return;
 };
 

--- a/lib/DDG/Spice/Edrpou.pm
+++ b/lib/DDG/Spice/Edrpou.pm
@@ -1,0 +1,26 @@
+package DDG::Spice::Edrpou;
+
+# ABSTRACT: Get information about Ukrainian companies by EDRPOU code
+
+use DDG::Spice;
+use strict;
+use warnings;
+
+# Caching - http://docs.duckduckhack.com/backend-reference/api-reference.html#caching
+spice is_cached => 1;
+spice proxy_cache_valid => '200 10d'; # defaults to this automatically
+
+spice wrap_jsonp_callback => 1;
+
+spice to => 'https://edr.data-gov-ua.org/api/companies?where={%22edrpou%22:%22$1%22}';
+
+# Triggers - https://duck.co/duckduckhack/spice_triggers
+triggers startend => "EDRPOU","ЄДРПОУ","ЄДР","edrpou", "єдрпоу", "єдр";
+
+# Handle statement
+handle remainder => sub {
+    return $_ if $_;
+    return;
+};
+
+1;

--- a/lib/DDG/Spice/Edrpou.pm
+++ b/lib/DDG/Spice/Edrpou.pm
@@ -15,12 +15,12 @@ spice wrap_jsonp_callback => 1;
 spice to => 'https://edr.data-gov-ua.org/api/companies?where={%22edrpou%22:%22$1%22}';
 
 # Triggers - https://duck.co/duckduckhack/spice_triggers
-triggers startend => "EDRPOU","ЄДРПОУ","ЄДР","edrpou", "єдрпоу", "єдр";
+triggers startend => "ЄДРПОУ","ЄДР","edrpou", "єдрпоу", "єдр";
 
 # Handle statement
 handle remainder => sub {
-    # Trigger if query includes an 8 digit number
-    return $_ if $_ =~ /\d{8}/;
+    # Trigger if query includes number length 5-8
+    return $_ if $_ =~ /^\d{5,8}$/;
     return;
 };
 

--- a/lib/DDG/Spice/Edrpou.pm
+++ b/lib/DDG/Spice/Edrpou.pm
@@ -19,7 +19,8 @@ triggers startend => "EDRPOU","ЄДРПОУ","ЄДР","edrpou", "єдрпоу", 
 
 # Handle statement
 handle remainder => sub {
-    return $_ if $_;
+    # Trigger if query includes an 8 digit number
+    return $_ if $_ =~ /\d{8}/i;
     return;
 };
 

--- a/share/spice/edrpou/edrpou.js
+++ b/share/spice/edrpou/edrpou.js
@@ -1,0 +1,59 @@
+(function (env) {
+    "use strict";
+
+    env.ddg_spice_edrpou = function(api_result) {
+
+        // Validate the response (customize for your Spice)
+        if (!api_result || api_result.error || api_result.length === 0) {
+            return Spice.failed('edrpou');
+        }
+
+        // Render the response
+        Spice.add({
+            id: 'edrpou',
+
+            // Customize these properties
+            name: 'Ukrainian company',
+            data: api_result,
+            meta: {
+                sourceName: 'edr.data-gov-ua.org',
+                sourceUrl: 'https://edr.data-gov-ua.org/organizations/' + api_result[0].edrpou
+            },
+            normalize: function(item) {
+                return {
+                    infoboxData: [
+                        {
+                            heading: item.name || item.officialName
+                        },
+                        {
+                            label: "Address",
+                            value: item.address
+                        },
+                        {
+                            label: "Chairman",
+                            value: item.mainPerson
+                        },
+                        {
+                            label: "Activity",
+                            value: item.occupation
+                        },
+                        {
+                            label: "Status",
+                            value: item.status
+                        },
+                    ],
+                    title: item.edrpou + " " +(item.name || item.officialName),
+                    description: item.occupation,
+                    url: 'https://edr.data-gov-ua.org/organizations/' + item.edrpou
+                };
+            },
+            templates: {
+                group: 'info',
+                options: {
+                    content: Spice.edrpou.content,
+                    moreAt: true
+                }
+            }
+        });
+    };
+}(this));

--- a/t/Edrpou.t
+++ b/t/Edrpou.t
@@ -1,0 +1,41 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+spice is_cached => 1;
+
+ddg_spice_test(
+    [qw( DDG::Spice::Edrpou)],
+    'EDRPOU 32289188' => test_spice(
+        '/js/spice/edrpou/32289188',
+        call_type => 'include',
+        caller => 'DDG::Spice::Edrpou'
+    ),
+    '32289188 ЄДР' => test_spice(
+        '/js/spice/edrpou/32289188',
+        caller    => 'DDG::Spice::Edrpou',
+    ),
+    '32289188 ЄДРПОУ' => test_spice(
+        '/js/spice/edrpou/32289188',
+        caller    => 'DDG::Spice::Edrpou',
+    ),
+    'ЄДРПОУ 32289188' => test_spice(
+        '/js/spice/edrpou/32289188',
+        caller    => 'DDG::Spice::Edrpou',
+    ),
+    'ЄДР 32289188' => test_spice(
+        '/js/spice/edrpou/32289188',
+        caller    => 'DDG::Spice::Edrpou',
+    ),    
+    # Try to include some examples of queries on which it might
+    # appear that your answer will trigger, but does not.
+    'EDRPOU code' => undef,
+    'ЄДРПОУ код' => undef,
+    'ЄДР код' => undef,
+);
+
+done_testing;
+


### PR DESCRIPTION
## Description of new Instant Answer, or changes

Edrpou is a Ukranian company registry. Each company has a "edrpou" code.
Registry has official API, but it costs money.
There are also weekly extracts, based on which open source API is built.
This InstantAnswer allows to query searches:
e.g.: "edrpou 20077720"

Couldn't find a way to trigger unicode instant answer, e.g. "ЄДР 20077720".

Also in todo: add "only digits" regex, add more queries.

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->

## People to notify
<!-- Please @mention any relevant people/organizations here: -->

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/edrpou
<!-- FILL THIS IN:                           ^^^^ -->
