### PR TITLE
Fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - npm install -g uglify-js handlebars
   - cpanm --quiet --notest Dist::Zilla
   - dzil authordeps | grep -ve '^\W' | cpanm --quiet --notest --mirror http://www.cpan.org/ --mirror http://duckpan.org --mirror-only
-- dzil listdeps | grep -ve '^\W' | cpanm --quiet --notest --mirror http://www.cpan.org --mirror http://duckpan.org --mirror-onlylanguage: perl
+  - dzil listdeps | grep -ve '^\W' | cpanm --quiet --notest --mirror http://www.cpan.org --mirror http://duckpan.org --mirror-onlylanguage: perl
 perl:
   - 5.16
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ install:
   - npm install -g uglify-js handlebars
   - cpanm --quiet --notest Dist::Zilla
   - dzil authordeps | grep -ve '^\W' | cpanm --quiet --notest --mirror http://www.cpan.org/ --mirror http://duckpan.org --mirror-only
-  - dzil listdeps | grep -ve '^\W' | cpanm --quiet --notest --mirror http://www.cpan.org --mirror http://duckpan.org --mirror-onlylanguage: perl
+  - dzil listdeps | grep -ve '^\W' | cpanm --quiet --notest --mirror http://www.cpan.org --mirror http://duckpan.org --mirror-only
+language: perl
 perl:
   - 5.16
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,8 @@ before_install:
 install:
   - npm install -g uglify-js handlebars
   - cpanm --quiet --notest Dist::Zilla
-  - dzil authordeps | grep -ve '^\W' | cpanm --notest --quiet --mirror http://www.cpan.org/ --mirror http://duckpan.org
-  - dzil listdeps | grep -ve '^\W' | cpanm --notest --quiet --mirror http://www.cpan.org/ --mirror http://duckpan.org
-language: perl
+  - dzil authordeps | grep -ve '^\W' | cpanm --quiet --notest --mirror http://www.cpan.org/ --mirror http://duckpan.org --mirror-only
+- dzil listdeps | grep -ve '^\W' | cpanm --quiet --notest --mirror http://www.cpan.org --mirror http://duckpan.org --mirror-onlylanguage: perl
 perl:
   - 5.16
 script:


### PR DESCRIPTION
## Description of new Instant Answer, or changes

Ensure `DZP::AutoModuleShareDirs` installs newest version from Duckpan.org instead of BackPAN. This will ensure `listdeps` works and all dependencies are installed.

/cc @zachthompson 