### PR TITLE
Whois: Update API endpoint to version 2.0

### DIFF
--- a/lib/DDG/Spice/Whois.pm
+++ b/lib/DDG/Spice/Whois.pm
@@ -9,7 +9,7 @@ use Text::Trim;
 triggers any => "whois", "lookup", "domain", "is domain", "available", "is available", "register", "owner", "owner of", "who owns", "buy", "how to buy";
 
 # API call details for Whois API (http://www.whoisxmlapi.com/)
-spice to => 'http://www.whoisxmlapi.com/whoisserver/WhoisService?domainName=$1&outputFormat=JSON&callback={{callback}}&username={{ENV{DDG_SPICE_WHOIS_USERNAME}}}&password={{ENV{DDG_SPICE_WHOIS_PASSWORD}}}';
+spice to => 'https://www.whoisxmlapi.com/whoisserver/WhoisService?domainName=$1&outputFormat=JSON&callback={{callback}}&apiKey={{ENV{DDG_SPICE_WHOIS_APIKEY}}}';
 
 handle remainder_lc => sub {
 


### PR DESCRIPTION
<!-- 

***
DuckDuckHack is currently in Maintenance mode
Please read before submitting: https://duckduckhack.com
***

Use the appropriate format for your Pull Request title above ^^^^^:

If this is a bug fix:
{IA Name}: {Description of change}

If this is a New Instant Answer:
New {IA Name} Spice

If this is something else:
{Tests/Docs/Other}: {Short Description}

-->

## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
The current API endpoint for WHOIS searches uses version 1.0, which is obsolete according to https://www.whoisxmlapi.com/whois-api-guide.php. This fix changes the endpoint to version 2.0, which requires an API key, instead of the previous username and password. The 2.0 docs can be found [here](https://whoisapi.whoisxmlapi.com/docs).

All tests are continue to pass on duckpan with only this change. The required API key has been named `DDG_SPICE_WHOIS_APIKEY`.

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->
Fixes #3518 

## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@b1ake @moollaza 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/whois
<!-- FILL THIS IN:                           ^^^^ -->
