### PR TITLE
PackageTracking: Adds the regex for OnTrac

### DIFF
--- a/lib/DDG/Spice/PackageTracking.pm
+++ b/lib/DDG/Spice/PackageTracking.pm
@@ -116,7 +116,7 @@ triggers query_nowhitespace_nodash => qr/^
 ## OnTrac
 triggers query_nowhitespace_nodash => qr/^
                                 (?:
-                                    c\d{14}
+                                    [cd]\d{14}
                                 )
                                 $/xi;
 

--- a/lib/DDG/Spice/PackageTracking.pm
+++ b/lib/DDG/Spice/PackageTracking.pm
@@ -113,6 +113,13 @@ triggers query_nowhitespace_nodash => qr/^
                                     l[a-z]\d{8}
                                 )
                                 $/xi;
+## OnTrac
+triggers query_nowhitespace_nodash => qr/^
+                                (?:
+                                    c\d{14}
+                                )
+                                $/xi;
+
 
 handle query => sub {
 

--- a/t/PackageTracking.t
+++ b/t/PackageTracking.t
@@ -41,6 +41,7 @@ ddg_spice_test(
         call_type => 'include',
         caller => 'DDG::Spice::PackageTracking'
     ),
+		
 
     # Fedex
     'fedex 9241990100130206401644' => test_spice(
@@ -168,6 +169,14 @@ ddg_spice_test(
     ),
     'LL 12345678' => test_spice(
         "/js/spice/package_tracking/LL12345678",
+        call_type => 'include',
+        caller => 'DDG::Spice::PackageTracking'
+
+    ),
+		
+    # OnTrac
+    'C11422907783469' => test_spice(
+        "/js/spice/package_tracking/C11422907783469",
         call_type => 'include',
         caller => 'DDG::Spice::PackageTracking'
 


### PR DESCRIPTION
## Description of new Instant Answer, or changes
This PR adds the regex trigger for OnTrac and update the test.
Test using `prove -Ilib t/PrackageTracking.t` passed

Earlier:
![screenshot from 2017-06-28 17-32-17](https://user-images.githubusercontent.com/25108385/27636185-e5141566-5c27-11e7-94ed-1b44e4efd641.png)

Now:
![screenshot from 2017-06-28 17-31-59](https://user-images.githubusercontent.com/25108385/27636200-f5b7451e-5c27-11e7-904a-8ebdb5a80a1c.png)

## Related Issues and Discussions
Fixes #3344 

## People to notify
@moollaza 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/package_tracking
<!-- FILL THIS IN:                           ^^^^ -->
