### PR TITLE
Forecast Spice: Added more foreign trigger words

### DIFF
--- a/lib/DDG/Spice/Forecast.pm
+++ b/lib/DDG/Spice/Forecast.pm
@@ -5,7 +5,7 @@ use strict;
 use DDG::Spice;
 use Text::Trim;
 
-triggers start => "weather", "forecast", "weather forecast", "weer", "meteo", "wetter", "clima", "tiempo", "météo";
+triggers start => "weather", "forecast", "weather forecast", "weer", "meteo", "wetter", "clima", "tiempo", "météo", "天気", "天气";
 
 spice from => '([^/]*)/?([^/]*)';
 spice to => 'https://darksky.net/ddg?apikey={{ENV{DDG_SPICE_FORECAST_APIKEY}}}&q=$1&callback={{callback}}&lang=$2';


### PR DESCRIPTION
<!-- 

***
DuckDuckHack is currently in Maintenance mode
Please read before submitting: https://duckduckhack.com
***

Use the appropriate format for your Pull Request title above ^^^^^:

If this is a bug fix:
{IA Name}: {Description of change}

If this is a New Instant Answer:
New {IA Name} Spice

If this is something else:
{Tests/Docs/Other}: {Short Description}

-->

## Description of new Instant Answer, or changes
Enables Japanese, Simplified Chinese and Traditional Chinese trigger words for weather, in addition to existing French, German, Italian, etc.
Non-Roman alphabet city names are already recognised, e.g. [weather 東京](https://duckduckgo.com/?q=weather+%E6%9D%B1%E4%BA%AC&ia=weather)

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->

## People to notify
<!-- Please @mention any relevant people/organizations here: -->

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/forecast
<!-- FILL THIS IN:                           ^^^^ -->
