### PR TITLE
Currency: Add alias pounds sterling to gbp

### DIFF
--- a/share/spice/currency/currencyNames.txt
+++ b/share/spice/currency/currencyNames.txt
@@ -44,7 +44,7 @@ etb,ethiopian birr,ethiopia birr,
 eur,euro,euros,
 fjd,fijian dollar,fiji dollar,
 fkp,falkland island pound,
-gbp,british pound,united kingdom pound,uk pound,uk pounds,pound,sterling,pound sterling
+gbp,british pound,united kingdom pound,uk pound,uk pounds,pound,sterling,pound sterling, pounds sterling
 gel,georgian lari,georgia lari,
 ggp,guernsey pound,guernsey pound,
 ghs,ghanaian cedi,ghana cedi,

--- a/t/Currency.t
+++ b/t/Currency.t
@@ -379,6 +379,12 @@ ddg_spice_test(
         caller => 'DDG::Spice::Currency',
         is_cached => 0
     ),
+    '71.42 pounds sterling to usd' => test_spice(
+        '/js/spice/currency/71.42/gbp/usd',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
 		# testing addition of rur alias
     '600 usd in rur' => test_spice(
         '/js/spice/currency/600/usd/rub',


### PR DESCRIPTION
<!-- 

***
DuckDuckHack is currently in Maintenance mode
Please read before submitting: https://duckduckhack.com
***

Use the appropriate format for your Pull Request title above ^^^^^:

If this is a bug fix:
{IA Name}: {Description of change}

If this is a New Instant Answer:
New {IA Name} Spice

If this is something else:
{Tests/Docs/Other}: {Short Description}

-->

## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
Adds alias "pounds sterling" and test

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->
Fixes #3438 

## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@pjhampton @moollaza 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/currency
<!-- FILL THIS IN:                           ^^^^ -->
