### PR TITLE
News (related to internal change): add answerType

### DIFF
--- a/share/spice/news/news.js
+++ b/share/spice/news/news.js
@@ -93,6 +93,7 @@
             name: 'News',
             data: goodStories,
             ads: api_result.ads,
+            answerType: 'News',
             meta: {
                 idField: 'url',
                 count: goodStories.length,


### PR DESCRIPTION

## Description of new Instant Answer, or changes
Making sure answerType is specified for News, because of the internal changes to the model.


## Related Issues and Discussions
See asana


## People to notify
@bsstoner 


<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/news
<!-- FILL THIS IN:                           ^^^^ -->
