### PR TITLE
Docs: Add a link to the DuckDuckHack Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ We're a community of open source developers from around the world, contributing 
 - [**Create new Spice Instant Answers, and improve existing ones**](https://duckduckhack.com/issues)
     - **Note**: Spices are written in Perl (back-end) and JavaScript (front-end). They can also typically use CSS, and [Handlebars](http://handlebarsjs.com) Templates.
 - [**Visit DuckDuckHack**](https://duckduckhack.com/#get-help) to learn more about how you can help!
+- [**Read the DuckDuckHack Docs**](https://docs.duckduckhack.com/) to learn how to set up a development environment and start contributing!
 
 
 ### What are Spice Instant Answers?


### PR DESCRIPTION
## Description of new Instant Answer, or changes

It took me a about an hour of trial-and-error before I found a link to the _DuckDuckHack Docs_ book inside the template module. I think it would be way more useful if this link was nearer the top of the README.

## Related Issues and Discussions

duckduckgo/zeroclickinfo-goodies#4389

## People to notify


<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/{ID}
<!-- FILL THIS IN:                           ^^^^ -->
