### PR TITLE
dictionary_definition: Use HTTPS URL

### DIFF
--- a/share/spice/dictionary/definition/dictionary_definition.js
+++ b/share/spice/dictionary/definition/dictionary_definition.js
@@ -58,7 +58,7 @@ var ddg_spice_dictionary = {
 
             meta: {
                 sourceName: "Wordnik",
-                sourceUrl : "http://www.wordnik.com/words/" + word,
+                sourceUrl : "https://www.wordnik.com/words/" + word,
                 attributionText: definitions[0].attributionText
             },
 


### PR DESCRIPTION
## Description of Instant Answer changes
Change URL to use HTTPS instead of HTTP

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/dictionary_definition
<!-- FILL THIS IN:                           ^^^^ -->
