### PR TITLE
Cryptocurrency: Add bitcoin cash

### DIFF
--- a/lib/DDG/Spice/Cryptocurrency.pm
+++ b/lib/DDG/Spice/Cryptocurrency.pm
@@ -40,6 +40,7 @@ my @nonTriggeringSymbols = (
 # Top currencies from coinmarketcap.com/currencies/
 my @topCurrencies = (
     'btc',
+    'bcc',
     'ltc',
     'eth',
     'dsh',

--- a/share/spice/cryptocurrency/cryptocurrency.js
+++ b/share/spice/cryptocurrency/cryptocurrency.js
@@ -16,6 +16,7 @@
     // Cryptocurrencies (For Selects)
     var crypto_currencies = [
 
+        { symbol: "BCC", name: "Bitcoin Cash" },
         { symbol: "BTC", name: "Bitcoin" },
         { symbol: "LTC", name: "Litecoin" },
         { symbol: "FTC", name: "Feathercoin" },

--- a/share/spice/cryptocurrency/cryptocurrencylist.txt
+++ b/share/spice/cryptocurrency/cryptocurrencylist.txt
@@ -1,4 +1,5 @@
 btc,bitcoin,bit coin,
+bcc,bitcash,bitcoin cash,
 ftc,feathercoin,feather coin,
 ltc,litecoin,lite coin,
 blk,blackcoin,black coin,

--- a/t/Cryptocurrency.t
+++ b/t/Cryptocurrency.t
@@ -75,6 +75,18 @@ ddg_spice_test(
         caller => 'DDG::Spice::Cryptocurrency',
         is_cached => 0
     ),
+    'bitcoin cash to bitcoin' => test_spice(
+        '/js/spice/cryptocurrency/ticker/bcc-btc/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::Cryptocurrency',
+        is_cached => 0
+    ),
+    'bitcoin cash' => test_spice(
+        '/js/spice/cryptocurrency/ticker/bcc-usd/1',
+        call_type => 'include',
+        caller => 'DDG::Spice::Cryptocurrency',
+        is_cached => 0
+    ),
 
     # location dependant tests
     DDG::Request->new(


### PR DESCRIPTION
## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
Adds [Bitcoin cash](https://www.bitcoincash.org/)

![screen shot 2017-08-01 at 9 24 47 pm](https://user-images.githubusercontent.com/8960296/28845520-412a488c-7700-11e7-9257-11aa2c9137fb.png)
![screen shot 2017-08-01 at 9 24 06 pm](https://user-images.githubusercontent.com/8960296/28845521-412e3f78-7700-11e7-9102-4ecfdac30cd8.png)


## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->


## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@moollaza 
<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/cryptocurrency
<!-- FILL THIS IN:                           ^^^^ -->
