### PR TITLE
Transit: updated api urls

### DIFF
--- a/lib/DDG/Spice/Transit/NJT.pm
+++ b/lib/DDG/Spice/Transit/NJT.pm
@@ -4,7 +4,7 @@ package DDG::Spice::Transit::NJT;
 use strict;
 use DDG::Spice;
 
-spice to => 'http://njt-api.appspot.com/njt/times/$1';
+spice to => 'http://njt-api1.appspot.com/njt/times/$1';
 spice wrap_jsonp_callback => 1;
 spice proxy_cache_valid => "418 1d";
 

--- a/lib/DDG/Spice/Transit/PATH.pm
+++ b/lib/DDG/Spice/Transit/PATH.pm
@@ -4,11 +4,11 @@ package DDG::Spice::Transit::PATH;
 use strict;
 use DDG::Spice;
 
-spice to => 'http://njt-api.appspot.com/path/times/$1';
+spice to => 'http://njt-api1.appspot.com/path/times/$1';
 spice wrap_jsonp_callback => 1;
 spice proxy_cache_valid => "418 1d";
 
-#load a list of stops so we don't trigger this if we don't get njt stops
+#load a list of stops so we don't trigger this if we don't get path stops
 #(the triggers are similar to other transit IAs)
 my @stops = share('stops.txt')->slurp;
 


### PR DESCRIPTION
<!-- Use the appropriate format for your Pull Request title above ^^^^^:

If this is a bug fix:
{IA Name}: {Description of change}

If this is a New Instant Answer:
New {IA Name} Spice

If this is something else:
{Tests/Docs/Other}: {Short Description}

-->

I went to update the transit data on my APIs and somehow I lost the credentials to the old app engine service, yet it's still running at its old url (with old data). I spun up a new instance so we can get these IAs working again, would appreciate a quick merge, thanks! 🚋 🚀 

---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/transit_njt
<!-- FILL THIS IN:                           ^^^^ -->
