### PR TITLE
Dictionary: Move filter() in dictionary below the guard

### DIFF
--- a/share/spice/dictionary/definition/dictionary_definition.js
+++ b/share/spice/dictionary/definition/dictionary_definition.js
@@ -102,9 +102,8 @@ var ddg_spice_dictionary = {
     definition: function(api_result) {
         "use strict";
 
+        api_result = api_result && api_result.length && api_result.filter(function(result) { return result.text; })
         if (!api_result || !api_result.length) { return Spice.failed('dictionary_definition'); }
-
-        api_result = api_result.filter(function(result) { return result.text; })
 
         // Prevent jQuery from appending "_={timestamp}" in our url when we use $.getScript.
         // If cache was set to false, it would be calling /js/spice/dictionary/definition/hello?_=12345

--- a/share/spice/dictionary/definition/dictionary_definition.js
+++ b/share/spice/dictionary/definition/dictionary_definition.js
@@ -102,8 +102,9 @@ var ddg_spice_dictionary = {
     definition: function(api_result) {
         "use strict";
 
-        api_result = api_result.filter(function(result) { return result.text; })
         if (!api_result || !api_result.length) { return Spice.failed('dictionary_definition'); }
+
+        api_result = api_result.filter(function(result) { return result.text; })
 
         // Prevent jQuery from appending "_={timestamp}" in our url when we use $.getScript.
         // If cache was set to false, it would be calling /js/spice/dictionary/definition/hello?_=12345


### PR DESCRIPTION
@moollaza why did we add that above the guard? It seems functionally equivalent to put it below and it's throwing JS errors in production:

```
/t/jse_spice?2101784&msg=TypeError%3A%20undefined%20is%20not%20an%20object%20(evaluating%20'api_result.filter')&url=https%3A%2F%2Fduckduckgo.com%2Fshare%2Fspice%2Fdictionary%2Fdefinition%2F1307%2Fdictionary_definition.spice.js&line=1&col=3628&ct=NZ
```

https://duck.co/ia/view/dictionary_definition