### PR TITLE
Flights::Route under 5.24 push on arrayref is forbidden

### DIFF
--- a/lib/DDG/Spice/Flights/Route.pm
+++ b/lib/DDG/Spice/Flights/Route.pm
@@ -36,7 +36,7 @@ foreach my $line (share('cities.csv')->slurp) {
     # map city names to their airport codes; if this city name
     # already exists, append the new airport code to the end
     if (exists $citiesByName{$cityName}) {
-        push($citiesByName{$cityName}, $airportCode);
+        push(@{$citiesByName{$cityName}}, $airportCode);
     } else {
         $citiesByName{$cityName} = [$airportCode];
     }
@@ -54,7 +54,7 @@ foreach my $line (share('cities.csv')->slurp) {
 
     if ($strippedAirportName ne $cityName) {
         if (exists $citiesByName{$strippedAirportName}) {
-            push($citiesByName{$strippedAirportName}, $airportCode);
+            push(@{$citiesByName{$strippedAirportName}}, $airportCode);
         } else {
             $citiesByName{$strippedAirportName} = [$airportCode];
         }


### PR DESCRIPTION
Part-fixes: https://github.com/duckduckgo/zeroclickinfo-spice/issues/3396

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/route
<!-- FILL THIS IN:                           ^^^^ -->
