### PR TITLE
Package Tracking: Add fallback prompt

### DIFF
--- a/lib/DDG/Spice/PackageTracking.pm
+++ b/lib/DDG/Spice/PackageTracking.pm
@@ -3,6 +3,7 @@ package DDG::Spice::PackageTracking;
 use strict;
 use DDG::Spice;
 use Text::Trim;
+use List::Util qw(uniq);
 use YAML::XS 'LoadFile';
 
 spice is_cached => 1;
@@ -202,6 +203,8 @@ handle query => sub {
             push(@possible_carriers, $carrier);
         }
     }
+
+    @possible_carriers = uniq @possible_carriers;
 
     return $_, (join ',', @possible_carriers);
 };

--- a/lib/DDG/Spice/PackageTracking.pm
+++ b/lib/DDG/Spice/PackageTracking.pm
@@ -138,6 +138,10 @@ handle query => sub {
     # remainder should be numeric or alphanumeric, not alpha
     return if m/^[A-Z\-\s]+$/i;
 
+    # ignore searches for courier holiday dates
+    # e.g. "ups holidays 2017"
+    return if m/\bholidays?\b/i;
+
     # ignore remainder with 2+ words
     return if m/\b[A-Z]+\s+[A-Z]+\b/i;
 

--- a/lib/DDG/Spice/PackageTracking.pm
+++ b/lib/DDG/Spice/PackageTracking.pm
@@ -10,6 +10,7 @@ spice proxy_cache_valid => "200 1m";
 
 spice wrap_jsonp_callback => 1;
 
+spice from => '([^/]+)/?.+?$';
 spice to => 'https://api.packagetrackr.com/ddg/v1/track/simple?n=$1&api_key={{ENV{DDG_SPICE_PACKAGETRACKR_API_KEY}}}';
 
 my @carriers = sort { length $b <=> length $a } @{LoadFile(share('carriers.yml'))};
@@ -30,96 +31,102 @@ triggers query_lc => qr/\b(?:$carriers_re)\b/i;
 triggers query_lc => qr/^$triggers_re .+|.+ $triggers_re$/i;
 
 ### Regex triggers for queries only containing a tracking number
+my %courier_regex = (
 
-## UPS
-# Soure: https://www.ups.com/content/ca/en/tracking/help/tracking/tnh.html
-# To Do: Some additional formats exist
-triggers query_nowhitespace => qr/^
-                                (?:
-                                    1Z[0-9A-Z]{16} |
-                                    \d{9} |
-                                    \d{12} |
-                                    T\d{10}
-                                )
-                                $/xi;
+    ## UPS
+    # Soure: https://www.ups.com/content/ca/en/tracking/help/tracking/tnh.html
+    # To Do: Some additional formats exist
+    ups => qr/^
+        (?:
+            1Z[0-9A-Z]{16} |
+            \d{9} |
+            \d{12} |
+            T\d{10}
+        )
+        $/xi,
 
-## Fedex
-# Source: https://www.trackingex.com/fedex-tracking.html
-#         https://www.trackingex.com/fedexuk-tracking.html
-#         https://www.trackingex.com/fedex-poland-domestic-tracking.html
-triggers query_nowhitespace => qr/^
-                                \d{12,22}
-                                $/xi;
+    ## Fedex
+    # Source: https://www.trackingex.com/fedex-tracking.html
+    #         https://www.trackingex.com/fedexuk-tracking.html
+    #         https://www.trackingex.com/fedex-poland-domestic-tracking.html
+    fedex => qr/^
+        \d{12,22}
+        $/xi,
 
-## USPS
-# Source: https://tools.usps.com/go/TrackConfirmAction!input.action
-triggers query_nowhitespace => qr/^
-                                (?:
-                                    (94001|92055|94073|93033|92701|92088|92021)\d{17} |
-                                    82\d{8} |
-                                    [A-Z]{2}\d{9}US
-                                )
-                                $/xi;
+    ## USPS
+    # Source: https://tools.usps.com/go/TrackConfirmAction!input.action
+    usps => qr/^
+        (?:
+            (94001|92055|94073|93033|92701|92088|92021)\d{17} |
+            82\d{8} |
+            [A-Z]{2}\d{9}US
+        )
+        $/xi,
 
-## Parcelforce
-# Source: http://www.parcelforce.com/help-and-advice/sending-worldwide/tracking-number-formats
-# Note:   May need to restrict pattern #3 if overtriggering
-#         https://github.com/duckduckgo/zeroclickinfo-goodies/issues/3900
-triggers query_nowhitespace => qr/^
-                                (?:
-                                    [A-Z]{2}\d{7} |
-                                    [A-Z]{4}\d{10} |
-                                    [A-Z]{2}\d{9}[A-Z]{2} |
-                                    \d{12}
-                                )
-                                $/xi;
+    ## Parcelforce
+    # Source: http://www.parcelforce.com/help-and-advice/sending-worldwide/tracking-number-formats
+    # Note:   May need to restrict pattern #3 if overtriggering
+    #         https://github.com/duckduckgo/zeroclickinfo-goodies/issues/3900
+    parcelforce => qr/^
+        (?:
+            [A-Z]{2}\d{7} |
+            [A-Z]{4}\d{10} |
+            [A-Z]{2}\d{9}[A-Z]{2} |
+            \d{12}
+        )
+        $/xi,
 
-## CanadaPost
-# Source: https://www.canadapost.ca/web/en/kb/details.page?article=learn_about_tracking&cattype=kb&cat=receiving&subcat=tracking
-triggers query_nowhitespace_nodash => qr/^
-                                (?:
-                                    [\d]{12} |
-                                    [\d]{16} |
-                                    [A-Z]{2}\d{9}CA
-                                )
-                                $/xi;
+    ## CanadaPost
+    # Source: https://www.canadapost.ca/web/en/kb/details.page?article=learn_about_tracking&cattype=kb&cat=receiving&subcat=tracking
+    canadapost => qr/^
+        (?:
+            [\d]{12} |
+            [\d]{16} |
+            [A-Z]{2}\d{9}CA
+        )
+        $/xi,
 
-## DHL
-triggers query_nowhitespace_nodash => qr/^
-                                (?:
-                                    \d{10} |
-                                    \[a-zA-Z]{5}\d{10} |
-                                    \[a-zA-Z]{3}\d{20}
-                                )
-                                $/xi;
+    ## DHL
+    dhl => qr/^
+        (?:
+            \d{10} |
+            \[a-zA-Z]{5}\d{10} |
+            \[a-zA-Z]{3}\d{20}
+        )
+        $/xi,
 
-##HKDK
-triggers query_nowhitespace_nodash => qr/^
-                                (?:
-                                    [a-z]{2}\d{9}(?:hk|dk)
-                                )
-                                $/xi;
+    ##HKDK
+    hkdk => qr/^
+        (?:
+            [a-z]{2}\d{9}(?:hk|dk)
+        )
+        $/xi,
 
-## IPS
-triggers query_nowhitespace_nodash => qr/^
-                                (?:
-                                    E[MA]\d{9}(?:IN|HR)
-                                )
-                                $/xi;
+    ## IPS
+    ips => qr/^
+        (?:
+            E[MA]\d{9}(?:IN|HR)
+        )
+        $/xi,
 
-## LaserShip
-triggers query_nowhitespace_nodash => qr/^
-                                (?:
-                                    l[a-z]\d{8}
-                                )
-                                $/xi;
-## OnTrac
-triggers query_nowhitespace_nodash => qr/^
-                                (?:
-                                    [cd]\d{14}
-                                )
-                                $/xi;
+    ## LaserShip
+    lasership => qr/^
+        (?:
+            l[a-z]\d{8}
+        )
+        $/xi,
 
+    ## OnTrac
+    ontrac => qr/^
+        (?:
+            [cd]\d{14}
+        )
+        $/xi
+);
+
+foreach my $regex (values %courier_regex){
+    triggers query_nowhitespace_nodash => $regex;
+}
 
 handle query => sub {
 
@@ -150,16 +157,19 @@ handle query => sub {
     # e.g. ups building 2 worldport
     return if m/\b[A-Z]+ \d{1,8} [A-Z]+\b/i;
 
+    # ignore numbers that start with 0
+    return if m/^0.+/i;
+
     # remove spaces/dashes
     s/(\s|-)//g;
 
     # Validate likely UPS tracking numbers
-    # Skipping \d{12} because that matches other carriers as well
-    if (m/^(\d{9}|T\d{10})$/) {
+    # Skipping \d{12} because that matches several other carriers as well
+    if (m/$courier_regex{ups}/ && not m/\d{12}/) {
         return unless is_valid_ups($_);
     }
     # Validate DHL tracking numbers
-    elsif (m/^\d{10}$/) {
+    elsif (m/$courier_regex{dhl}/) {
         return unless is_valid_dhl($_);
     }
 
@@ -172,7 +182,14 @@ handle query => sub {
     # ignore if isbn is present
     return if m/isbn/i;
 
-    return $_;
+    my @possible_couriers;
+    while (my($courier, $regex) = each %courier_regex) {
+        if ($_ =~ m/$regex/) {
+            push(@possible_couriers, $courier);
+        }
+    }
+
+    return $_, (join ',', @possible_couriers);
 };
 
 

--- a/lib/DDG/Spice/PackageTracking.pm
+++ b/lib/DDG/Spice/PackageTracking.pm
@@ -136,35 +136,35 @@ handle query => sub {
     return unless $_;
 
     # remainder should be numeric or alphanumeric, not alpha
-    return if m/^[A-Z\-\s]+$/i;
+    return if /^[A-Z\-\s]+$/i;
 
     # ignore searches for courier holiday dates
     # e.g. "ups holidays 2017"
-    return if m/\bholidays?\b/i;
+    return if /\bholidays?\b/i;
 
     # ignore remainder with 2+ words
-    return if m/\b[A-Z]+\s+[A-Z]+\b/i;
+    return if /\b[A-Z]+\s+[A-Z]+\b/i;
 
     # ignore phone numbers
-    return if m/^(\d(-|\s))?\d{3}(-|\s)\d{3}(-|\s)\d{4}$/;
-    return if m/^\d{5} \d{7}$/;
-    return if m/^\d{4} \d{3} \d{3}$/;
+    return if /^(\d(-|\s))?\d{3}(-|\s)\d{3}(-|\s)\d{4}$/;
+    return if /^\d{5} \d{7}$/;
+    return if /^\d{4} \d{3} \d{3}$/;
 
 
     # ignore address lookup
-    return if m/^#\d+ [A-Z\s]+$/i;
+    return if /^#\d+ [A-Z\s]+$/i;
 
     # ignore Microsoft knowledge base codes and Luhn Check queries
     # e.g. KB2553549
-    return if m/^(kb|luhn)\s?\d+/i;
+    return if /^(kb|luhn)\s?\d+/i;
 
     # ignore pattern: "word number word"
     # e.g. ups building 2 worldport
-    return if m/\b[A-Z]+ \d{1,8} [A-Z]+\b/i;
+    return if /\b[A-Z]+ \d{1,8} [A-Z]+\b/i;
 
 
     # ignore numbers that start with 0
-    return if m/^0.+/i;
+    return if /^0.+/i;
 
     # remove spaces/dashes
     s/(\s|-)//g;
@@ -182,13 +182,13 @@ handle query => sub {
 
 
     # ignore repeated strings of single digit (e.g. 0000 0000 0000)
-    return if m/^(\d)\1+$/;
+    return if /^(\d)\1+$/;
 
     # remainder should be 6-30 characters long
-    return unless m/^[A-Z0-9]{6,30}$/i;
+    return unless /^[A-Z0-9]{6,30}$/i;
 
     # ignore if isbn is present
-    return if m/isbn/i;
+    return if /isbn/i;
 
 
     my @possible_couriers;

--- a/share/spice/package_tracking/list_content.handlebars
+++ b/share/spice/package_tracking/list_content.handlebars
@@ -1,0 +1,5 @@
+{{!-- Inline style permitted to prevent loading CSS file when this template is not used --}}
+<a href="{{url}}" class="text--primary" style="display:block">
+    <span>Track with {{name}}</span>
+    <span class="ddgsi ddgsi-right pull-right"></span>
+</a>

--- a/share/spice/package_tracking/package_tracking.js
+++ b/share/spice/package_tracking/package_tracking.js
@@ -162,10 +162,22 @@
         "ceva": { name: "CEVA" },
         "china-ems": { name: "China EMS" },
         "china-post": { name: "China Post" },
-        "dhl": { name: "DHL" },
-        "dhl-express": { name: "DHL Express" },
-        "dhl-ecommerce-us": { name: "DHL eCommerce US" },
-        "dhl-deutsche-post": { name: "Deutsche Post DHL" },
+        "dhl": {
+            name: "DHL",
+            url: "http://www.dhl.com/en/express/tracking.html?AWB={{code}}&brand=DHL"
+        },
+        "dhl-express": {
+            name: "DHL Express",
+            url: "http://www.dhl.com/en/express/tracking.html?AWB={{code}}&brand=DHL"
+        },
+        "dhl-ecommerce-us": {
+            name: "DHL eCommerce US",
+            url: "http://www.dhl.com/en/express/tracking.html?AWB={{code}}&brand=DHL"
+        },
+        "dhl-deutsche-post": {
+            name: "Deutsche Post DHL",
+            url: "http://www.dhl.com/en/express/tracking.html?AWB={{code}}&brand=DHL"
+        },
         "dpd-de": { name: "DPD Germany" },
         "dynamex": { name: "Dynamex" },
         "ensenda": { name: "Ensenda" },
@@ -189,9 +201,15 @@
         "hongkong-post": { name: "Hongkong Post" },
         "india-post": { name: "India Post" },
         "japan-post": { name: "Japan Post" },
-        "lasership": { name: "LaserShip" },
+        "lasership": {
+            name: "LaserShip",
+            url: "http://www.lasership.com/track/{{code}}"
+        },
         "prestige": { name: "Prestige" },
-        "ontrac": { name: "OnTrac" },
+        "ontrac": {
+            name: "OnTrac",
+            url: "http://www.ontrac.com/trackingres.asp?tracking_number={{code}}"
+        },
         "osm": { name: "OSM" },
         "parcelforce": {
             name: "Parcelforce",
@@ -200,7 +218,10 @@
         "post-danmark": { name: "Post Danmark" },
         "posten-norge": { name: "Posten Norge" },
         "postnord-sverige": { name: "PostNord Sverige" },
-        "purolator": { name: "Purolator" },
+        "purolator": {
+            name: "Purolator",
+            url: "https://www.purolator.com/purolator/ship-track/tracking-summary.page?sc={{code}}"
+        },
         "royal-mail": { name: "Royal Mail" },
         "spee-dee": { name: "Spee Dee Delivery" },
         "thailand-post": { name: "Thailand Post" },

--- a/t/PackageTracking.t
+++ b/t/PackageTracking.t
@@ -79,7 +79,7 @@ ddg_spice_test(
         caller => 'DDG::Spice::PackageTracking'
     ),
     'usps 9400 1000 0000 0000 0000 00' => test_spice(
-        '/js/spice/package_tracking/9400100000000000000000/fedex%2Cusps',
+        '/js/spice/package_tracking/9400100000000000000000/usps%2Cfedex',
         call_type => 'include',
         caller => 'DDG::Spice::PackageTracking'
     ),
@@ -96,7 +96,7 @@ ddg_spice_test(
         caller => 'DDG::Spice::PackageTracking'
     ),
     'royal mail track parcel QE001331410GB' => test_spice(
-        '/js/spice/package_tracking/QE001331410GB/parcelforce',
+        '/js/spice/package_tracking/QE001331410GB/royal%20mail%2Cparcelforce',
         call_type => 'include',
         caller => 'DDG::Spice::PackageTracking'
     ),


### PR DESCRIPTION
## Description of new Instant Answer, or changes
When no API results returned, provide a list of URL for the user to track the package directly on potential couriers' website.

Also, now ignores potential tracking numbers that start with a 0 as none seem to be valid.

_**Note: This is still WIP. Needs further testing.**_

## People to notify
@bsstoner 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/package_tracking
<!-- FILL THIS IN:                           ^^^^ -->


