### PR TITLE
Add new trigger for What3Words

### DIFF
--- a/lib/DDG/Spice/What3Words.pm
+++ b/lib/DDG/Spice/What3Words.pm
@@ -21,7 +21,7 @@ my $coord_re = qr/[+-]?[0-9]+(?:\.\d{1,6})?/;
 
 # Handles queries like:
 # what3words | w3w | what three words word.word.word
-triggers query_lc => qr/^(?:$w3w_re)(\p{L}{4,}+\.\p{L}{4,}+\.\p{L}{1,}+)$/i;
+triggers query_lc => qr!^(?:$w3w_re|///\s*)(\p{L}{4,}+\.\p{L}{4,}+\.\p{L}{1,}+)$!i;
 
 # Handles queries like:
 # what3words | w3w | what three words +/-##.####, +/-###.#####

--- a/lib/DDG/Spice/What3Words.pm
+++ b/lib/DDG/Spice/What3Words.pm
@@ -21,7 +21,7 @@ my $coord_re = qr/[+-]?[0-9]+(?:\.\d{1,6})?/;
 
 # Handles queries like:
 # what3words | w3w | what three words word.word.word
-triggers query_lc => qr!^(?:$w3w_re|///\s*)(\p{L}{4,}+\.\p{L}{4,}+\.\p{L}{1,}+)$!i;
+triggers query_lc => qr!^(?:$w3w_re|///\s)(\p{L}{4,}+\.\p{L}{4,}+\.\p{L}{1,}+)$!i;
 
 # Handles queries like:
 # what3words | w3w | what three words +/-##.####, +/-###.#####

--- a/t/What3Words.t
+++ b/t/What3Words.t
@@ -14,6 +14,11 @@ ddg_spice_test(
         call_type => 'include',
         caller => 'DDG::Spice::What3Words'
     ),
+    '/// veal.notion.loses' => test_spice(
+        '/js/spice/what3words/forward/addr/veal.notion.loses',
+        call_type => 'include',
+        caller => 'DDG::Spice::What3Words'
+    ),
     'what three words veal.notion.loses' => test_spice(
         '/js/spice/what3words/forward/addr/veal.notion.loses',
         call_type => 'include',


### PR DESCRIPTION
## Description of new Instant Answer, or changes
Adds new trigger to support the companies new approach to handling addresses.


<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/what3words
<!-- FILL THIS IN:                           ^^^^ -->
