### PR TITLE
Dota 2: Fixes #3296 Skeleton King Trigger not working

### DIFF
--- a/share/spice/dota2/dota2.js
+++ b/share/spice/dota2/dota2.js
@@ -3,6 +3,7 @@
 
     function getItemFromData(itemdata, itemName) {
         var item;
+
         if (itemdata[itemName]) {
             item = itemdata[itemName];
         } else {
@@ -83,6 +84,7 @@
 
     function getHeroFromData(herodata, heroName) {
         var hero;
+
         if (herodata[heroName]) {
             hero = herodata[heroName];
             hero.heroKey = heroName;
@@ -179,10 +181,12 @@
         }
 
         var searchTarget = DDG.get_query().toLowerCase().replace(/dota\s?2/, "").trim();
+        var keyTarget = searchTarget.split(' ').join('_');
         var returnData;
-        var item = getItemFromData(api_result.itemdata, searchTarget);
+        var item = getItemFromData(api_result.itemdata, keyTarget);
         var sourceUrl;
         var template;
+
         if (typeof item !== 'undefined') {
             returnData = createItemReturnObject(item, api_result);
             sourceUrl = 'https://www.dota2.com/items/';
@@ -193,7 +197,7 @@
                 }
             };
         } else {
-            var hero = getHeroFromData(api_result.herodata, searchTarget);
+            var hero = getHeroFromData(api_result.herodata, keyTarget);
             if (!hero) { return Spice.failed('dota2'); }
 
             returnData = createHeroReturnObject(hero, api_result);

--- a/share/spice/dota2/dota2.js
+++ b/share/spice/dota2/dota2.js
@@ -181,7 +181,7 @@
         }
 
         var searchTarget = DDG.get_query().toLowerCase().replace(/dota\s?2/, "").trim();
-        var keyTarget = searchTarget.split(' ').join('_');
+        var keyTarget = searchTarget.replace(' ', '_');
         var returnData;
         var item = getItemFromData(api_result.itemdata, keyTarget);
         var sourceUrl;


### PR DESCRIPTION
## Description of new Instant Answer, or changes
The API response must have changed and now spaces between bigrams are being padded with underscores. This fixes the search result which was currently being used directly.


## Related Issues and Discussions
Fixes #3296


## People to notify
@pjhampton @echosa

---

Instant Answer Page: https://duck.co/ia/view/dota2
