### PR TITLE
Currency: Patch triggering edge case

### DIFF
--- a/lib/DDG/Spice/Currency.pm
+++ b/lib/DDG/Spice/Currency.pm
@@ -40,7 +40,7 @@ foreach my $currency (@currencies){
 # Define the regexes here.
 my $currency_qr = join('|', @currTriggers);
 my $into_qr = qr/\s(?:en|in|=(?:\s*\?\s*)?|to|in ?to|to|convert (?:in)?to)\s/i;
-my $vs_qr = qr/\sv(?:ersu|)s?\.?\s/i;
+my $vs_qr = qr/\sv(?:ersu|)s?\.?\s|\s?-\s?/i;
 my $joins_qr = qr/\s(?:and|equals)\.?\s/i;
 my $question_prefix = qr/xe|(?:convert|calculate|what (?:is|are|does)|how (?:much|many) (?:is|are))?\s?/;
 my $number_re = number_style_regex();
@@ -179,6 +179,11 @@ handle query_lc => sub {
 
         if ($to eq '' && $toSymbol) {
             $to = $currencyCodes->{ord($toSymbol)};
+        }
+
+        # work around for captured `-` from the number style regex
+        if ($amount =~ m/-/) {
+            $amount = 1;
         }
 
         # if only a currency symbol is present without "currency" keyword, then bail unless a top currency

--- a/t/Currency.t
+++ b/t/Currency.t
@@ -845,12 +845,12 @@ ddg_spice_test(
         is_cached => 0
     ),
     '33.90 USD - NOK' => test_spice(
-        '/js/spice/currency/1/usd/nok',
+        '/js/spice/currency/33.90/usd/nok',
         call_type => 'include',
         caller => 'DDG::Spice::Currency',
         is_cached => 0
     ),
-    'USD-EUR' => test_spice(
+    'USD - EUR' => test_spice(
         '/js/spice/currency/1/usd/eur',
         call_type => 'include',
         caller => 'DDG::Spice::Currency',

--- a/t/Currency.t
+++ b/t/Currency.t
@@ -844,6 +844,18 @@ ddg_spice_test(
         caller => 'DDG::Spice::Currency',
         is_cached => 0
     ),
+    '33.90 USD - NOK' => test_spice(
+        '/js/spice/currency/1/usd/nok',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
+    'USD-EUR' => test_spice(
+        '/js/spice/currency/1/usd/eur',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
 
     # single unambigious symbols that should trigger
     'usd' => test_spice(


### PR DESCRIPTION
## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->

This PR allows queries such as:
   - `usd - gbp`
   - `322 cad - nok`

@mintsoft `-` is  being captured by the `number_style_regex()` from the NumberStyler role. Is this intended behaviour? I worked around it in 184 - 189

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->
n/a

## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@mintsoft 
@moollaza 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/currency
<!-- FILL THIS IN:                           ^^^^ -->
