### PR TITLE
XKCD: Switch API call to HTTPS to prevent redirect from HTTP

### DIFF
--- a/lib/DDG/Spice/Xkcd/Display.pm
+++ b/lib/DDG/Spice/Xkcd/Display.pm
@@ -11,10 +11,10 @@ spice proxy_cache_valid => '200 1h';
 spice wrap_jsonp_callback => 1;
 
 spice alt_to => {
-	latest => {
-        	to => 'http://xkcd.com/info.0.json',
-        	proxy_cache_valid => '200 1h'
-	}
+    latest => {
+            to => 'https://xkcd.com/info.0.json',
+            proxy_cache_valid => '200 1h'
+    }
 };
 
 handle remainder => sub {


### PR DESCRIPTION
## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->

The API now redirects HTTP to HTTPS which breaks the IA in production. This updates the API to point directly to the HTTPS endpoint.

Fixes #3178 


<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/xkcd
<!-- FILL THIS IN:                           ^^^^ -->
