### PR TITLE
Cryptocurrency: Open up triggering

### DIFF
--- a/lib/DDG/Spice/Cryptocurrency.pm
+++ b/lib/DDG/Spice/Cryptocurrency.pm
@@ -29,6 +29,13 @@ my @excludedCurrencies = (
     'uah',
 );
 
+# Handles ambiguities in the symbol names
+my @nonTriggeringSymbols = (
+    'ftc',
+    'ppc',
+    'nmc',
+);
+
 # Used to filter on queries of the form '1 <cryptocurrency>'
 # Top currencies from coinmarketcap.com/currencies/
 my @topCurrencies = (
@@ -71,8 +78,8 @@ my %availableLocalCurrencies = map {$_ => 1} @availableLocalCurrencies;
 #Define regexes
 my $currency_qr = join('|', @currTriggers);
 my $crypto_qr = join('|', @cryptoTriggers);
-my $question_prefix = qr/(?:convert|what (?:is|are|does)|how (?:much|many) (?:is|are))?\s?/;
-my $rate_qr = qr/\s(?:rate|exchange|exchange rate|conver(?:sion|ter)|calc(?:ulator)?|price)/i;
+my $question_prefix = qr/(?:convert|current value (?:of)?|what (?:is|are|does)|(?:conversion|exchange|fx) rate\s?(?:for)?|how (?:much|many) (?:is|are))?\s?/;
+my $rate_qr = qr/\s(?:rate|exchange|(?:exchange|fx) rate|conver(?:sion|ter)|calc(?:ulator)?|price)/i;
 my $into_qr = qr/\s(?:en|in|to|in ?to|to|from)\s/i;
 my $vs_qr = qr/\sv(?:ersu|)s\.?\s/i;
 my $number_re = number_style_regex();
@@ -232,6 +239,10 @@ handle query_lc => sub {
         # Case where the first amount is available.
         elsif(length($amount)) {
             return checkCurrencyCode($amount, $from, $to);
+        }
+        # Ignore if no amount and a non triggering symbol
+        elsif (grep(/^$from$/, @nonTriggeringSymbols)) {
+            return;
         }
         # Case where the second amount is available.
         elsif(length($alt_amount)) {

--- a/lib/DDG/Spice/Cryptocurrency.pm
+++ b/lib/DDG/Spice/Cryptocurrency.pm
@@ -9,19 +9,13 @@ use YAML::XS qw(LoadFile);
 
 # Get all the valid currencies from a text file.
 my @currTriggers;
+my @cryptoTriggers;
 my @currencies = share('cryptocurrencylist.txt')->slurp;
 my %currHash = ();
 my $currDisplayName = '';
 
 # link country codes to a currency symbol
 my $currencyPerCountry = LoadFile share("currencyPerCountry.yml");
-
-foreach my $currency (@currencies){
-    chomp($currency);
-    my @currency = split(/,/,$currency);
-    push(@currTriggers, @currency);
-    $currHash{$currency[0]} = \@currency;
-}
 
 # Used when a single currency is given in the query.
 # These currencies should be handled by DDG::Spice::Currency or DDG::Spice::Bitcoin.
@@ -54,8 +48,21 @@ my @availableLocalCurrencies = (
     'eur',
     'jpy',
     'rur',
+    'rub',
     'uah'
 );
+
+foreach my $currency (@currencies){
+    chomp($currency);
+    my @currency = split(/,/,$currency);
+
+    if(!grep(/^$currency[0]$/, @availableLocalCurrencies) || !grep(/^$currency[0]$/, @excludedCurrencies)) {
+        push(@cryptoTriggers, @currency);
+    }
+
+    push(@currTriggers, @currency);
+    $currHash{$currency[0]} = \@currency;
+}
 
 my %excludedCurrencies = map { $_ => 1 } @excludedCurrencies;
 my %topCurrencies = map { $_ => 1 } @topCurrencies;
@@ -63,15 +70,18 @@ my %availableLocalCurrencies = map {$_ => 1} @availableLocalCurrencies;
 
 #Define regexes
 my $currency_qr = join('|', @currTriggers);
+my $crypto_qr = join('|', @cryptoTriggers);
 my $question_prefix = qr/(?:convert|what (?:is|are|does)|how (?:much|many) (?:is|are))?\s?/;
-my $rate_qr = qr/\s(?:rate|exchange|exchange rate|conversion|price)/i;
+my $rate_qr = qr/\s(?:rate|exchange|exchange rate|conver(?:sion|ter)|calc(?:ulator)?|price)/i;
 my $into_qr = qr/\s(?:en|in|to|in ?to|to|from)\s/i;
 my $vs_qr = qr/\sv(?:ersu|)s\.?\s/i;
 my $number_re = number_style_regex();
 
+my $crypto_triggers = qr/^(?:$crypto_qr)(?:\s$rate_qr)?$/i;
 my $guard = qr/^$question_prefix($number_re*?\s+|)($currency_qr)(?:s)?(?:$into_qr|$vs_qr|$rate_qr|\s)?($number_re*?\s+|)($currency_qr)?(?:s)?\??$/i;
+my $generic_triggers = qr/^(?:((?:crypto\s?(currency)?)\s?(?:calc(?:ulator)?|conver(?:sion|ter)|exchanges?)?)|(?:coin exchanges?))$/;
 
-triggers query_lc => qr/$currency_qr/;
+triggers query_lc => qr/$generic_triggers|$currency_qr|$crypto_triggers/;
 
 spice from => '([^/]+)/([^/]+)/([^/]*)';
 spice to => 'https://api.cryptonator.com/api/full/$2-$3';
@@ -99,7 +109,7 @@ sub getCode {
 
 # This function is responsible for processing the input.
 sub checkCurrencyCode {
-    my($amount, $from, $to) = @_;
+    my($amount, $from, $to, $generic) = @_;
     my $endpoint = '';
     my $query = '';
     my $query2 = '';
@@ -116,10 +126,9 @@ sub checkCurrencyCode {
     # Avoids triggering on common queries like '1 gig' or '1 electron'
     # If the cryptocurrency is not in the top currencies list, the query does not include a 'to' currency,
     # and the query doesn't include 'coin' then don't trigger
-    if ($normalized_number == 1 && $to eq '' && !exists($topCurrencies{getCode($from)}) && index($from, 'coin') == -1) {
+    if ($normalized_number == 1 && $to eq '' && exists($availableLocalCurrencies{getCode($from)}) ) {
         return;
     }
-
     # There are cases where people type in "2016 bitcoin", so we don't want to trigger on those queries.
     # The first cryptocoins appeared in 2008, so dates before that could be valid amounts.
     if($normalized_number >= 2008 && $normalized_number < 2100 && (length($from) == 0 || length($to) == 0)) {
@@ -142,10 +151,13 @@ sub checkCurrencyCode {
 
     # If both currencies are available, use the ticker endpoint
     if (length($from) && length($to)) {
-        # Return early if both currencies are in the excluded list
+        # Return early if both currencies are in the excluded list uncless a generic trigger
+        # which will not trigger the currency spice
         # Allows searches like "ftc to aud" but excludes searches like "aud to usd"
-        if (exists($excludedCurrencies{$from}) && exists($excludedCurrencies{$to})) {
-            return;
+        if(!$generic) {
+            if (exists($excludedCurrencies{$from}) && exists($excludedCurrencies{$to})) {
+                return;
+            }
         }
         $endpoint = 'ticker';
         $query = $from . '-' . $to;
@@ -195,6 +207,16 @@ sub getLocalCurrency {
 }
 
 handle query_lc => sub {
+
+    # generic type queries
+    # ie. 'crypto currency', 'crypto exchange'
+    if ($_ =~ qr/$generic_triggers/) {
+        my $local_currency = getLocalCurrency();
+        return checkCurrencyCode(1, 'btc', $local_currency, 1);
+    }
+
+    # all other queries
+    # ie. 'ltc', 'feather coin calculator', 'eth to usd'
     if (/$guard/) {
         my ($amount, $from, $alt_amount, $to) = ($1, $2, $3, $4 || '');
 
@@ -205,12 +227,6 @@ handle query_lc => sub {
         # ignore queries that don't involve a cryptocurrency
         # these are handled by the Currency Spice
         elsif (defined $availableLocalCurrencies{$from} && defined $availableLocalCurrencies{$to}) {
-            return;
-        }
-        # Case where only ticker symbol is give.
-        # Most cryptocurrency ticker symbols are already common acronyms that we don't want to trigger on them.
-        # Done before standardizing currency value: "42coin?" and "100 ftc" will trigger spice, "42" and "ftc" will not.
-        elsif (exists($currHash{$from}) && !length($to) && !length($amount)) {
             return;
         }
         # Case where the first amount is available.

--- a/share/spice/cryptocurrency/cryptocurrency.js
+++ b/share/spice/cryptocurrency/cryptocurrency.js
@@ -249,7 +249,7 @@
                         Converter.rate = parseFloat(price);
                         Converter.fromCurrency = base;
                         Converter.toCurrency = target;
-                        Converter.updateMoreAtLink(Converter.fromCurrency, Converter.toCurrency);
+                        Converter.updateMoreAtLink(Converter.toCurrency, Converter.fromCurrency);
                         Converter.updateChangeRate(api_result.ticker.change);
 
                         // set the selects with the correct initial value

--- a/t/Cryptocurrency.t
+++ b/t/Cryptocurrency.t
@@ -245,11 +245,87 @@ ddg_spice_test(
         query_raw => "eth calculator",
         location => test_location("us")
     ) => test_spice(
-        '/js/spice/cryptocurrency/ticker/etc-usd/1',
+        '/js/spice/cryptocurrency/ticker/eth-usd/1',
         call_type => 'include',
         caller => 'DDG::Spice::Cryptocurrency',
         is_cached => 0
     ),
+    DDG::Request->new(
+        query_raw => "eth",
+        location => test_location("us")
+    ) => test_spice(
+        '/js/spice/cryptocurrency/ticker/eth-usd/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::Cryptocurrency',
+        is_cached => 0
+    ),
+    DDG::Request->new(
+        query_raw => "eth",
+        location => test_location("de")
+    ) => test_spice(
+        '/js/spice/cryptocurrency/ticker/eth-eur/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::Cryptocurrency',
+        is_cached => 0
+    ),
+    DDG::Request->new(
+        query_raw => "ltc",
+        location => test_location("de")
+    ) => test_spice(
+        '/js/spice/cryptocurrency/ticker/ltc-eur/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::Cryptocurrency',
+        is_cached => 0
+    ),
+    DDG::Request->new(
+        query_raw => "feather coin calculator",
+        location => test_location("de")
+    ) => test_spice(
+        '/js/spice/cryptocurrency/ticker/ftc-eur/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::Cryptocurrency',
+        is_cached => 0
+    ),
+    DDG::Request->new(
+        query_raw => "primecoin exchange rate",
+        location => test_location("de")
+    ) => test_spice(
+        '/js/spice/cryptocurrency/ticker/xpm-eur/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::Cryptocurrency',
+        is_cached => 0
+    ),
+    DDG::Request->new(
+        query_raw => "zcash?",
+        location => test_location("de")
+    ) => test_spice(
+        '/js/spice/cryptocurrency/ticker/zec-eur/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::Cryptocurrency',
+        is_cached => 0
+    ),
+    DDG::Request->new(
+        query_raw => "zcash to ltc",
+        location => test_location("de")
+    ) => test_spice(
+        '/js/spice/cryptocurrency/ticker/zec-ltc/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::Cryptocurrency',
+        is_cached => 0
+    ),
+    DDG::Request->new(
+        query_raw => "feathercoins",
+        location => test_location("us")
+    ) => test_spice(
+        '/js/spice/cryptocurrency/ticker/ftc-usd/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::Cryptocurrency',
+        is_cached => 0
+    ),
+
+    # should trigger on anything bitcoin specific
+    'btc' => undef,
+    'bitcoin' => undef,
 
     # Malformed queries
     'ltc to ltc' => undef,
@@ -260,7 +336,6 @@ ddg_spice_test(
     '666' => undef,
     '2015' => undef,
     # Words or acronyms that shouldn't trigger spice.
-    'ftc?' => undef,
     'BOOM' => undef,
     'Sloths' => undef,
     # Numbers with ambiguous formatting.
@@ -305,6 +380,32 @@ ddg_spice_test(
 
     # Should not trigger because diode is not in the top 10 and name does not include coin
     '1 diode' => undef,
+
+    # generic queries
+    'coin exchanges near me' => undef,
+    'belfast coin exchanges' => undef,
+    'buy cryptocurrency' => undef,
+    'crytocurrency' => undef,
+    'currency calculator' => undef,
+    'btc ltc dark web' => undef,
+    'btc top up' => undef,
+    'how to sell ltc' => undef,
+    'Show me crypto prices' => undef,
+    '2017 ltc' => undef,
+    'calculator' => undef,
+    'currency converter' => undef,
+    'convert currency' => undef,
+    'exchange rate' => undef,
+    'fx rate' => undef,
+
+    # should be handled by currency IA
+    'usd' => undef,
+    'cad' => undef,
+    'usd to eur' => undef,
+    'cad to php' => undef,
+    'eur to eur' => undef,
+    'cad to usd' => undef,
+
 );
 
 done_testing;

--- a/t/Cryptocurrency.t
+++ b/t/Cryptocurrency.t
@@ -322,6 +322,24 @@ ddg_spice_test(
         caller => 'DDG::Spice::Cryptocurrency',
         is_cached => 0
     ),
+    DDG::Request->new(
+        query_raw => "current value of feathercoins",
+        location => test_location("us")
+    ) => test_spice(
+        '/js/spice/cryptocurrency/ticker/ftc-usd/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::Cryptocurrency',
+        is_cached => 0
+    ),
+    DDG::Request->new(
+        query_raw => "exchange rate for namecoins",
+        location => test_location("us")
+    ) => test_spice(
+        '/js/spice/cryptocurrency/ticker/nmc-usd/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::Cryptocurrency',
+        is_cached => 0
+    ),
 
     # should trigger on anything bitcoin specific
     'btc' => undef,
@@ -405,6 +423,9 @@ ddg_spice_test(
     'cad to php' => undef,
     'eur to eur' => undef,
     'cad to usd' => undef,
+
+    # crypto edge cases
+    'ftc' => undef,
 
 );
 

--- a/t/Cryptocurrency.t
+++ b/t/Cryptocurrency.t
@@ -150,6 +150,107 @@ ddg_spice_test(
         is_cached => 0
     ),
 
+    # language based queries
+    DDG::Request->new(
+        query_raw => "Crypto currency",
+        location => test_location("us")
+    ) => test_spice(
+        '/js/spice/cryptocurrency/ticker/btc-usd/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::Cryptocurrency',
+        is_cached => 0
+    ),
+    DDG::Request->new(
+        query_raw => "cryptocurrency",
+        location => test_location("us")
+    ) => test_spice(
+        '/js/spice/cryptocurrency/ticker/btc-usd/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::Cryptocurrency',
+        is_cached => 0
+    ),
+    DDG::Request->new(
+        query_raw => "cryptocurrency",
+        location => test_location("us")
+    ) => test_spice(
+        '/js/spice/cryptocurrency/ticker/btc-usd/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::Cryptocurrency',
+        is_cached => 0
+    ),
+    DDG::Request->new(
+        query_raw => "crypto currency exchange",
+        location => test_location("de")
+    ) => test_spice(
+        '/js/spice/cryptocurrency/ticker/btc-eur/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::Cryptocurrency',
+        is_cached => 0
+    ),
+    DDG::Request->new(
+        query_raw => "coin exchange",
+        location => test_location("de")
+    ) => test_spice(
+        '/js/spice/cryptocurrency/ticker/btc-eur/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::Cryptocurrency',
+        is_cached => 0
+    ),
+    DDG::Request->new(
+        query_raw => "eth converter",
+        location => test_location("de")
+    ) => test_spice(
+        '/js/spice/cryptocurrency/ticker/eth-eur/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::Cryptocurrency',
+        is_cached => 0
+    ),
+    DDG::Request->new(
+        query_raw => "convert ltc",
+        location => test_location("de")
+    ) => test_spice(
+        '/js/spice/cryptocurrency/ticker/ltc-eur/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::Cryptocurrency',
+        is_cached => 0
+    ),
+    DDG::Request->new(
+        query_raw => "ltc calculator",
+        location => test_location("de")
+    ) => test_spice(
+        '/js/spice/cryptocurrency/ticker/ltc-eur/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::Cryptocurrency',
+        is_cached => 0
+    ),
+    DDG::Request->new(
+        query_raw => "zcash calculator",
+        location => test_location("us")
+    ) => test_spice(
+        '/js/spice/cryptocurrency/ticker/zec-usd/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::Cryptocurrency',
+        is_cached => 0
+    ),
+    DDG::Request->new(
+        query_raw => "primecoin",
+        location => test_location("us")
+    ) => test_spice(
+        '/js/spice/cryptocurrency/ticker/xpm-usd/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::Cryptocurrency',
+        is_cached => 0
+    ),
+    DDG::Request->new(
+        query_raw => "eth calculator",
+        location => test_location("us")
+    ) => test_spice(
+        '/js/spice/cryptocurrency/ticker/etc-usd/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::Cryptocurrency',
+        is_cached => 0
+    ),
+
     # Malformed queries
     'ltc to ltc' => undef,
     'ltc to' => undef,

--- a/t/Cryptocurrency.t
+++ b/t/Cryptocurrency.t
@@ -170,7 +170,7 @@ ddg_spice_test(
         is_cached => 0
     ),
     DDG::Request->new(
-        query_raw => "cryptocurrency",
+        query_raw => "cryptocurrency converter",
         location => test_location("us")
     ) => test_spice(
         '/js/spice/cryptocurrency/ticker/btc-usd/1',


### PR DESCRIPTION
## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->

1. Will now open for all cryptocurrency names that we support (<strike>ftc</strike>, ltc, zcash, etc) except for btc.

![screen shot 2017-06-16 at 6 31 07 pm](https://user-images.githubusercontent.com/8960296/27237675-fe1fd690-52c1-11e7-9efb-f7f750b142db.png)

2. Will now open on generic queries (defaulting to BTC / local currency) such as "cryptocurrency calculator", "crypto prices" etc.

![screen shot 2017-06-16 at 6 35 34 pm](https://user-images.githubusercontent.com/8960296/27237918-cbe6d63c-52c2-11e7-8c6d-4225c533e0ab.png)


## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->

## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@moollaza 
cc/ @bsstoner 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/cryptocurrency
<!-- FILL THIS IN:                           ^^^^ -->
