### PR TITLE
New Terms of Service; Didn't Read Spice

### DIFF
--- a/lib/DDG/Spice/TermsOfService.pm
+++ b/lib/DDG/Spice/TermsOfService.pm
@@ -1,0 +1,25 @@
+package DDG::Spice::TermsOfService;
+
+# ABSTRACT: Provide definitions and meanings for emoji characters.
+
+use strict;
+use utf8;
+use DDG::Spice;
+
+spice is_cached => 1;
+spice proxy_cache_valid => "200 1d";
+
+spice wrap_jsonp_callback => 1;
+
+spice to => 'https://tosdr.org/api/1/service/$1.json';
+
+
+triggers startend => "terms of service", "summary tos";
+
+
+handle remainder => sub {
+    return $_ if $_;
+    return;
+};
+
+1;

--- a/share/spice/terms_of_service/terms_of_service.js
+++ b/share/spice/terms_of_service/terms_of_service.js
@@ -1,0 +1,31 @@
+(function (env) {
+    "use strict";
+    env.ddg_spice_terms_of_service = function(api_result){
+        
+        if (!api_result || api_result.error) {
+            return Spice.failed('terms_of_service');
+        }
+
+        Spice.add({
+            id: "terms_of_service",
+            name: "Terms of Service",
+            data: api_result,
+            meta: {
+                sourceName: "Terms of Service; Didn't Read",
+                sourceUrl: 'http://tosdr.org'
+            },
+            normalize: function(item) {
+                return {
+                    title: "Class " + item.class,
+                    
+                };
+            },
+            templates: {
+                group: 'info'
+//                 options: {
+//                     content: Spice.terms_of_service.content
+//                 }
+            }
+        });
+    };
+}(this));

