### PR TITLE
Force JS ContentType for Wordnik API responses

### DIFF
--- a/lib/DDG/Spice/RandPOS.pm
+++ b/lib/DDG/Spice/RandPOS.pm
@@ -7,6 +7,7 @@ use Text::Trim;
 spice from => '([^/]+)/?(?:([^/]+)/?(?:([^/]+)|)|)';
 spice to => 'http://api.wordnik.com/v4/words.json/randomWords?includePartOfSpeech=$1&minCorpusCount=10000&limit=$2&api_key={{ENV{DDG_SPICE_WORDNIK_APIKEY}}}&callback={{callback}}';
 spice proxy_cache_valid => '418 1d';
+spice content_type_javascript => 1;
 
 # List of all trigger words
 my @triggerWords = map { ($_, $_."s") } qw(noun verb adjective pronoun preposition conjunction adverb);

--- a/lib/DDG/Spice/RandWord.pm
+++ b/lib/DDG/Spice/RandWord.pm
@@ -8,6 +8,7 @@ use List::Util 'min';
 spice from => '(?:([0-9]+)\-([0-9]+)\-([0-9]+))';
 spice to => 'http://api.wordnik.com/v4/words.json/randomWords?minLength=$1&maxLength=$2&limit=$3&api_key={{ENV{DDG_SPICE_WORDNIK_APIKEY}}}&callback={{callback}}';
 spice proxy_cache_valid => "418 1d";
+spice content_type_javascript => 1;
 
 triggers any => "random word", "random words";
 

--- a/lib/DDG/Spice/WordOfTheDay.pm
+++ b/lib/DDG/Spice/WordOfTheDay.pm
@@ -6,10 +6,9 @@ use DDG::Spice;
 
 spice is_cached => 1;
 spice proxy_cache_valid => "200 1d";
-
 spice wrap_jsonp_callback => 1;
+spice content_type_javascript => 1;
 
-# for testing, run: DDG_SPICE_WORDNIK_APIKEY=a2a73e7b926c924fad7001ca3111acd55af2ffabf50eb4ae5 duckpan server
 spice to => 'http://api.wordnik.com/v4/words.json/wordOfTheDay?api_key={{ENV{DDG_SPICE_WORDNIK_APIKEY}}}';
 
 triggers start =>
@@ -19,9 +18,7 @@ triggers start =>
     'what is the word of the day';
 
 handle remainder => sub {
-    
     return unless $_ eq '';
-    
     return $_;
 };
 


### PR DESCRIPTION
## Description of new Instant Answer, or changes
Forces correct content-type for API responses from Wordnik

## Related Issues and Discussions
Fixes #3466 

## People to notify
@x-15a2 


<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Pages:
- https://duck.co/ia/view/RandWord
- https://duck.co/ia/view/RandPOS
- https://duck.co/ia/view/WordOfTheDay
<!-- FILL THIS IN:                           ^^^^ -->
