### PR TITLE
Just Delete Me: Switch to new API

### DIFF
--- a/lib/DDG/Spice/JustDeleteMe.pm
+++ b/lib/DDG/Spice/JustDeleteMe.pm
@@ -5,7 +5,7 @@ package DDG::Spice::JustDeleteMe;
 use DDG::Spice;
 spice is_cached => 1;
 spice wrap_jsonp_callback => 1;
-spice to => 'https://raw.githubusercontent.com/rmlewisuk/justdelete.me/master/sites.json';
+spice to => 'https://raw.githubusercontent.com/jdm-contrib/jdm/master/_data/sites.json';
 
 my $MIN_QUERY_LENGTH = 4;
 my @tr = qw (delete cancel remove);

--- a/share/spice/just_delete_me/just_delete_me.js
+++ b/share/spice/just_delete_me/just_delete_me.js
@@ -44,14 +44,14 @@
             name: "Answer",
             meta: {
                 sourceName: 'Just Delete Me',
-                sourceUrl: "http://justdelete.me/#" + decodedQuery
+                sourceUrl: "http://justdeleteme.xyz/#" + decodedQuery
             },
             data: api_result,
             normalize: function(item) {
                 return {
                     delete_url: item.url,
                     title: item.name,
-                    url: "http://justdelete.me/#" + item.name,
+                    url: "http://justdeleteme.xyz/#" + item.name,
                     subtitle: "Difficulty: " + DDG.capitalize(item.difficulty),
                     description: item.notes  ? item.notes :
                                  item.email  ? "Send an email to the provided address to delete your account." :


### PR DESCRIPTION
## Description of new Instant Answer, or changes
Justdelete.me, the current data source, has been abandoned. The community has created a fork
here that is being updated with new information. Changes the data source for just delete me from http://justdelete.me/# to http://justdeleteme.xyz/#

## Related Issues and Discussions
Fixes #3309


## People to notify
Maintainer: @riqpe
/cc @tupaschoal @neeklamy @PyroSamurai @katzrkool


<!-- DO NOT REMOVE -->
---

IA Page: http://duck.co/ia/view/just_delete_me
Maintainer: @riqpe