--- a/share/spice/terms_of_service/terms_of_service.js
+++ b/share/spice/terms_of_service/terms_of_service.js
@@ -1,15 +1,13 @@
-(function (env) {
+(function(env) {
     "use strict";
-    env.ddg_spice_terms_of_service = function(api_result){
-        
-        if (!api_result || api_result.error) {
+    env.ddg_spice_terms_of_service = function(api_result) {
+        if(!api_result || api_result.error) {
             return Spice.failed('terms_of_service');
         }
         var script = $('[src*="/js/spice/terms_of_service/"]')[0],
-        source = $(script).attr("src"),
-        query = source.match(/terms_of_service\/([^\/]+)/)[1],
-        decodedQuery = decodeURIComponent(query);
-        
+            source = $(script).attr("src"),
+            query = source.match(/terms_of_service\/([^\/]+)/)[1],
+            decodedQuery = decodeURIComponent(query);
         Spice.add({
             id: "terms_of_service",
             name: "Terms of Service",
@@ -20,17 +18,34 @@
             },
             normalize: function(item) {
                 var tldrresult = (item.pointsData[item.points[0]].tosdr.tldr);
-                if (item.class == false) {
+                var rating;
+                switch(item.class) {
+                    case "A":
+                        rating = "Very good";
+                        break;
+                    case "B":
+                        rating = "Good";
+                        break;
+                    case "C":
+                        rating = "Fair";
+                        break;
+                    case "D":
+                        rating = "Poor";
+                        break;
+                    case "E":
+                        rating = "Very poor";
+                        break;
+                }
+                if(item.class == false) {
                     return {
                         title: "No classification yet",
                         description: tldrresult
                     }
-                }
-                else {
-                return {
-                    title: "Class " + item.class,
-                    description: tldrresult
-                };
+                } else {
+                    return {
+                        title: "Class " + item.class + " (" + rating + ")",
+                        description: tldrresult
+                    };
                 }
             },
             templates: {

--- a/share/spice/terms_of_service/terms_of_service.js
+++ b/share/spice/terms_of_service/terms_of_service.js
@@ -22,9 +22,6 @@
             },
             templates: {
                 group: 'info'
-//                 options: {
-//                     content: Spice.terms_of_service.content
-//                 }
             }
         });
     };

--- a/share/spice/terms_of_service/terms_of_service.js
+++ b/share/spice/terms_of_service/terms_of_service.js
@@ -9,6 +9,7 @@
         source = $(script).attr("src"),
         query = source.match(/terms_of_service\/([^\/]+)/)[1],
         decodedQuery = decodeURIComponent(query);
+        
         Spice.add({
             id: "terms_of_service",
             name: "Terms of Service",
@@ -18,17 +19,17 @@
                 sourceUrl: 'https://tosdr.org#' + decodedQuery
             },
             normalize: function(item) {
+                var tldrresult = (item.pointsData[item.points[0]].tosdr.tldr);
                 if (item.class == false) {
                     return {
                         title: "No classification yet",
-                        description: "TOS;DR evaluates company terms of services with class-based ratings from A to E."
-                        
+                        description: tldrresult
                     }
                 }
                 else {
                 return {
                     title: "Class " + item.class,
-                    description: "TOS;DR evaluates company terms of services with class-based ratings from A to E."
+                    description: tldrresult
                 };
                 }
             },

--- a/share/spice/terms_of_service/terms_of_service.js
+++ b/share/spice/terms_of_service/terms_of_service.js
@@ -5,20 +5,32 @@
         if (!api_result || api_result.error) {
             return Spice.failed('terms_of_service');
         }
-
+        var script = $('[src*="/js/spice/terms_of_service/"]')[0],
+        source = $(script).attr("src"),
+        query = source.match(/terms_of_service\/([^\/]+)/)[1],
+        decodedQuery = decodeURIComponent(query);
         Spice.add({
             id: "terms_of_service",
             name: "Terms of Service",
             data: api_result,
             meta: {
                 sourceName: "Terms of Service; Didn't Read",
-                sourceUrl: 'http://tosdr.org'
+                sourceUrl: 'https://tosdr.org#' + decodedQuery
             },
             normalize: function(item) {
+                if (item.class == false) {
+                    return {
+                        title: "No classification yet",
+                        description: "TOS;DR evaluates company terms of services with class-based ratings from A to E."
+                        
+                    }
+                }
+                else {
                 return {
                     title: "Class " + item.class,
-                    
+                    description: "TOS;DR evaluates company terms of services with class-based ratings from A to E."
                 };
+                }
             },
             templates: {
                 group: 'info'

--- a/t/TermsOfService.t
+++ b/t/TermsOfService.t
@@ -9,17 +9,17 @@ spice is_cached => 1;
 
 ddg_spice_test(
     [qw( DDG::Spice::TermsOfService)],
-    # At a minimum, be sure to include tests for all:
-    # - primary_example_queries
-    # - secondary_example_queries
-    'example query' => test_spice(
-        '/js/spice/terms_of_service/query',
+    'terms of service duckduckgo' => test_spice(
+        '/js/spice/terms_of_service/duckduckgo',
         call_type => 'include',
         caller => 'DDG::Spice::TermsOfService'
     ),
-    # Try to include some examples of queries on which it might
-    # appear that your answer will trigger, but does not.
-    'bad example query' => undef,
+    'summary tos twitter' => test_spice(
+        '/js/spice/terms_of_service/twitter',
+        call_type => 'include',
+        caller => 'DDG::Spice::TermsOfService'
+    ),
+    'terms for citizenship of the united states' => undef,
 );
 
 done_testing;

--- a/t/TermsOfService.t
+++ b/t/TermsOfService.t
@@ -1,0 +1,26 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+spice is_cached => 1;
+
+ddg_spice_test(
+    [qw( DDG::Spice::TermsOfService)],
+    # At a minimum, be sure to include tests for all:
+    # - primary_example_queries
+    # - secondary_example_queries
+    'example query' => test_spice(
+        '/js/spice/terms_of_service/query',
+        call_type => 'include',
+        caller => 'DDG::Spice::TermsOfService'
+    ),
+    # Try to include some examples of queries on which it might
+    # appear that your answer will trigger, but does not.
+    'bad example query' => undef,
+);
+
+done_testing;
+


### PR DESCRIPTION
## Description of new Instant Answer, or changes
Creates a Terms of Service; Didn't Read spice. Fetches and displays API data from tosdr.org on company terms of services and privacy policies. 


## Related Issues and Discussions
Currently has only very basic functionality. The JSON response generated by the TOS;DR API has kind of weird formatting, and it's a little hard to parse. Also not sure what other information I should add to this IA. 


## People to notify
@duckduckgo/community-leaders 

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/terms_of_service_didn_t_read
<!-- FILL THIS IN:                           ^^^^ -->

It's good to be back. 