### PR TITLE
Tor Node: Updates name and URLs for Tor Metrics Relay Search (Fixes: #3491)

### DIFF
--- a/share/spice/tor_node/tor_node.js
+++ b/share/spice/tor_node/tor_node.js
@@ -45,7 +45,7 @@
                 node.bandwidth = prettifyBitrate(node.advertised_bandwidth);
             }
 
-            node.url = "https://atlas.torproject.org/#details/" + node.ref;
+            node.url = "https://metrics.torproject.org/rs.html#details/" + node.ref;
         }
 
         var spice = {
@@ -53,8 +53,8 @@
             name: "Tor Node",
             nodes: nodes,
             meta: {
-                sourceName: "Tor Atlas",
-                sourceUrl: "https://atlas.torproject.org/#search/" + query,
+                sourceName: "Tor Metrics Relay Search",
+                sourceUrl: "https://metrics.torproject.org/rs.html#search/" + query,
                 itemType: "Nodes"
             },
             templates: {


### PR DESCRIPTION
## Description of new Instant Answer, or changes

Fixes the URLs for Tor Relay Search, the old URLs will stop working at some time in the future. If this is not merged, the links will simply stop working when the old URLs are turned off.

## Related Issues and Discussions

Fixes #3491

## People to notify

@mogigoma
---

Instant Answer Page: https://duck.co/ia/view/tor_node