### PR TITLE
MagicTheGathering: Move from deprecated Deckbrew API to Scryfall API

### DIFF
--- a/lib/DDG/Spice/MagicTheGathering.pm
+++ b/lib/DDG/Spice/MagicTheGathering.pm
@@ -6,11 +6,11 @@ use strict;
 use DDG::Spice;
 
 spice is_cached => 1;
-spice proxy_cache_valid => "200 1d";
+spice proxy_cache_valid => "200 1w";
 
 spice wrap_jsonp_callback => 1;
 
-spice to => 'https://api.deckbrew.com/mtg/cards?name=$1';
+spice to => 'https://api.scryfall.com/cards/search?q=$1';
 
 triggers startend => 'magic card', 'mtg', 'magic: the gathering', 'magic the gathering';
 

--- a/share/spice/magic_the_gathering/footer.handlebars
+++ b/share/spice/magic_the_gathering/footer.handlebars
@@ -1,5 +1,5 @@
 <div class="pull-left">
-    <span class="magic-types">{{types}}</span>
+    <span class="card-artist">{{artist}}</span>
 </div>
 {{#if rarity}}
 <div class="pull-right">

--- a/share/spice/magic_the_gathering/magic_the_gathering.js
+++ b/share/spice/magic_the_gathering/magic_the_gathering.js
@@ -1,23 +1,9 @@
 (function (env) {
     "use strict";
 
-    /**
-     * Get the search term from the DDG query that triggered this IA.
-     *
-     * @return {String} The unencoded search term without the IA trigger words.
-     */
-    function getSearchTerm() {
-        var query = DDG.get_query();
-        var triggers = [
-            'magic card',
-            'mtg',
-            'magic: the gathering',
-            'magic the gathering'
-        ];
-        return query.replace(new RegExp(triggers.join('|')), '').trim();
-var query = DDG.get_query(),
-    triggerRe = /mtg|magic:? (card|the gathering)/ig,
-    searchTerm = query.replace(triggerRe, '').trim();
+    var query = DDG.get_query(),
+        triggerRe = /mtg|magic:? (card|the gathering)/ig,
+        searchTerm = query.replace(triggerRe, '').trim();
 
     env.ddg_spice_magic_the_gathering = function(api_result){
         // Validate the response (customize for your Spice)
@@ -34,13 +20,13 @@ var query = DDG.get_query(),
                 itemType: "Cards",
                 sourceName: "Scryfall",
                 sourceUrl: "https://scryfall.com/search?q="
-                    + encodeURIComponent(getSearchTerm()),
-                searchTerm: getSearchTerm(),
+                    + encodeURIComponent(searchTerm),
+                searchTerm: searchTerm,
                 count: api_result.data.length,
                 snippetChars: 150
             },
             normalize: function(item) {
-                if (item.name === DDG.get_query()){
+                if (item.name === query){
                     item.exactMatch = true;
 
                 }

--- a/share/spice/magic_the_gathering/magic_the_gathering.js
+++ b/share/spice/magic_the_gathering/magic_the_gathering.js
@@ -31,7 +31,8 @@
             meta: {
                 itemType: "Cards",
                 sourceName: "Scryfall",
-                sourceUrl: "https://scryfall.com/search?q=" + encodeURI(getSearchTerm()),
+                sourceUrl: "https://scryfall.com/search?q="
+                    + encodeURIComponent(getSearchTerm()),
                 searchTerm: getSearchTerm(),
                 count: api_result.data.length,
                 snippetChars: 150

--- a/share/spice/magic_the_gathering/magic_the_gathering.js
+++ b/share/spice/magic_the_gathering/magic_the_gathering.js
@@ -15,7 +15,9 @@
             'magic the gathering'
         ];
         return query.replace(new RegExp(triggers.join('|')), '').trim();
-    }
+var query = DDG.get_query(),
+    triggerRe = /mtg|magic:? (card|the gathering)/ig,
+    searchTerm = query.replace(triggerRe, '').trim();
 
     env.ddg_spice_magic_the_gathering = function(api_result){
         // Validate the response (customize for your Spice)

--- a/share/spice/magic_the_gathering/magic_the_gathering.js
+++ b/share/spice/magic_the_gathering/magic_the_gathering.js
@@ -1,8 +1,25 @@
 (function (env) {
     "use strict";
+
+    /**
+     * Get the search term from the DDG query that triggered this IA.
+     *
+     * @return {String} The unencoded search term without the IA trigger words.
+     */
+    function getSearchTerm() {
+        var query = DDG.get_query();
+        var triggers = [
+            'magic card',
+            'mtg',
+            'magic: the gathering',
+            'magic the gathering'
+        ];
+        return query.replace(new RegExp(triggers.join('|')), '').trim();
+    }
+
     env.ddg_spice_magic_the_gathering = function(api_result){
         // Validate the response (customize for your Spice)
-        if (!api_result || api_result.error) {
+        if (!api_result || api_result.error || api_result.object === 'error') {
             return Spice.failed('magic_the_gathering');
         }
 
@@ -10,36 +27,48 @@
         Spice.add({
             id: "magic_the_gathering",
             name: "Games",
-            data: api_result,
+            data: api_result.data,
             meta: {
                 itemType: "Cards",
-                sourceName: "Deckbrew.com",
-                sourceUrl: "http://deckbrew.com/api/",
-                count: api_result.length,
-                snippetChars: 120
+                sourceName: "Scryfall",
+                sourceUrl: "https://scryfall.com/search?q=" + encodeURI(getSearchTerm()),
+                searchTerm: getSearchTerm(),
+                count: api_result.data.length,
+                snippetChars: 150
             },
             normalize: function(item) {
                 if (item.name === DDG.get_query()){
                     item.exactMatch = true;
 
                 }
-                var card_image = DDG.toHTTP(item.editions[0].image_url);
+
+                // the template calls a .set() function on the item, so change
+                // the 'set' field in the item so an error isn't thrown
+                item['set_label'] = item.set;
+                delete item.set;
+                var card_image = item.image_uris
+                            ? DDG.toHTTPS(item.image_uris.png)
+                            : "";
+                var classify = item.type_line.split('—');
+                var type = classify[0] ? classify[0].trim() : ' ';
+                var subtype = classify[1] ? classify[1].trim() : ' ';
                 var infoboxData = [
                     { heading: "Card Details" },
-                    { label: "Types", value: item.types },
-                    { label: "Subtypes", value: item.subtypes },
+                    { label: "Types", value: type },
+                    { label: "Subtypes", value: subtype },
                     { label: "Colors", value: item.colors },
                     { label: "CMC", value: item.cmc },
-                    { label: "Cost", value: item.cost },
+                    { label: "Cost", value: item.mana_cost },
                     { label: "Power", value: item.power },
                     { label: "Toughness", value: item.toughness }
                 ];
                 return {
                     title: item.name,
-                    description: item.text ? item.text : "No description",
-                    types: item.types,
-                    altSubtitle: item.subtypes ? item.subtypes : " ",
-                    url: item.editions[0].store_url,
+                    description: item.oracle_text ? item.oracle_text : "No description",
+                    artist: 'Illus. ' + item.artist,
+                    subtitle: subtype,
+                    altSubtitle: type,
+                    url: DDG.toHTTPS(item.scryfall_uri),
                     rarity: item.power ? item.power + "/" + item.toughness : null,
                     image: card_image,
                     infoboxData: infoboxData


### PR DESCRIPTION
<!-- 

***
DuckDuckHack is currently in Maintenance mode
Please read before submitting: https://duckduckhack.com
***

Use the appropriate format for your Pull Request title above ^^^^^:

If this is a bug fix:
{IA Name}: {Description of change}

If this is a New Instant Answer:
New {IA Name} Spice

If this is something else:
{Tests/Docs/Other}: {Short Description}

-->

## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
According to https://redd.it/7j0s7g, the Deckbrew API shut down on May 1, 2018. There, the API developer suggested using Scryfall's API for future projects. This PR adds support for the Scryfall API to the Magic: The Gathering IA.

Some things DDG might want to clarify with Scryfall:
### [Scryfall Data Usage Guidelines](https://scryfall.com/docs/api#use-of-scryfall-data)
The Scryfall API is free to use for the purposes of searching cards, and this IA is only searching for cards. The guidelines do say:
> You may not use Scryfall logos or use the Scryfall name in a way that implies Scryfall has endorsed you, your work, or your product.

I am not sure if the "More at Scryfall" link, and the favicon beside it, would indicate endorsement.

### [Scryfall Image guidelines](https://scryfall.com/docs/api/images#image-guidelines)
> Do not cover, crop, or clip off the copyright or artist name on card images.

The `media` template and some CSS does crop the card image when multiple card results are returned from the API, but the full card image can be seen when the individual items are clicked and the `media_item_detail` template is shown. While multiple cards are being shown, each card also lists the illustrator. The full card is also shown when one card result is returned from the API, and the `basic_info_detail` template is shown.

I think these details satisfy the following from the image guidelines:
> List the artist name and copyright elsewhere in the same interface presenting the art crop, or use the full card image elsewhere in the same interface. Users should be able to identify the artist and source of the image somehow.

More information on how to contact Scryfall can be found at https://scryfall.com/docs/contact.

## Images
![mtg-basic-info-detail](https://user-images.githubusercontent.com/29383537/43993965-1233c712-9d63-11e8-9d7d-48c6096a0d78.png)
![mtg-media-item-detail](https://user-images.githubusercontent.com/29383537/43993966-124f618e-9d63-11e8-9020-e74a220c92e7.png)
![mtg-media-items](https://user-images.githubusercontent.com/29383537/43993967-12605124-9d63-11e8-9591-d1048e8d82e9.png)
## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->


## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@alohaas @moollaza 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/magic_the_gathering
<!-- FILL THIS IN:                           ^^^^ -->
