### PR TITLE
Holiday: Normalize holiday data and query to handle 'day'

### DIFF
--- a/lib/DDG/Spice/Holiday.pm
+++ b/lib/DDG/Spice/Holiday.pm
@@ -68,6 +68,10 @@ handle query_lc => sub {
     $query =~ s/[^\w\s\-]//;
     $query =~ s/-/ /;
 
+    # Sanitize the query by replacing "day", eg:
+    #   "st patricks day" -> "st patricks"
+    $query =~ s/[[:space:]]day$//;
+
     # Extract holiday from query
     $query =~ s/(?<holiday>$triggers_re)//;
     $chosen_holiday = $+{holiday};

--- a/share/spice/holiday/countries/ad.txt
+++ b/share/spice/holiday/countries/ad.txt
@@ -1,12 +1,12 @@
-all saints day
-ascension day
+all saints
+ascension
 assumption of mary
 bank holiday
-boxing day
+boxing
 carnival
-christmas day
+christmas
 christmas eve
-constitution day
+constitution
 daylight saving time ends
 daylight saving time starts
 day of st charles borromeu
@@ -18,13 +18,13 @@ feast of the immaculate conception
 good friday
 holy saturday
 june solstice
-labour day
+labour
 march equinox
 maundy thursday
-may day
-midsummer day
-national day
-new years day
+may
+midsummer
+national
+new years
 new years eve
 september equinox
 whit monday

--- a/share/spice/holiday/countries/ae.txt
+++ b/share/spice/holiday/countries/ae.txt
@@ -6,16 +6,16 @@ eid al adha holiday
 eid al fitr
 end of ramadan
 feast of sacrifice
-haj day
+haj
 islamic new year
 june solstice
 leilat al meiraj
 march equinox
-martyrs day
+martyrs
 mouloud
-national day
+national
 national day holiday
-new years day
+new years
 new years eve
 ramadan begins
 september equinox

--- a/share/spice/holiday/countries/af.txt
+++ b/share/spice/holiday/countries/af.txt
@@ -1,12 +1,12 @@
-afghan victory day
+afghan victory
 ashura
 december solstice
 eid al fitr
 eid al qurban
-independence day
+independence
 june solstice
 march equinox
-national day
+national
 ramadan starts
 september equinox
 the prophets birthday

--- a/share/spice/holiday/countries/al.txt
+++ b/share/spice/holiday/countries/al.txt
@@ -1,4 +1,4 @@
-christmas day
+christmas
 christmas eve
 daylight saving time ends
 daylight saving time starts
@@ -8,24 +8,24 @@ easter saturday
 easter sunday
 eid al fitr
 end of ramadan
-fathers day
+fathers
 feast of the sacrifice
 good friday
 halloween
 holy saturday
-independence day
+independence
 june solstice
-labour day
-liberation day
+labour
+liberation
 march equinox
-may day
-mothers day
-mother teresa beatification day
-national youth day
-nevruz day
-new years day
+may
+mothers
+mother teresa beatification
+national youth
+nevruz
+new years
 new years eve
 orthodox
 september equinox
-summer day
-valentines day
+summer
+valentines

--- a/share/spice/holiday/countries/am.txt
+++ b/share/spice/holiday/countries/am.txt
@@ -1,32 +1,32 @@
-armenian christmas day
+armenian christmas
 armenian christmas eve
-army day
-childrens day
+army
+childrens
 congress
-constitution day
+constitution
 december solstice
 easter monday
 easter sunday
-fathers day
+fathers
 feast of saint vartan
-genocide remembrance day
+genocide remembrance
 good friday
 halloween
 holy saturday
-independence day
-international womens day
+independence
+international womens
 june solstice
-knowledge and literature day
-labour day
+knowledge and literature
+labour
 march equinox
-may day
-motherhood and beauty day
-new years day
+may
+motherhood and beauty
+new years
 new years eve
-republic day
+republic
 september equinox
-spitak remembrance day
-translators day
-valentines day
+spitak remembrance
+translators
+valentines
 vardavar
-victory and peace day
+victory and peace

--- a/share/spice/holiday/countries/ao.txt
+++ b/share/spice/holiday/countries/ao.txt
@@ -1,15 +1,15 @@
-all souls day
+all souls
 begin of the armed fight for national liberation
 carnival
-christmas day
+christmas
 december solstice
 good friday
-independence day
-international womans day
+independence
+international womans
 june solstice
 march equinox
-may day
-national hero day
+may
+national hero
 new year
-peace day
+peace
 september equinox

--- a/share/spice/holiday/countries/ar.txt
+++ b/share/spice/holiday/countries/ar.txt
@@ -1,33 +1,33 @@
 action day for tolerance and respect between people
 carnival
-christmas day
+christmas
 day of respect for cultural diversity
 day of the veterans
 december solstice
-easter day
+easter
 eid al adha
 end of ramadan
 feast of the immaculate conception
 first day of passover
-flag day
+flag
 good friday
-independence day
+independence
 june solstice
-labor day
+labor
 last day of passover
 march equinox
 maundy thursday
+may
 may 1810 revolution
-may day
-memorial day
+memorial
 muharram
-national day
-national sovereignty day
+national
+national sovereignty
 new year
-new years day
+new years
 new years eve
 rosh hashana
-san martín day
+san martín
 second day of rosh hashana
 september equinox
 shrove tuesday

--- a/share/spice/holiday/countries/at.txt
+++ b/share/spice/holiday/countries/at.txt
@@ -1,28 +1,28 @@
-all saints day
-all souls day
-ascension day
+all saints
+all souls
+ascension
 assumption of mary
-christmas day
+christmas
 christmas eve
 corpus christi
 daylight saving time ends
 daylight saving time starts
 december solstice
-easter day
+easter
 easter monday
 epiphany
 first sunday advent
 good friday
 immaculate conception
 june solstice
-labor day
+labor
 march equinox
-may day
-national day
-new years day
+may
+national
+new years
 new years eve
 palm sunday
 september equinox
-st stephens day
+st stephens
 whit monday
 whit sunday

--- a/share/spice/holiday/countries/au.txt
+++ b/share/spice/holiday/countries/au.txt
@@ -1,20 +1,19 @@
 adelaide cup
 afl grand final friday
-all saints day
-all souls day
-anzac day
-arbor day
-ascension day
+all saints
+all souls
+anzac
+arbor
+ascension
 ash wednesday
 assumption of mary
-australia day
-boxing day
+australia
+boxing
 boxing day holiday
-canberra day
+canberra
 carnival
 chinese new year
 christmas
-christmas day
 christmas eve
 corpus christi
 daylight saving time ends
@@ -22,15 +21,15 @@ daylight saving time starts
 december solstice
 deepavali
 diwali
-easter day
+easter
 easter monday
 easter tuesday
 eid al adha
 eid al fitr
-eight hours day
+eight hours
 epiphany
-family & community day
-fathers day
+family & community
+fathers
 feast of st francis of assisi
 feast of the immaculate conception
 first day of hanukkah
@@ -40,30 +39,30 @@ first day of sukkot
 first sunday of advent
 good friday
 halloween
-harmony day
+harmony
 holy saturday
 islamic new year
 isra and miraj
 june solstice
-labour day
+labour
 lag bomer
 last day of passover
 last day of sukkot
 laylat al qadr
 march equinox
 maundy thursday
-may day
-melbourne cup day
-mothers day
+may
+melbourne cup
+mothers
 muharram
-national close the gap day
-national sorry day
+national close the gap
+national sorry
 new south wales bank holiday
-new years day
+new years
 new years eve
 night of destiny
-northern territory picnic day
-orthodox christmas day
+northern territory picnic
+orthodox christmas
 orthodox easter
 orthodox easter monday
 orthodox good friday
@@ -71,14 +70,14 @@ orthodox holy saturday
 orthodox new year
 palm sunday
 pentecost
-proclamation day
+proclamation
 prophets birthday
 purim
 queens birthday
-queensland day
+queensland
 ramadan begins
-recreation day
-remembrance day
+recreation
+remembrance
 rosh hashana
 royal hobart regatta
 royal national agricultural show day queensland
@@ -87,12 +86,12 @@ shavuot
 shmini atzeret
 shrove tuesday
 simchat torah
-st patricks day
+st patricks
 tisha bav
 trinity sunday
 tu bshevat
-valentines day
-western australia day
+valentines
+western australia
 whit monday
 yom haatzmaut
 yom hashoah

--- a/share/spice/holiday/countries/aw.txt
+++ b/share/spice/holiday/countries/aw.txt
@@ -1,14 +1,14 @@
-ascension day
+ascension
 betico croes birthday
-boxing day
-christmas day
+boxing
+christmas
 december solstice
 easter monday
 good friday
 june solstice
-kings day
-labor day
+kings
+labor
 march equinox
-national anthem and flag day
-new years day
+national anthem and flag
+new years
 september equinox

--- a/share/spice/holiday/countries/az.txt
+++ b/share/spice/holiday/countries/az.txt
@@ -1,25 +1,25 @@
-azerbaijan armed forces day
+azerbaijan armed forces
 azerbaijan armed forces day observed
-constitution day
+constitution
 constitution day observed
 december solstice
 extra holiday
 feast of the sacrifice
 june solstice
 march equinox
-martyrs’ day
-national independence day
-national revival day
-new years day
+martyrs’
+national independence
+national revival
+new years
 new years eve
 nowruz
 ramadan holiday
-republic day
+republic
 republic day observed
 september equinox
 spring holiday
 state flag day of azerbaijan
 the day of national salvation of the azerbaijani people
 victory day over fascism
-womens day
-world azerbaijanis solidarity day
+womens
+world azerbaijanis solidarity

--- a/share/spice/holiday/countries/ba.txt
+++ b/share/spice/holiday/countries/ba.txt
@@ -1,32 +1,31 @@
-all saints day
-christmas day
+all saints
+christmas
 day of the republika srpska
-dayton peace agreement day
+dayton peace agreement
 december solstice
 easter monday
 easter sunday
 end of ramadan
-fathers day
+fathers
 feast of the sacrifice
 good friday
 halloween
 holy saturday
-independence day
+independence
 june solstice
-labor day
+labor
 labor day observed
 march equinox
-mothers day
+mothers
 new years
-new years day
 new years eve
-orthodox christmas day
+orthodox christmas
 orthodox christmas eve
 orthodox easter monday
 orthodox easter sunday
 orthodox good friday
 orthodox holy saturday
 september equinox
-statehood day
-valentines day
-victory day
+statehood
+valentines
+victory

--- a/share/spice/holiday/countries/bb.txt
+++ b/share/spice/holiday/countries/bb.txt
@@ -1,28 +1,28 @@
-boxing day
-christmas day
+boxing
+christmas
 christmas day observed
 christmas eve
 december solstice
 easter monday
 easter sunday
-emancipation day
+emancipation
 emancipation day observed
-errol barrow day
-fathers day
+errol barrow
+fathers
 good friday
 halloween
-independence day
+independence
 june solstice
-kadooment day
-labor day
+kadooment
+labor
 march equinox
-may day
+may
 may day observed
-mothers day
-national heroes day
-new years day
+mothers
+national heroes
+new years
 old years night
 september equinox
-valentines day
+valentines
 whit monday
 whit sunday

--- a/share/spice/holiday/countries/bd.txt
+++ b/share/spice/holiday/countries/bd.txt
@@ -1,39 +1,39 @@
 ashura
 ash wednesday
 bengali new year
-boxing day
+boxing
 buddha purnima
-christmas day
+christmas
 christmas eve
 december solstice
-easter day
+easter
 easter monday
 eid e milad un nabi
 eid ul adha
 eid ul fitr
-fathers day
+fathers
 good friday
 halloween
 holy saturday
-independence day
+independence
 janmashtami
 july 1 bank holiday
 jumatul bidah
 june solstice
-language martyrs day
+language martyrs
 march equinox
 maundy thursday
-may day
-mothers day
-national flag day
-national mourning day
-new years day
+may
+mothers
+national flag
+national mourning
+new years
 new years eve
 night of destiny
 september equinox
 shab e barat
 shab e meraj
 sheikh mujibur rahman’s birthday
-valentines day
+valentines
 vesak
-victory day
+victory

--- a/share/spice/holiday/countries/be.txt
+++ b/share/spice/holiday/countries/be.txt
@@ -1,21 +1,21 @@
-all saints day
-armistice day
-ascension day
+all saints
+armistice
+ascension
 assumption of mary
-belgian national day
-christmas day
+belgian national
+christmas
 christmas eve
 daylight saving time ends
 daylight saving time starts
 december solstice
-easter day
+easter
 easter monday
 good friday
 june solstice
-labor day
+labor
 march equinox
-may day
-new years day
+may
+new years
 new years eve
 september equinox
 whit monday

--- a/share/spice/holiday/countries/bf.txt
+++ b/share/spice/holiday/countries/bf.txt
@@ -1,13 +1,13 @@
 all saints eve
-ascension day
+ascension
 assumption of mary
-christmas day
+christmas
 december solstice
 easter monday
 eid al adha
 eid al fitr
 june solstice
-labour day
+labour
 march equinox
 new year
 september equinox

--- a/share/spice/holiday/countries/bg.txt
+++ b/share/spice/holiday/countries/bg.txt
@@ -1,7 +1,7 @@
 baba marta
-christmas day
+christmas
 christmas eve
-culture and literacy day
+culture and literacy
 daylight saving time ends
 daylight saving time starts
 day of remembrance and respect to victims of the communist regime
@@ -10,14 +10,14 @@ easter monday
 easter sunday
 good friday
 holy saturday
-independence day
+independence
 june solstice
-labor day
-liberation day
+labor
+liberation
 march equinox
-new years day
-revival day
+new years
+revival
 second day of christmas
 september equinox
-st georges day
-unification day
+st georges
+unification

--- a/share/spice/holiday/countries/bh.txt
+++ b/share/spice/holiday/countries/bh.txt
@@ -1,14 +1,14 @@
-arafat day
+arafat
 ashoora
 december solstice
 eid al adha
 eid al fitr
 june solstice
 march equinox
-may day
+may
 muharram
-national day
+national
 new year
-second day
+second
 september equinox
 the prophets birthday

--- a/share/spice/holiday/countries/bi.txt
+++ b/share/spice/holiday/countries/bi.txt
@@ -1,16 +1,16 @@
-all saints day
-ascension day
+all saints
+ascension
 assumption of mary
-christmas day
+christmas
 december solstice
 eid al adha
-independence day
+independence
 june solstice
-labour day
+labour
 march equinox
 new year
-president ndadayes day
-president ntaryamira day
-prince louis rwagasore day
+president ndadayes
+president ntaryamira
+prince louis rwagasore
 september equinox
-unity day
+unity

--- a/share/spice/holiday/countries/bj.txt
+++ b/share/spice/holiday/countries/bj.txt
@@ -1,16 +1,16 @@
-all saints day
-ascension day
-christmas day
+all saints
+ascension
+christmas
 december solstice
 easter monday
-fathers day
-independence day
+fathers
+independence
 june solstice
 korité
-labour day
+labour
 march equinox
 mawlid
-mothers day
+mothers
 new year
 september equinox
 tabaski

--- a/share/spice/holiday/countries/bm.txt
+++ b/share/spice/holiday/countries/bm.txt
@@ -1,27 +1,26 @@
-bermuda day
-boxing day
+bermuda
+boxing
 boxing day holiday
 christmas
-christmas day
 christmas day observed
 christmas eve
 daylight saving time ends
 daylight saving time starts
 december solstice
 easter sunday
-emancipation day
-fathers day
+emancipation
+fathers
 good friday
 halloween
 june solstice
-labor day
+labor
 march equinox
-may day
-mothers day
-national heroes day
-new years day
+may
+mothers
+national heroes
+new years
 new years eve
-remembrance day
+remembrance
 september equinox
-somers day
-valentines day
+somers
+valentines

--- a/share/spice/holiday/countries/bo.txt
+++ b/share/spice/holiday/countries/bo.txt
@@ -1,27 +1,27 @@
-all saints day
-aymara new year day
+all saints
+aymara new year
 aymara new year day holiday
 carnival
-childrens day
-christmas day
+childrens
+christmas
 corpus christi
 day of the sea
 december solstice
-father day
+father
 feast of candelaria
-flag day
+flag
 good friday
-independence day
-indigenous resistances day
+independence
+indigenous resistances
 june solstice
-labor day
+labor
 march equinox
 maundy thursday
-may day
+may
 may day observed
-mother day
-new years day
-plurinational state foundation day
+mother
+new years
+plurinational state foundation
 september equinox
 shrove tuesday
-the three wise men day
+the three wise men

--- a/share/spice/holiday/countries/br.txt
+++ b/share/spice/holiday/countries/br.txt
@@ -1,35 +1,35 @@
-all souls day
-black consciousness day
-brazilian valentines day
+all souls
+black consciousness
+brazilian valentines
 carnival end
 carnival monday
 carnival saturday
 carnival sunday
 carnival tuesday
-childrens day
-christmas day
+childrens
+christmas
 christmas day observed
 christmas eve
 corpus christi
 december solstice
 easter sunday
-fathers day
+fathers
 good friday
-independence day
+independence
 june solstice
-labor day
+labor
 march equinox
-may day
-mothers day
-new years day
+may
+mothers
+new years
 new years eve
 our lady aparecida
 public service holiday
-republic proclamation day
+republic proclamation
 rio 2016 summer olympics end
 rio 2016 summer olympics start
 rio 2016 summer paralympics end
 rio 2016 summer paralympics start
 september equinox
-teachers day
-tiradentes day
+teachers
+tiradentes

--- a/share/spice/holiday/countries/bs.txt
+++ b/share/spice/holiday/countries/bs.txt
@@ -1,5 +1,5 @@
-boxing day
-christmas day
+boxing
+christmas
 christmas day observed
 christmas eve
 daylight saving time ends
@@ -7,21 +7,21 @@ daylight saving time starts
 december solstice
 easter monday
 easter sunday
-emancipation day
-fathers day
+emancipation
+fathers
 good friday
-independence day
+independence
 independence day observed
 june solstice
-majority rule day
+majority rule
 majority rule day observed
 march equinox
-mothers day
-national heroes day
-new years day
+mothers
+national heroes
+new years
 new years eve
-randol fawkes labour day
+randol fawkes labour
 september equinox
-valentines day
+valentines
 whit monday
 whit sunday

--- a/share/spice/holiday/countries/bw.txt
+++ b/share/spice/holiday/countries/bw.txt
@@ -1,15 +1,15 @@
-ascension day
-botswana day
-christmas day
+ascension
+botswana
+christmas
 december solstice
 easter monday
-fathers day
+fathers
 good friday
 june solstice
 march equinox
-may day
-mothers day
+may
+mothers
 new year
-presidents day
+presidents
 september equinox
-sir seretse khama day
+sir seretse khama

--- a/share/spice/holiday/countries/by.txt
+++ b/share/spice/holiday/countries/by.txt
@@ -1,25 +1,25 @@
-catholic christmas day
+catholic christmas
 catholic easter sunday
-constitution day
+constitution
 day of remembrance of the chernobyl tragedy
 day of the national emblem and flag of belarus
 december solstice
-defender of the fatherland day
+defender of the fatherland
 independence day of the republic of belarus
 june solstice
 kupalle
-labour day
+labour
 march equinox
-new years day
+new years
 new years eve
-october revolution day
-orthodox christmas day
+october revolution
+orthodox christmas
 orthodox easter sunday
 radonitsa
-remembrance day
+remembrance
 remembrance day of victims of the great patriotic war
 september equinox
 union day of belarus and russia
-valentines day
-victory day
-womens day
+valentines
+victory
+womens

--- a/share/spice/holiday/countries/ca.txt
+++ b/share/spice/holiday/countries/ca.txt
@@ -1,34 +1,34 @@
-all saints day
-all souls day
+all saints
+all souls
 anniversary of the statute of westminster
-arbor day
-ascension day
+arbor
+ascension
 ash wednesday
 assumption of mary
-boxing day
-british columbia day
-canada day
+boxing
+british columbia
+canada
 carnival
 chinese new year
 christmas
 christmas eve
 civic
-commonwealth day
+commonwealth
 corpus christi
-day after new year’s day
+day after new year’s
 daylight saving time ends
 daylight saving time starts
 december solstice
 deepavali
-discovery day
+discovery
 diwali
 easter monday
 easter sunday
 eid al adha
 eid al fitr
 epiphany
-family day
-fathers day
+family
+fathers
 feast of st francis of assisi
 feast of the immaculate conception
 first day of hanukkah
@@ -37,38 +37,38 @@ first day of sukkot
 first sunday of advent
 gold cup parade
 good friday
-groundhog day
+groundhog
 halloween
 heritage day in alberta
 holy saturday
 islamic new year
-islander day
+islander
 isra and miraj
 june solstice
-labour day
+labour
 lag bomer
 last day of passover
 last day of sukkot
 laylat al qadr
-louis riel day
+louis riel
 march equinox
 maundy thursday
-memorial day
-mothers day
+memorial
+mothers
 muharram
-natal day
-national aboriginal day
-national flag of canada day
-national patriots day
-national tartan day
-new brunswick day
-new years day
+natal
+national aboriginal
+national flag of canada
+national patriots
+national tartan
+new brunswick
+new years
 new years eve
 night of destiny
-nova scotia heritage day
-nunavut day
-orangemens day
-orthodox christmas day
+nova scotia heritage
+nunavut
+orangemens
+orthodox christmas
 orthodox easter
 orthodox easter monday
 orthodox good friday
@@ -77,32 +77,32 @@ orthodox new year
 palm sunday
 pentecost
 prophets birthday
-provincial day
+provincial
 purim
 ramadan begins
-regatta day
-remembrance day
+regatta
+remembrance
 rosh hashana
 september equinox
 shavuot
 shmini atzeret
 shrove tuesday
 simchat torah
-st davids day
-st georges day
-st jean baptiste day
-st patricks day
-terry fox day
-thanksgiving day
+st davids
+st georges
+st jean baptiste
+st patricks
+terry fox
+thanksgiving
 the royal st johns regatta
 tisha bav
 trinity sunday
 tu bshevat
-valentines day
-victoria day
-vimy ridge day
+valentines
+victoria
+vimy ridge
 whit monday
 yom haatzmaut
 yom hashoah
 yom kippur
-yukon heritage day
+yukon heritage

--- a/share/spice/holiday/countries/cd.txt
+++ b/share/spice/holiday/countries/cd.txt
@@ -1,25 +1,25 @@
 anniversary of president laurent kabila’s assassination
 anniversary of prime minister patrice emery lumumba’s assassination
 anniversary of prime minister patrice emery lumumba’s assassination observed
-christmas day
+christmas
 christmas day observed
 christmas eve
 december solstice
-education day
-independence day
-international francophonie day
-international womens day
+education
+independence
+international francophonie
+international womens
 june solstice
-liberation day
+liberation
 march equinox
-martyrs of independence day
-may day
+martyrs of independence
+may
 may day observed
 music festival
-new years day
+new years
 new years day observed
 new years eve
-parents day
+parents
 september equinox
-valentines day
-world tourism day
+valentines
+world tourism

--- a/share/spice/holiday/countries/cf.txt
+++ b/share/spice/holiday/countries/cf.txt
@@ -1,17 +1,17 @@
 all saints eve
-ascension day
+ascension
 assumption of mary
-christmas day
+christmas
 commemoration of boganda
 december solstice
 easter monday
 eid al adha
 eid al fitr
-independence day
+independence
 june solstice
-labour day
+labour
 march equinox
-national payer day
+national payer
 new year
-republic day
+republic
 september equinox

--- a/share/spice/holiday/countries/cg.txt
+++ b/share/spice/holiday/countries/cg.txt
@@ -1,16 +1,16 @@
 all saints eve
-ascension day
-christmas day
+ascension
+christmas
 december solstice
-easter day
+easter
 easter monday
-fathers day
-independence day
+fathers
+independence
 june solstice
-labour day
+labour
 march equinox
-mothers day
+mothers
 new year
-reconciliation day
+reconciliation
 september equinox
 whit monday

--- a/share/spice/holiday/countries/ch.txt
+++ b/share/spice/holiday/countries/ch.txt
@@ -1,8 +1,8 @@
-all saints day
-ascension day
+all saints
+ascension
 assumption of mary
-berchtold day
-christmas day
+berchtold
+christmas
 christmas eve
 corpus christi
 december solstice
@@ -15,15 +15,15 @@ jeune genevois
 june solstice
 knabenschiessen
 march equinox
-may day
-new years day
+may
+new years
 new years eve
 pentecost
 pentecost monday
-saint josephs day
+saint josephs
 sechseläuten
 september equinox
 st peter and st paul
-st stephens day
+st stephens
 swiss federal fast
-swiss national day
+swiss national

--- a/share/spice/holiday/countries/ci.txt
+++ b/share/spice/holiday/countries/ci.txt
@@ -1,17 +1,17 @@
 aid el fitr
 aid el kebir
-all saints day
-ascension day
+all saints
+ascension
 assumption of mary
-christmas day
+christmas
 december solstice
 easter monday
-independence day
+independence
 june solstice
-labor day
+labor
 laila tou kadr
 march equinox
-national peace day
+national peace
 new year
 september equinox
 the prophets birthday

--- a/share/spice/holiday/countries/cl.txt
+++ b/share/spice/holiday/countries/cl.txt
@@ -1,25 +1,25 @@
 2016 municipal elections
 2016 primary elections
-all saints day
-army day
+all saints
+army
 assumption of mary
-christmas day
-columbus day
+christmas
+columbus
 december solstice
-easter day
+easter
 good friday
 holy saturday
-inmaculate conception day
+inmaculate conception
 june solstice
-labor day
+labor
 march equinox
 maundy thursday
-may day
-national day
-navy day
-new years day
+may
+national
+navy
+new years
 new years eve
 our lady of mount carmel
-reformation day
+reformation
 saint peter and saint paul
 september equinox

--- a/share/spice/holiday/countries/cm.txt
+++ b/share/spice/holiday/countries/cm.txt
@@ -1,16 +1,16 @@
-ascension day
+ascension
 assumption of mary
-christmas day
+christmas
 december solstice
-easter day
+easter
 eid al adha
 eid al fitr
 good friday
-independence day
+independence
 independence of southern british cameroons from uk
 june solstice
 march equinox
-national day
+national
 september equinox
 the prophets birthday
-youth day
+youth

--- a/share/spice/holiday/countries/cn.txt
+++ b/share/spice/holiday/countries/cn.txt
@@ -1,27 +1,27 @@
-arbor day
-army day
-childrens day
+arbor
+army
+childrens
 chinese new year
-christmas day
-cpc founding day
+christmas
+cpc founding
 december solstice
 double ninth festival
 double seven festival
 dragon boat festival
 dragon boat festival holiday
-international womens day
-journalists day
+international womens
+journalists
 june solstice
-labour day
+labour
 labour day holiday
 lantern festival
 march equinox
-maritime day
+maritime
 mid autumn festival
 mid autumn festival holiday
-national day
+national
 national day golden week holiday
-new years day
+new years
 new years weekend
 qing ming jie
 qing ming jie holiday
@@ -29,6 +29,6 @@ september equinox
 spirit festival
 spring festival eve
 spring festival golden week holiday
-teachers day
-youth day
+teachers
+youth
 zhonghe festival

--- a/share/spice/holiday/countries/co.txt
+++ b/share/spice/holiday/countries/co.txt
@@ -1,39 +1,39 @@
-all saints day
-ascension day
+all saints
+ascension
 assumption of mary
-battle of boyacá day
-childrens day
-christmas day
+battle of boyacá
+childrens
+christmas
 christmas eve
-colombian womens day
-columbus day
+colombian womens
+columbus
 corpus christi
 day of trees
 december solstice
-easter day
+easter
 epiphany
 eve of the feast of the immaculate conception
-fathers day
+fathers
 feast of saint peter and saint paul
 feast of the immaculate conception
 good friday
 halloween
-independence day
+independence
 independence of cartagena
 june solstice
-labor day
-language day
+labor
+language
 march equinox
 maundy thursday
-may day
-mothers day
-new years day
+may
+mothers
+new years
 new years eve
 palm sunday
 sacred heart
-saint josephs day
-secretaries day
+saint josephs
+secretaries
 september equinox
-teachers day
-valentines day
-womens day
+teachers
+valentines
+womens

--- a/share/spice/holiday/countries/cr.txt
+++ b/share/spice/holiday/countries/cr.txt
@@ -1,24 +1,24 @@
-all souls day
+all souls
 annexation of guanacaste
 battle of rivas
-childrens day
-christmas day
+childrens
+christmas
 day of the cultures
 december solstice
-fathers day
+fathers
 feast of the immaculate conception
 good friday
-independence day
+independence
 june solstice
-labor day
+labor
 march equinox
 maundy thursday
-may day
-mother day
-national parks day
-new years day
+may
+mother
+national parks
+new years
 new years eve
 our lady of los ángeles
-saint josephs day
+saint josephs
 september equinox
-teachers day
+teachers

--- a/share/spice/holiday/countries/cu.txt
+++ b/share/spice/holiday/countries/cu.txt
@@ -1,21 +1,21 @@
 beginning of the war of independence
-christmas day
+christmas
 daylight saving time ends
 daylight saving time starts
 day of the rebellion
 december solstice
 epiphany
 good friday
-independence day
+independence
 josé martís birthday memorial
 june solstice
-labor day
-liberation day
+labor
+liberation
 march equinox
 maundy thursday
-may day
-mothers day
-new year day
+may
+mothers
+new year
 new years eve
 palm sunday
 revolution anniversary

--- a/share/spice/holiday/countries/cv.txt
+++ b/share/spice/holiday/countries/cv.txt
@@ -1,18 +1,18 @@
-all saints day
+all saints
 ash wednesday
 assumption of mary
 carnival
-childrens day
-christmas day
+childrens
+christmas
 december solstice
-democracy day
-fathers day
-heroes day
-independence day
+democracy
+fathers
+heroes
+independence
 june solstice
-labour day
+labour
 march equinox
-mothers day
-national day
+mothers
+national
 new year
 september equinox

--- a/share/spice/holiday/countries/cw.txt
+++ b/share/spice/holiday/countries/cw.txt
@@ -1,18 +1,18 @@
-ascension day
-boxing day
+ascension
+boxing
 carnival monday
-christmas day
-curaçao day
+christmas
+curaçao
 december solstice
 easter monday
-fathers day
-flag day
+fathers
+flag
 good friday
 june solstice
 kings birthday
-labor day
+labor
 march equinox
-may day
-mothers day
-new years day
+may
+mothers
+new years
 september equinox

--- a/share/spice/holiday/countries/cy.txt
+++ b/share/spice/holiday/countries/cy.txt
@@ -1,9 +1,9 @@
 assumption of the virgin mary
 banks only
-boxing day
-christmas day
+boxing
+christmas
 christmas eve
-cyprus independence day
+cyprus independence
 cyprus national holiday
 daylight saving time ends
 daylight saving time starts
@@ -12,16 +12,16 @@ easter monday
 easter sunday
 epiphany
 good friday
-greek independence day
+greek independence
 green monday
 holy saturday
 june solstice
-labour day
+labour
 march equinox
-may day
-new years day
+may
+new years
 new years eve
-ochi day
+ochi
 orthodox
 orthodox easter tuesday
 orthodox pentecost monday

--- a/share/spice/holiday/countries/cz.txt
+++ b/share/spice/holiday/countries/cz.txt
@@ -1,28 +1,28 @@
-ascension day
+ascension
 ash wednesday
 carnival
-christmas day
+christmas
 christmas eve
 december solstice
-easter day
+easter
 easter monday
 good friday
 holy saturday
-independent czechoslovak state day
-jan hus day
+independent czechoslovak state
+jan hus
 june solstice
-labor day
+labor
 march equinox
 maundy thursday
-may day
-new years day
+may
+new years
 palm sunday
-restoration of the czech independence day
+restoration of the czech independence
 saints cyril and methodius
 september equinox
-struggle for freedom and democracy day
-st stephens day
-st wenceslas day
+struggle for freedom and democracy
+st stephens
+st wenceslas
 trinity
-victory in europe day
+victory in europe
 whit monday

--- a/share/spice/holiday/countries/de.txt
+++ b/share/spice/holiday/countries/de.txt
@@ -1,17 +1,17 @@
-all saints day
-ascension day
+all saints
+ascension
 ash wednesday
 assumption of mary
-boxing day
+boxing
 carnival
-christmas day
+christmas
 christmas eve
 corpus christi
 daylight saving time ends
 daylight saving time starts
 day of german unity
 december solstice
-easter day
+easter
 easter monday
 epiphany
 first sunday advent
@@ -21,23 +21,23 @@ halloween
 june solstice
 march equinox
 maundy thursday
-may day
-mothers day
+may
+mothers
 national day of mourning
-new years day
+new years
 new years eve
 palm sunday
 peace festival
-reformation day
-repentance day
-saint nicholas day
+reformation
+repentance
+saint nicholas
 second sunday advent
 september equinox
 shrove monday
 shrove tuesday
-st martins day
+st martins
 sunday of the dead
 third sunday advent
-valentines day
+valentines
 whit monday
 whit sunday

--- a/share/spice/holiday/countries/dj.txt
+++ b/share/spice/holiday/countries/dj.txt
@@ -1,7 +1,7 @@
 december solstice
 eid al adha
 eid al fitr
-independence day
+independence
 june solstice
 march equinox
 muharram

--- a/share/spice/holiday/countries/dk.txt
+++ b/share/spice/holiday/countries/dk.txt
@@ -1,22 +1,22 @@
-2nd christmas day
-ascension day
+2nd christmas
+ascension
 carnival
-christmas day
+christmas
 christmas eve
-constitution day
+constitution
 daylight saving time ends
 daylight saving time starts
 december solstice
-easter day
+easter
 easter monday
 good friday
-great prayer day
+great prayer
 june solstice
-labor day
+labor
 march equinox
 maundy thursday
-may day
-new years day
+may
+new years
 new years eve
 palm sunday
 september equinox

--- a/share/spice/holiday/countries/do.txt
+++ b/share/spice/holiday/countries/do.txt
@@ -1,22 +1,22 @@
-christmas day
+christmas
 christmas eve
-constitution day
+constitution
 corpus christi
 december solstice
-duartes day
+duartes
 epiphany
-fathers day
+fathers
 good friday
-independence day
+independence
 june solstice
-labor day
+labor
 labor day observed
 march equinox
 maundy thursday
-mothers day
-new years day
+mothers
+new years
 new years eve
 our lady of altagracia
 our lady of las mercedes
-restoration day
+restoration
 september equinox

--- a/share/spice/holiday/countries/dz.txt
+++ b/share/spice/holiday/countries/dz.txt
@@ -3,10 +3,10 @@ day of achura
 december solstice
 eid al adha
 eid al fitr
-independence day
+independence
 june solstice
 march equinox
-may day
+may
 muharram
 new year
 september equinox

--- a/share/spice/holiday/countries/ec.txt
+++ b/share/spice/holiday/countries/ec.txt
@@ -1,6 +1,6 @@
-all souls day
+all souls
 carnival
-christmas day
+christmas
 compensation for carnival monday
 compensation for carnival tuesday
 december solstice
@@ -8,17 +8,17 @@ easter sunday
 foundation of quito
 good friday
 holy saturday
-independence day
+independence
 independence of cuenca
 independence of guayaquil
 june solstice
-labor day
+labor
 march equinox
 maundy thursday
-may day
-new years day
+may
+new years
 new years eve
 september equinox
 simón bolívars birthday memorial
-special working day
+special working
 the battle of pichincha

--- a/share/spice/holiday/countries/ee.txt
+++ b/share/spice/holiday/countries/ee.txt
@@ -1,16 +1,16 @@
-boxing day
-christmas day
+boxing
+christmas
 christmas eve
 december solstice
 easter sunday
 good friday
-independence day
-independence restoration day
+independence
+independence restoration
 june solstice
-labor day
+labor
 march equinox
-midsummer day
-new years day
+midsummer
+new years
 september equinox
-victory day
+victory
 whitsunday

--- a/share/spice/holiday/countries/eg.txt
+++ b/share/spice/holiday/countries/eg.txt
@@ -1,5 +1,5 @@
-armed forces day
-coptic christmas day
+armed forces
+coptic christmas
 coptic easter sunday
 coptic good friday
 coptic holy saturday
@@ -12,12 +12,12 @@ january 1 bank holiday
 july 1 bank holiday
 june 30 uprising
 june solstice
-labor day
+labor
 march equinox
 muharram
 prophet mohameds birthday
 revolution day january 25
 revolution day july 23
 september equinox
-sinai liberation day
+sinai liberation
 spring festival

--- a/share/spice/holiday/countries/er.txt
+++ b/share/spice/holiday/countries/er.txt
@@ -1,16 +1,16 @@
-christmas day
+christmas
 commencement day of eritrean armed struggle
 december solstice
-easter day
+easter
 eid al adha
 eid al fitr
 good friday
-independence day
-international workers day
+independence
+international workers
 june solstice
 march equinox
 meskel
 new year
 september equinox
 the prophets birthday
-womens day
+womens

--- a/share/spice/holiday/countries/es.txt
+++ b/share/spice/holiday/countries/es.txt
@@ -1,13 +1,13 @@
 80th anniversary of the constitution of the basque government in guernica
-all saints day
+all saints
 ash wednesday
 assumption of mary
 canaries day observed
-castile and león day
-christmas day
+castile and león
+christmas
 christmas day observed
 christmas eve
-constitution day
+constitution
 corpus christi
 daylight saving time ends
 daylight saving time starts
@@ -34,29 +34,29 @@ epiphany
 feast day of st isidore
 feast of saint james the apostle
 feast of the holy family
-galicia literature day
+galicia literature
 good friday
-hispanic day
+hispanic
 immaculate conception
 june solstice
-labor day
+labor
 labor day observed
 march equinox
 maundy thursday
-may day
-mothers day
-new years day
+may
+mothers
+new years
 new years eve
 nuestra señora de la bien aparecida
 observed
 palm sunday
 pentecost
-saint john the baptist day
+saint john the baptist
 san antonio
 san jose
 september equinox
-st georges day
-st stephens day
+st georges
+st stephens
 the day of cantabria
 the day of our lady of africa
 virgin of the victory

--- a/share/spice/holiday/countries/et.txt
+++ b/share/spice/holiday/countries/et.txt
@@ -1,15 +1,15 @@
-adwa victory day
+adwa victory
 december solstice
-derg downfall day
+derg downfall
 eid al adha
 eid al fitr
 epiphany
-ethiopian christmas day
+ethiopian christmas
 ethiopian easter sunday
 ethiopian good friday
 ethiopian new year
-freedom day
-international labor day
+freedom
+international labor
 june solstice
 march equinox
 september equinox

--- a/share/spice/holiday/countries/fi.txt
+++ b/share/spice/holiday/countries/fi.txt
@@ -1,21 +1,21 @@
-all saints day
-ascension day
-christmas day
+all saints
+ascension
+christmas
 christmas eve
 december solstice
-easter day
+easter
 easter monday
 epiphany
-fathers day
+fathers
 good friday
-independence day
+independence
 june solstice
 march equinox
-may day
+may
 midsummer
 midsummer eve
-mothers day
-new years day
+mothers
+new years
 september equinox
-st stephens day
+st stephens
 whit sunday

--- a/share/spice/holiday/countries/fj.txt
+++ b/share/spice/holiday/countries/fj.txt
@@ -1,17 +1,17 @@
-boxing day
-christmas day
-constitution day
+boxing
+christmas
+constitution
 daylight saving time ends
 daylight saving time starts
 december solstice
 diwali
 easter monday
-fiji day
+fiji
 good friday
 holy saturday
 june solstice
 march equinox
-national sports day
+national sports
 new year
 september equinox
 the prophets birthday

--- a/share/spice/holiday/countries/fo.txt
+++ b/share/spice/holiday/countries/fo.txt
@@ -1,24 +1,24 @@
-ascension day
-boxing day
-christmas day
+ascension
+boxing
+christmas
 christmas eve
-constitution day
+constitution
 daylight saving time ends
 daylight saving time starts
 december solstice
-easter day
+easter
 easter monday
 good friday
 june solstice
 march equinox
 maundy thursday
-national day
-national flag day
+national
+national flag
 new year
 new years eve
-prayer day
+prayer
 september equinox
-st olavs day
+st olavs
 st olavs eve
 whit monday
 whit sunday

--- a/share/spice/holiday/countries/fr.txt
+++ b/share/spice/holiday/countries/fr.txt
@@ -1,26 +1,26 @@
-all saints day
-armistice day
-ascension day
+all saints
+armistice
+ascension
 assumption of mary
-bastille day
-christmas day
+bastille
+christmas
 christmas eve
 daylight saving time ends
 daylight saving time starts
 december solstice
-easter day
+easter
 easter monday
-fathers day
+fathers
 good friday
 june solstice
-labor day
+labor
 march equinox
-may day
-mothers day
-new years day
+may
+mothers
+new years
 new years eve
 september equinox
-st stephens day
+st stephens
 whit monday
 whit sunday
-wwii victory day
+wwii victory

--- a/share/spice/holiday/countries/ga.txt
+++ b/share/spice/holiday/countries/ga.txt
@@ -1,18 +1,18 @@
 all saints eve
 assumption of mary
-christmas day
+christmas
 december solstice
-easter day
+easter
 easter monday
 eid al adha
 eid al fitr
-fathers day
-independence day
+fathers
+independence
 june solstice
-labour day
+labour
 march equinox
-mothers day
+mothers
 new year
 september equinox
 whit monday
-womens rights day
+womens rights

--- a/share/spice/holiday/countries/gb.txt
+++ b/share/spice/holiday/countries/gb.txt
@@ -1,16 +1,16 @@
-all saints day
-all souls day
-arbor day
-ascension day
+all saints
+all souls
+arbor
+ascension
 ash wednesday
 assumption of mary
 bank holiday
 battle of the boyne
-boxing day
+boxing
 burns night
 carnival
 chinese new year
-christmas day
+christmas
 christmas eve
 corpus christi
 daylight saving time ends
@@ -24,7 +24,7 @@ easter sunday
 eid al adha
 eid al fitr
 epiphany
-fathers day
+fathers
 feast of st francis of assisi
 feast of the immaculate conception
 first day of hanukkah
@@ -32,7 +32,7 @@ first day of passover
 first day of sukkot
 first sunday of advent
 good friday
-guy fawkes day
+guy fawkes
 halloween
 holy saturday
 islamic new year
@@ -42,15 +42,15 @@ lag bomer
 last day of passover
 last day of sukkot
 laylat al qadr
-liberation day
+liberation
 march equinox
 maundy thursday
 mothering sunday
 muharram
-new years day
+new years
 new years eve
 night of destiny
-orthodox christmas day
+orthodox christmas
 orthodox easter
 orthodox easter monday
 orthodox good friday
@@ -64,21 +64,21 @@ ramadan begins
 remembrance sunday
 rosh hashana
 september equinox
-shakespeare day
+shakespeare
 shavuot
 shmini atzeret
 shrove tuesday
 simchat torah
 spring bank holiday
-st andrews day
-st davids day
-st georges day
-st patricks day
+st andrews
+st davids
+st georges
+st patricks
 summer bank holiday
 tisha bav
 trinity sunday
 tu bshevat
-valentines day
+valentines
 whit monday
 yom haatzmaut
 yom hashoah

--- a/share/spice/holiday/countries/gd.txt
+++ b/share/spice/holiday/countries/gd.txt
@@ -1,20 +1,20 @@
-boxing day
+boxing
 carnaval
-christmas day
+christmas
 corpus christi
 december solstice
-easter day
+easter
 easter monday
-emancipation day
-first day
+emancipation
+first
 good friday
-independence day
+independence
 june solstice
 march equinox
-may day
-mothers day
+may
+mothers
 new year
-second day
+second
 september equinox
 thanksgiving
 whit monday

--- a/share/spice/holiday/countries/ge.txt
+++ b/share/spice/holiday/countries/ge.txt
@@ -1,25 +1,24 @@
 day of the assumption of mary
 december solstice
-fathers day
-independence day
-independence restoration day
-international womens day
+fathers
+independence
+independence restoration
+international womens
 june solstice
 march equinox
-mothers day
+mothers
 new years
-new years day
 new years eve
 nowruz
-orthodox christmas day
+orthodox christmas
 orthodox easter monday
 orthodox easter sunday
 orthodox epiphany
 orthodox good friday
 orthodox holy saturday
 september equinox
-st andrews day
-st georges day
+st andrews
+st georges
 svetitskhovloba
-valentines day
-victory day
+valentines
+victory

--- a/share/spice/holiday/countries/gh.txt
+++ b/share/spice/holiday/countries/gh.txt
@@ -1,26 +1,26 @@
-african union day
-boxing day
-christmas day
+african union
+boxing
+christmas
 christmas day observed
 christmas eve
 december solstice
-easter day
+easter
 easter monday
-farmers day
-fathers day
-founders day
+farmers
+fathers
+founders
 good friday
 holy saturday
 id ul adha
 id ul fitr
-independence day
+independence
 independence day observed
 june solstice
 march equinox
-may day
+may
 may day observed
-mothers day
-new years day
+mothers
+new years
 new years eve
-republic day
+republic
 september equinox

--- a/share/spice/holiday/countries/gi.txt
+++ b/share/spice/holiday/countries/gi.txt
@@ -1,27 +1,27 @@
-boxing day
-christmas day
+boxing
+christmas
 christmas eve
 christmas holiday
-commonwealth day
+commonwealth
 daylight saving time ends
 daylight saving time starts
 december solstice
 easter sunday
-fathers day
-gibraltar day
+fathers
+gibraltar
 gibraltar day observed
 good friday
 halloween
 june solstice
 late summer bank holiday
 march equinox
-may day
+may
 may day observed
-mothers day
-new years day
+mothers
+new years
 new years eve
 queens birthday
 september equinox
 spring bank holiday
-valentines day
-workers memorial day
+valentines
+workers memorial

--- a/share/spice/holiday/countries/gl.txt
+++ b/share/spice/holiday/countries/gl.txt
@@ -1,19 +1,19 @@
-ascension day
-boxing day
-christmas day
+ascension
+boxing
+christmas
 christmas eve
 daylight saving time ends
 daylight saving time starts
 december solstice
-easter day
+easter
 easter monday
 epiphany
-general prayer day
+general prayer
 good friday
 june solstice
 march equinox
-may day
-national day
+may
+national
 new year
 new years eve
 september equinox

--- a/share/spice/holiday/countries/gm.txt
+++ b/share/spice/holiday/countries/gm.txt
@@ -1,15 +1,15 @@
-africa day
+africa
 ashura
 assumption of mary
-christmas day
+christmas
 december solstice
 easter monday
 eid al adha
 eid al fitr
 good friday
-independence day
+independence
 june solstice
-labour day
+labour
 lailat al qadr
 march equinox
 new year

--- a/share/spice/holiday/countries/gn.txt
+++ b/share/spice/holiday/countries/gn.txt
@@ -1,13 +1,13 @@
-africa day
+africa
 assumption of mary
-christmas day
+christmas
 december solstice
 easter monday
 eid al adha
 eid al fitr
-independence day
+independence
 june solstice
-labour day
+labour
 lailat al qadr
 march equinox
 september equinox

--- a/share/spice/holiday/countries/gq.txt
+++ b/share/spice/holiday/countries/gq.txt
@@ -1,22 +1,22 @@
-christmas day
+christmas
 christmas day observed
 christmas eve
-constitution day
+constitution
 corpus christi
 december solstice
 feast of the immaculate conception
-freedom day
+freedom
 good friday
-human rights day
-independence day
+human rights
+independence
 june solstice
-labor day
+labor
 march equinox
 maundy thursday
-may day
+may
 may day observed
-new years day
+new years
 new years eve
-presidents day
+presidents
 presidents day observed
 september equinox

--- a/share/spice/holiday/countries/gr.txt
+++ b/share/spice/holiday/countries/gr.txt
@@ -1,7 +1,7 @@
 25th of march
 annunciation of the lord
-armed forces day
-christmas day
+armed forces
+christmas
 clean monday
 december solstice
 dormition of the holy virgin
@@ -11,14 +11,14 @@ epiphany
 good friday
 holy spirit monday
 june solstice
-labor day
+labor
 march equinox
-may day
+may
 national holiday
-new years day
+new years
 polytechneio
 september equinox
 synaxis of the mother of god
-the ochi day
+the ochi
 the restoration of democracy
 the three holy hierarchs

--- a/share/spice/holiday/countries/gt.txt
+++ b/share/spice/holiday/countries/gt.txt
@@ -1,8 +1,8 @@
-all saints day
-army day
-assumption day
-boxing day
-christmas day
+all saints
+army
+assumption
+boxing
+christmas
 christmas eve
 december solstice
 dia de la raza
@@ -10,13 +10,13 @@ easter monday
 easter saturday
 easter sunday
 good friday
-independence day
+independence
 june solstice
-labor day
+labor
 march equinox
 maundy thursday
-may day
-new years day
+may
+new years
 new years eve
 revolution of 1944
 september equinox

--- a/share/spice/holiday/countries/gw.txt
+++ b/share/spice/holiday/countries/gw.txt
@@ -1,14 +1,14 @@
-christmas day
+christmas
 december solstice
 eid al adha
 eid al fitr
-heroes day
-independence day
-international womens day
+heroes
+independence
+international womens
 june solstice
-labour day
+labour
 march equinox
-martyrs day
-national day
+martyrs
+national
 new year
 september equinox

--- a/share/spice/holiday/countries/hk.txt
+++ b/share/spice/holiday/countries/hk.txt
@@ -1,8 +1,8 @@
-boxing day
+boxing
 buddhas birthday
-chinese lunar new years day
+chinese lunar new years
 ching ming festival
-christmas day
+christmas
 christmas day observed
 chung yeung festival
 day after mid autumn festival
@@ -12,13 +12,13 @@ easter monday
 easter sunday
 good friday
 holy saturday
-hong kong special administrative region establishment day
+hong kong special administrative region establishment
 june solstice
-labour day
+labour
 labour day observed
 march equinox
 national day of the peoples republic of china
-new years day
+new years
 second day of chinese lunar new year
 september equinox
 third day of chinese lunar new year

--- a/share/spice/holiday/countries/hn.txt
+++ b/share/spice/holiday/countries/hn.txt
@@ -1,25 +1,25 @@
-america day
-army day
-childrens day
-christmas day
-columbus day
+america
+army
+childrens
+christmas
+columbus
 corpus christi
 december solstice
-easter day
-fathers day
+easter
+fathers
 good friday
 holy saturday
-independence day
+independence
 june solstice
-labor day
+labor
 march equinox
 maundy thursday
-may day
-morazans day
-mothers day
-new years day
+may
+morazans
+mothers
+new years
 new years eve
 our lady of suyapa
 september equinox
-teachers day
-the three wise men day
+teachers
+the three wise men

--- a/share/spice/holiday/countries/hr.txt
+++ b/share/spice/holiday/countries/hr.txt
@@ -1,19 +1,19 @@
-all saints day
+all saints
 assumption of mary
-christmas day
+christmas
 corpus christi
 day of antifascist struggle
 december solstice
-easter day
+easter
 easter monday
 epiphany
-homeland thanksgiving day
-independence day
+homeland thanksgiving
+independence
 june solstice
-labor day
+labor
 march equinox
-may day
-new years day
+may
+new years
 september equinox
-statehood day
-st stephens day
+statehood
+st stephens

--- a/share/spice/holiday/countries/ht.txt
+++ b/share/spice/holiday/countries/ht.txt
@@ -1,27 +1,27 @@
-agriculture and labor day
-all saints day
-all souls day
-ancestors’ day
+agriculture and labor
+all saints
+all souls
+ancestors’
 assumption of mary
 carnival
-christmas day
+christmas
 christmas eve
 corpus christi
 december solstice
-dessalines day
+dessalines
 easter sunday
-fathers day
-flag day
+fathers
+flag
 good friday
-heroes’ day
-independence day
+heroes’
+independence
 june solstice
 march equinox
-mothers day
-new years day
+mothers
+new years
 new years eve
 september equinox
 shrove tuesday
-university day
-valentines day
-vertières day
+university
+valentines
+vertières

--- a/share/spice/holiday/countries/hu.txt
+++ b/share/spice/holiday/countries/hu.txt
@@ -1,23 +1,23 @@
-1848 revolution memorial day
-1956 revolution memorial day
-all saints day
-boxing day
-christmas day
+1848 revolution memorial
+1956 revolution memorial
+all saints
+boxing
+christmas
 christmas eve
 december solstice
-easter day
+easter
 easter monday
 extra holiday
 extra work day for mar 14
 extra work day for oct 31
-hungary national day
+hungary national
 june solstice
-labor day
+labor
 march equinox
-may day
-new years day
+may
+new years
 new years eve
-saint nicholas day
+saint nicholas
 september equinox
 whit monday
 whit sunday

--- a/share/spice/holiday/countries/id.txt
+++ b/share/spice/holiday/countries/id.txt
@@ -2,27 +2,27 @@ ascension day of jesus christ
 ascension of the prophet muhammad
 balis day of silence and hindu new year
 buddhas anniversary
-chinese lunar new years day
-christmas day
+chinese lunar new years
+christmas
 christmas eve
-day after christmas day
+day after christmas
 december solstice
 deepavali
 diwali
 easter sunday
 good friday
 idul adha
-indonesian independence day
-international labor day
+indonesian independence
+international labor
 islamic new year
 joint holiday after idul fitri
 june solstice
 march equinox
 muharram
 muslim day of sacrifice
-new years day
+new years
 new years eve
 second joint holiday after idul fitri
 september equinox
 the prophet muhammads birthday
-waisak day
+waisak

--- a/share/spice/holiday/countries/ie.txt
+++ b/share/spice/holiday/countries/ie.txt
@@ -1,5 +1,5 @@
 august bank holiday
-christmas day
+christmas
 christmas day observed
 christmas eve
 december solstice
@@ -9,10 +9,10 @@ good friday
 june bank holiday
 june solstice
 march equinox
-may day
-new years day
+may
+new years
 new years eve
 october bank holiday
 september equinox
-st patricks day
-st stephens day
+st patricks
+st stephens

--- a/share/spice/holiday/countries/il.txt
+++ b/share/spice/holiday/countries/il.txt
@@ -10,16 +10,15 @@ hanukkah v
 hanukkah vi
 hanukkah vii
 holiday of lights
-holocaust memorial day
+holocaust memorial
 hoshanah rabah
-independence day
+independence
 jerusalem
-jerusalem day
 june solstice
 lag bomer
 last day of passover
 march equinox
-memorial day
+memorial
 new year
 passover
 pentecost

--- a/share/spice/holiday/countries/in.txt
+++ b/share/spice/holiday/countries/in.txt
@@ -14,24 +14,24 @@ deepavali
 diwali
 dolyatra
 dussehra
-easter day
+easter
 eid ul adha
 eid ul fitar
-fathers day
+fathers
 first day of hanukkah
 first day of passover
-friendship day
+friendship
 ganesh chaturthi
 good friday
 govardhan puja
 guru govind singh jayanti
 guru ravidas jayanti
-guru tegh bahadurs martyrdom day
+guru tegh bahadurs martyrdom
 halloween
 hazarat alis birthday
 holika dahana
 id e milad
-independence day
+independence
 jamat ul vida
 janmashtami
 june solstice
@@ -46,13 +46,13 @@ mahavir jayanti
 makar sankranti
 march equinox
 maundy thursday
-may day
+may
 mesadi
 milad un nabi
-mothers day
+mothers
 muharram
 naraka chaturdasi
-new years day
+new years
 new years eve
 onam
 parsi new year
@@ -63,15 +63,15 @@ raksha bandhan
 rama navami
 ramzan id
 rath yatra
-republic day
+republic
 september equinox
 shivaji jayanti
 shivaratri
 surya sashthi
-thanksgiving day
+thanksgiving
 vaisakhadi
 vaisakhi
-valentines day
+valentines
 vasant panchami
 vesak
 vinayaka chaturthi

--- a/share/spice/holiday/countries/iq.txt
+++ b/share/spice/holiday/countries/iq.txt
@@ -1,6 +1,6 @@
-army day
+army
 ashura
-christmas day
+christmas
 december solstice
 eid al adha
 eid al adha holiday
@@ -8,14 +8,14 @@ eid al fitr
 eid al fitr holiday
 end of ramadan
 feast of sacrifice
-iraqi independence day
+iraqi independence
 islamic new year
 june solstice
-labor day
+labor
 march equinox
-new years day
+new years
 new years eve
 nowruz
-republic day
+republic
 september equinox
 the prophets birthday

--- a/share/spice/holiday/countries/ir.txt
+++ b/share/spice/holiday/countries/ir.txt
@@ -10,20 +10,20 @@ eid e ghorban
 end of ramadan
 feast of sacrifice
 imam mahdis birthday
-islamic republic day
+islamic republic
 june solstice
 march equinox
 martyrdom of fatima
 martyrdom of imam ali
 martyrdom of imam reza
 martyrdom of imam sadeq
-nature day
+nature
 norooz
 norooz holiday
-oil nationalization day
+oil nationalization
 persian new year
 prophets ascension
 revolt of khordad 15
-revolution day
+revolution
 september equinox
 tassoua

--- a/share/spice/holiday/countries/is.txt
+++ b/share/spice/holiday/countries/is.txt
@@ -1,26 +1,26 @@
-ascension day
+ascension
 bank holiday
-christmas day
+christmas
 christmas eve
 december solstice
 easter monday
 easter sunday
-fathers day
+fathers
 first day of summer
 from noon
 good friday
 halloween
 holy saturday
-icelandic republic day
+icelandic republic
 june solstice
-labour day
+labour
 march equinox
 maundy thursday
-mothers day
-new years day
+mothers
+new years
 new years eve
 second day of christmas
 september equinox
-valentines day
+valentines
 whit monday
 whit sunday

--- a/share/spice/holiday/countries/it.txt
+++ b/share/spice/holiday/countries/it.txt
@@ -1,23 +1,23 @@
-all saints day
+all saints
 assumption of mary
-christmas day
+christmas
 december solstice
-easter day
+easter
 easter monday
 epiphany
 feast of the immaculate conception
 ferragosto
 good friday
 june solstice
-labor day
-liberation day
+labor
+liberation
 march equinox
-may day
-new years day
+may
+new years
 new years eve
-republic day
+republic
 september equinox
-st stephens day
+st stephens
 the feast of saint januarius
 the feast of st ambrose
 the feast of st john

--- a/share/spice/holiday/countries/jm.txt
+++ b/share/spice/holiday/countries/jm.txt
@@ -1,23 +1,22 @@
 ash wednesday
-boxing day
+boxing
 boxing day holiday
 christmas
-christmas day
 christmas eve
 december solstice
 easter monday
 easter sunday
-emancipation day
-fathers day
+emancipation
+fathers
 good friday
-independence day
+independence
 june solstice
-labor day
+labor
 march equinox
-may day
-mothers day
-national heroes day
-new years day
+may
+mothers
+national heroes
+new years
 new years eve
 september equinox
-valentines day
+valentines

--- a/share/spice/holiday/countries/jo.txt
+++ b/share/spice/holiday/countries/jo.txt
@@ -1,21 +1,21 @@
 al isra wal miraj
-christmas day
+christmas
 december solstice
-easter day
+easter
 easter monday
 eid al adha
 eid al adha holiday
 eid al fitr
 eid al fitr holiday
 good friday
-independence day
+independence
 june solstice
-labour day
+labour
 march equinox
 muharram
 new year
-new years day
-orthodox easter day
+new years
+orthodox easter
 prophets birthday
 ramadan begins
 september equinox

--- a/share/spice/holiday/countries/jp.txt
+++ b/share/spice/holiday/countries/jp.txt
@@ -1,29 +1,29 @@
-7 5 3 day
+7 5 3
 autumn equinox
-childrens day
+childrens
 christmas
-coming of age day
-constitution memorial day
-culture day
+coming of age
+constitution memorial
+culture
 december 31 bank holiday
 december solstice
 dolls festival
 emperors birthday
 girls festival
-greenery day
+greenery
 january 2 bank holiday
 january 3 bank holiday
 june solstice
-labor thanksgiving day
+labor thanksgiving
 march equinox
-mountain day
-national foundation day
-new years day
-respect for the aged day
-sea day
+mountain
+national foundation
+new years
+respect for the aged
+sea
 september equinox
-shōwa day
-sports day
+shōwa
+sports
 spring equinox
 spring equinox observed
 star festival

--- a/share/spice/holiday/countries/ke.txt
+++ b/share/spice/holiday/countries/ke.txt
@@ -1,5 +1,5 @@
-boxing day
-christmas day
+boxing
+christmas
 christmas day observed
 christmas eve
 december solstice
@@ -7,15 +7,15 @@ easter monday
 easter sunday
 eid al fitr
 good friday
-jamhuri day
+jamhuri
 june solstice
-labour day
-madaraka day
+labour
+madaraka
 march equinox
-mashujaa day
-may day
+mashujaa
+may
 may day observed
-mothers day
-new years day
+mothers
+new years
 new years eve
 september equinox

--- a/share/spice/holiday/countries/kg.txt
+++ b/share/spice/holiday/countries/kg.txt
@@ -1,20 +1,20 @@
-constitution day
+constitution
 constitution day of the kyrgyz republic
 day of the great october socialist revolution
 december solstice
-defender of the fatherland day
+defender of the fatherland
 defender of the fatherland extra holiday
 extra holiday
-extra working day
+extra working
 independence day of the kyrgyz republic
-international womens day
+international womens
 june solstice
 kurman ait
 march equinox
-may day
+may
 national holiday "nooruz"
 new year
 orozo ait
-orthodox christmas day
+orthodox christmas
 september equinox
-victory day
+victory

--- a/share/spice/holiday/countries/kh.txt
+++ b/share/spice/holiday/countries/kh.txt
@@ -1,26 +1,26 @@
 commemoration day of kings father
-constitutional day
+constitutional
 december solstice
-fathers day
-independence day
-international children day
-international human rights day
-international women day
+fathers
+independence
+international children
+international human rights
+international women
 june solstice
-khmer new year day
+khmer new year
 kings birthday
-kings coronation day
+kings coronation
 kings mothers birthday
-labour day
+labour
 labour day observed
 march equinox
-meak bochea day
-mothers day
+meak bochea
+mothers
 new year
-paris peace agreements day
-pchum ben day
+paris peace agreements
+pchum ben
 royal plowing ceremony
 september equinox
-victory over genocide day
-visak bochea day
+victory over genocide
+visak bochea
 water festival ceremony

--- a/share/spice/holiday/countries/km.txt
+++ b/share/spice/holiday/countries/km.txt
@@ -4,7 +4,7 @@ eid al adha
 eid al fitr
 isra and miraj
 june solstice
-labour day
+labour
 march equinox
 new year
 september equinox

--- a/share/spice/holiday/countries/kp.txt
+++ b/share/spice/holiday/countries/kp.txt
@@ -2,19 +2,19 @@ birth date of kim il sung
 birth date of kim jong il
 birth date of kim jong suk
 cheongwoldaeboreum
-chosun childrens union foundation day
-chosun peoples army foundation day
-constitution day
+chosun childrens union foundation
+chosun peoples army foundation
+constitution
 day of songun
 day of victory in the fatherland liberation war
 december solstice
-great leader kim jong il day
+great leader kim jong il
 june solstice
-lunar new years day
+lunar new years
 march equinox
-may day
-mothers day
-national day
+may
+mothers
+national
 new year
-party foundation day
+party foundation
 september equinox

--- a/share/spice/holiday/countries/kr.txt
+++ b/share/spice/holiday/countries/kr.txt
@@ -1,24 +1,24 @@
-arbor day
-armed forces day
+arbor
+armed forces
 buddhas birthday
-childrens day
-christmas day
+childrens
+christmas
 christmas eve
-constitution day
+constitution
 december solstice
-hangeul proclamation day
-independence movement day
+hangeul proclamation
+independence movement
 june solstice
-labor day
-liberation day
+labor
+liberation
 march equinox
-memorial day
-mid autumn festival day
-national foundation day
-new years day
+memorial
+mid autumn festival
+national foundation
+new years
 new years eve
-parents day
-seollal holiday day
+parents
+seollal holiday
 seollal substitute holiday
 september equinox
 temporary holiday

--- a/share/spice/holiday/countries/kw.txt
+++ b/share/spice/holiday/countries/kw.txt
@@ -8,11 +8,11 @@ feast of sacrifice
 islamic new year
 isra and miraj
 june solstice
-liberation day
+liberation
 march equinox
-national day
-new years day
+national
+new years
 new years eve
 september equinox
 the prophets birthday
-waqfat arafat day
+waqfat arafat

--- a/share/spice/holiday/countries/ky.txt
+++ b/share/spice/holiday/countries/ky.txt
@@ -1,24 +1,23 @@
 ash wednesday
-boxing day
+boxing
 boxing day holiday
 christmas
-christmas day
 christmas eve
-constitution day
+constitution
 december solstice
-discovery day
+discovery
 easter monday
 easter sunday
-fathers day
+fathers
 good friday
 halloween
 june solstice
 march equinox
-mothers day
-national heroes day
-new years day
+mothers
+national heroes
+new years
 new years eve
 queens birthday
-remembrance day
+remembrance
 september equinox
-valentines day
+valentines

--- a/share/spice/holiday/countries/kz.txt
+++ b/share/spice/holiday/countries/kz.txt
@@ -1,20 +1,19 @@
-constitution day
+constitution
 day of the capital
 day of the first president of the republic of kazakhstan
 december solstice
-defender of the fatherland day
+defender of the fatherland
 defender of the fatherland day observed
-independence day
-international womens day
+independence
+international womens
 june solstice
 kurban bairam
 march equinox
 nauryz
 new years
-new years day
 new years eve
-orthodox christmas day
+orthodox christmas
 september equinox
-unity day
+unity
 unity day observed
-victory day
+victory

--- a/share/spice/holiday/countries/lb.txt
+++ b/share/spice/holiday/countries/lb.txt
@@ -1,6 +1,6 @@
-all saints day
-ascension day
-christmas day
+all saints
+ascension
+christmas
 daylight saving time ends
 daylight saving time starts
 december solstice
@@ -11,19 +11,19 @@ feast of the annunciation
 feast of the assumption
 first day of ashura
 good friday
-independence day
+independence
 june solstice
-liberation and resistance day
+liberation and resistance
 march equinox
-martyrs day
-mothers day
+martyrs
+mothers
 muharram
 nativity of mary
 new year
-orthodox easter day
+orthodox easter
 orthodox good friday
 september equinox
-st marons day
-teachers day
+st marons
+teachers
 the prophets birthday
-workers day
+workers

--- a/share/spice/holiday/countries/li.txt
+++ b/share/spice/holiday/countries/li.txt
@@ -1,9 +1,9 @@
-all saints day
-ascension day
-berchtold day
+all saints
+ascension
+berchtold
 candlemas
 carnival
-christmas day
+christmas
 christmas eve
 corpus christi
 daylight saving time ends
@@ -15,16 +15,16 @@ epiphany
 feast of the immaculate conception
 good friday
 june solstice
-labour day
-liechtenstein national day
+labour
+liechtenstein national
 march equinox
-may day
+may
 nativity of our lady
-new years day
+new years
 new years eve
 september equinox
 shrove tuesday
-st josephs day
-st stephens day
+st josephs
+st stephens
 whit monday
 whit sunday

--- a/share/spice/holiday/countries/lk.txt
+++ b/share/spice/holiday/countries/lk.txt
@@ -1,37 +1,37 @@
-adhi esala full moon poya day
-bak full moon poya day
-binara full moon poya day
-christmas day
+adhi esala full moon poya
+bak full moon poya
+binara full moon poya
+christmas
 christmas eve
-day after vesak full moon poya day
+day after vesak full moon poya
 december solstice
 deepavali
-duruthu full moon poya day
+duruthu full moon poya
 easter sunday
 eid al adha
 eid al fitr
 end of ramadan
-fathers day
+fathers
 feast of sacrifice
 good friday
 holy prophets birthday
-il full moon poya day
+il full moon poya
 june solstice
-labour day
-madin full moon poya day
-mahasivarathri day
+labour
+madin full moon poya
+mahasivarathri
 march equinox
 milad un nabi
-mothers day
-national day
-navam full moon poya day
-nikini full moon poya day
-poson full moon poya day
+mothers
+national
+navam full moon poya
+nikini full moon poya
+poson full moon poya
 september equinox
-sinhala and tamil new years day
+sinhala and tamil new years
 sinhala and tamil new years eve
-tamil thai pongal day
-unduvap full moon poya day
-valentines day
-vap full moon poya day
-vesak full moon poya day
+tamil thai pongal
+unduvap full moon poya
+valentines
+vap full moon poya
+vesak full moon poya

--- a/share/spice/holiday/countries/lr.txt
+++ b/share/spice/holiday/countries/lr.txt
@@ -1,16 +1,16 @@
-armed forces day
-christmas day
+armed forces
+christmas
 december solstice
-decoration day
-fast and prayer day
-flag day
-independence day
+decoration
+fast and prayer
+flag
+independence
 j j roberts birthday
 june solstice
 march equinox
-national unification day
+national unification
 new year
-pioneers day
+pioneers
 september equinox
 thanksgiving
 william tubmans birthday

--- a/share/spice/holiday/countries/ls.txt
+++ b/share/spice/holiday/countries/ls.txt
@@ -1,15 +1,15 @@
-africa day
-ascension day
-boxing day
-christmas day
+africa
+ascension
+boxing
+christmas
 december solstice
 easter monday
 good friday
-independence day
+independence
 june solstice
 kings birthday
 march equinox
-may day
+may
 moshoeshoes birthday
 new year
 september equinox

--- a/share/spice/holiday/countries/lt.txt
+++ b/share/spice/holiday/countries/lt.txt
@@ -1,6 +1,6 @@
-all saints day
+all saints
 carnival
-christmas day
+christmas
 christmas eve
 daylight saving time ends
 daylight saving time starts
@@ -8,22 +8,22 @@ day of dew
 december solstice
 easter monday
 easter sunday
-fathers day
+fathers
 feast of the assumption of mary
 good friday
 halloween
 holy saturday
-independence day
-independence restoration day
+independence
+independence restoration
 june solstice
-king mindaugas’ coronation day
-labour day
+king mindaugas’ coronation
+labour
 march equinox
-mothers day
-national day
-new years day
+mothers
+national
+new years
 new years eve
 second day of christmas
 september equinox
-st johns day
-valentines day
+st johns
+valentines

--- a/share/spice/holiday/countries/lu.txt
+++ b/share/spice/holiday/countries/lu.txt
@@ -1,20 +1,20 @@
-all saints day
-ascension day
+all saints
+ascension
 assumption of mary
-christmas day
+christmas
 christmas eve
 december solstice
-easter day
+easter
 easter monday
 good friday
 june solstice
-labor day
+labor
 march equinox
-may day
-national day
-new years day
+may
+national
+new years
 new years eve
 september equinox
-st stephens day
+st stephens
 whit monday
 whit sunday

--- a/share/spice/holiday/countries/lv.txt
+++ b/share/spice/holiday/countries/lv.txt
@@ -1,26 +1,26 @@
-christmas day
+christmas
 christmas eve
 daylight saving time ends
 daylight saving time starts
 december solstice
 easter monday
 easter sunday
-fathers day
+fathers
 good friday
 halloween
 holy saturday
-independence restoration day
+independence restoration
 june solstice
-labour day
+labour
 march equinox
-may day
-midsummer day
+may
+midsummer
 midsummer eve
-mothers day
-new years day
+mothers
+new years
 new years eve
-republic of latvia proclamation day
+republic of latvia proclamation
 second day of christmas
 september equinox
-valentines day
+valentines
 whitsunday

--- a/share/spice/holiday/countries/ly.txt
+++ b/share/spice/holiday/countries/ly.txt
@@ -3,12 +3,12 @@ day of martyr omar al mokhtar
 december solstice
 eid al adha
 eid al fitr
-independence day
+independence
 june solstice
-liberation day
-libyan revolution day
+liberation
+libyan revolution
 march equinox
-may day
+may
 muharram
 september equinox
 the prophets birthday

--- a/share/spice/holiday/countries/ma.txt
+++ b/share/spice/holiday/countries/ma.txt
@@ -11,12 +11,12 @@ eid al fitr
 eid al fitr holiday
 feast of the throne
 hijra new year
-independence day
+independence
 june solstice
-labour day
+labour
 march equinox
-may day
-new years day
+may
+new years
 september equinox
 the prophet muhammads birthday
-youth day
+youth

--- a/share/spice/holiday/countries/mc.txt
+++ b/share/spice/holiday/countries/mc.txt
@@ -1,7 +1,7 @@
-all saints day
-ascension day
+all saints
+ascension
 assumption of mary
-christmas day
+christmas
 christmas day observed
 christmas eve
 corpus christi
@@ -14,14 +14,14 @@ feast of the immaculate conception
 good friday
 holy saturday
 june solstice
-labour day
+labour
 march equinox
-may day
+may
 may day observed
-national day
-new years day
+national
+new years
 new years eve
-saint dévotes day
+saint dévotes
 september equinox
 whit monday
 whit sunday

--- a/share/spice/holiday/countries/md.txt
+++ b/share/spice/holiday/countries/md.txt
@@ -1,40 +1,40 @@
-christmas day
+christmas
 christmas eve
 compensation for womens day extra holiday
-constitution day
+constitution
 daylight saving time ends
 daylight saving time starts
 december solstice
-dniester day
-europe day
+dniester
+europe
 extra holiday
-family day
+family
 first day of spring
 halloween
-independence day
+independence
 independence day holiday
-international childrens day
+international childrens
 international day of solidarity of workers
-international human rights day
-international womens day
+international human rights
+international womens
 june solstice
-language day
+language
 march equinox
 martisor
-memorial day
-new years day
+memorial
+new years
 new years eve
-orthodox christmas day
+orthodox christmas
 orthodox christmas day holiday
 orthodox easter monday
 orthodox easter sunday
 orthodox good friday
 orthodox holy saturday
-parents day
+parents
 september equinox
-state flag day
-statehood day
-valentines day
-victory day
-wine day
-world environment day
+state flag
+statehood
+valentines
+victory
+wine
+world environment

--- a/share/spice/holiday/countries/me.txt
+++ b/share/spice/holiday/countries/me.txt
@@ -1,16 +1,16 @@
-christmas day
+christmas
 christmas eve
 december solstice
 easter monday
 easter sunday
 good friday
-independence day
+independence
 june solstice
-labour day
+labour
 march equinox
-may day
-new years day
+may
+new years
 new years eve
 orthodox
 september equinox
-statehood day
+statehood

--- a/share/spice/holiday/countries/mg.txt
+++ b/share/spice/holiday/countries/mg.txt
@@ -1,16 +1,16 @@
-all saints day
-ascension day
+all saints
+ascension
 assumption of mary
-christmas day
+christmas
 december solstice
 easter monday
-independence day
-international womens day
+independence
+international womens
 june solstice
-labour day
+labour
 march equinox
-martyrs day
+martyrs
 new year
-republic day
+republic
 september equinox
 whit monday

--- a/share/spice/holiday/countries/mk.txt
+++ b/share/spice/holiday/countries/mk.txt
@@ -1,7 +1,7 @@
-albanian alphabet day
+albanian alphabet
 albanian community
-all saints day
-christmas day
+all saints
+christmas
 christmas eve
 daylight saving time ends
 daylight saving time starts
@@ -14,7 +14,7 @@ easter sunday
 eid al adha
 eid al fitr
 epiphany
-fathers day
+fathers
 feast of sacrifice
 feast of the assumption of mary
 first day of yom kippur
@@ -23,25 +23,25 @@ for romani community
 for vlach community
 good friday
 halloween
-independence day
-international bosniaks day
-international romani day
-international womens day
+independence
+international bosniaks
+international romani
+international womens
 jewish community
 june solstice
-labour day
+labour
 march equinox
-mothers day
-new years day
+mothers
+new years
 new years eve
 orthodox
-orthodox christmas day
-republic day
-saint kliment ohridskis day
-saints cyril and methodius day
+orthodox christmas
+republic
+saint kliment ohridskis
+saints cyril and methodius
 september equinox
-st savas day
+st savas
 turkish community
-turkish language day
-valentines day
-vlach’s national day
+turkish language
+valentines
+vlach’s national

--- a/share/spice/holiday/countries/ml.txt
+++ b/share/spice/holiday/countries/ml.txt
@@ -1,13 +1,13 @@
-africa day
-christmas day
+africa
+christmas
 december solstice
 easter monday
 eid al adha
 eid al fitr
-independence day
+independence
 june solstice
 march equinox
-martyrs day
+martyrs
 september equinox
 the prophets birthday
 whit monday

--- a/share/spice/holiday/countries/mn.txt
+++ b/share/spice/holiday/countries/mn.txt
@@ -1,26 +1,26 @@
-capital city day
-constitution day
+capital city
+constitution
 daylight saving time ends
 daylight saving time starts
 december solstice
-elders day
-family day
-health day
-human rights day
-independence day
-intellectual property day
-international womens day
+elders
+family
+health
+human rights
+independence
+intellectual property
+international womens
 june solstice
 march equinox
 naadam holiday
-national day
+national
 new year
-patriots day
-political flag day
-repression victims day
-republics day
+patriots
+political flag
+repression victims
+republics
 september equinox
-soldiers day
+soldiers
 tsagaan sar
-valentines day
-youths day
+valentines
+youths

--- a/share/spice/holiday/countries/mo.txt
+++ b/share/spice/holiday/countries/mo.txt
@@ -1,26 +1,26 @@
-all souls day
+all souls
 buddhas birthday
 cheng ming festival
 chong yeung festival
-christmas day
+christmas
 christmas eve
 day after the mid autumn festival
 december solstice
 dragon boat festival
 feast of the immaculate conception
 festival of ancestors
-first day
+first
 good friday
 holy saturday
 june solstice
-labor day
+labor
 lunar new year
-macau sar establishment day
+macau sar establishment
 march equinox
-may day
+may
 national day of the peoples republic of china
-new years day
+new years
 new years eve
-second day
+second
 september equinox
-third day
+third

--- a/share/spice/holiday/countries/mq.txt
+++ b/share/spice/holiday/countries/mq.txt
@@ -1,15 +1,15 @@
 all saints eve
-armistice day
-ascension day
+armistice
+ascension
 assumption of mary
-bastille day
-christmas day
+bastille
+christmas
 december solstice
 easter monday
 june solstice
-labor day
+labor
 march equinox
 new year
 september equinox
-victory day
+victory
 whit monday

--- a/share/spice/holiday/countries/mt.txt
+++ b/share/spice/holiday/countries/mt.txt
@@ -1,6 +1,6 @@
 bank holiday
-boxing day
-christmas day
+boxing
+christmas
 christmas eve
 easter monday
 easter sunday
@@ -8,14 +8,14 @@ feast of saint joseph
 feast of saint pauls shipwreck
 feast of saints peter and paul
 feast of the immaculate conception
-freedom day
+freedom
 good friday
-independence day
-labour day
-may day
-new years day
+independence
+labour
+may
+new years
 new years eve
-republic day
+republic
 sette giugno
 the feast of marys assumption
 the feast of our lady of victories

--- a/share/spice/holiday/countries/mu.txt
+++ b/share/spice/holiday/countries/mu.txt
@@ -1,20 +1,20 @@
 abolition of slavery
-all saints day
+all saints
 arrival of indentured labourers
 assumption of mary
 chinese spring festival
-christmas day
+christmas
 december solstice
 diwali
 eid al fitr
-fathers day
+fathers
 ganesh chaturthi
 june solstice
-labour day
+labour
 maha shivaratree
 march equinox
-mothers day
-national day
+mothers
+national
 new year
 ougadi
 september equinox

--- a/share/spice/holiday/countries/mw.txt
+++ b/share/spice/holiday/countries/mw.txt
@@ -1,16 +1,16 @@
-christmas day
+christmas
 december solstice
 easter monday
 eid al fitr
-freedom day
+freedom
 good friday
-independence day
-john chilembwe day
+independence
+john chilembwe
 june solstice
-kamuzu day
+kamuzu
 march equinox
-martyrs day
-may day
-mothers day
+martyrs
+may
+mothers
 new year
 september equinox

--- a/share/spice/holiday/countries/mx.txt
+++ b/share/spice/holiday/countries/mx.txt
@@ -1,44 +1,44 @@
-all saints day
-all souls day
-ascension day
+all saints
+all souls
+ascension
 ash wednesday
 assumption of mary
 battle of puebla
 benito juárezs birthday memorial
-childrens day
-christmas day
+childrens
+christmas
 christmas eve
-christ the king day
-columbus day
-constitution day
+christ the king
+columbus
+constitution
 corpus christi
-day off for constitution day
+day off for constitution
 day off for revolution day memorial
 day of the holy innocents
 day of the holy kings
 day of the virgin of guadalupe
 december solstice
-easter day
-fathers day
+easter
+fathers
 feast of the immaculate conception
-flag day
+flag
 good friday
 halloween
 holy saturday
-independence day
+independence
 june solstice
-labor day
+labor
 march equinox
 maundy thursday
-may day
-mothers day
-new years day
+may
+mothers
+new years
 new years eve
-oil expropriation day
+oil expropriation
 palm sunday
 revolution day memorial
 september equinox
 shout of dolores
-teachers day
-valentines day
+teachers
+valentines
 whit sunday

--- a/share/spice/holiday/countries/my.txt
+++ b/share/spice/holiday/countries/my.txt
@@ -1,26 +1,26 @@
-chinese lunar new years day
-christmas day
+chinese lunar new years
+christmas
 christmas eve
 december solstice
 deepavali
 diwali
 easter sunday
-federal territory day
-georgetown world heritage city day
+federal territory
+georgetown world heritage city
 good friday
 hari raya haji
 hari raya haji holiday
-hari raya puasa day
+hari raya puasa
 harvest festival
 isra and miraj
 june solstice
-labour day
-malaysia day
-malaysias national day
+labour
+malaysia
+malaysias national
 march equinox
 muharram
 new year
-new years day
+new years
 new years eve
 nuzul al quran
 penang governors birthday
@@ -30,4 +30,4 @@ september equinox
 thaipusam
 the prophet muhammads birthday
 the yang di pertuan agongs birthday
-wesak day
+wesak

--- a/share/spice/holiday/countries/mz.txt
+++ b/share/spice/holiday/countries/mz.txt
@@ -1,14 +1,14 @@
-armed forces day
-christmas day
+armed forces
+christmas
 december solstice
 good friday
-independence day
+independence
 june solstice
 march equinox
-may day
-mozambican heroes day
-mozambican womans day
+may
+mozambican heroes
+mozambican womans
 new year
-peace and reconciliation day
+peace and reconciliation
 september equinox
-victory day
+victory

--- a/share/spice/holiday/countries/na.txt
+++ b/share/spice/holiday/countries/na.txt
@@ -1,19 +1,19 @@
-africa day
-ascension day
-cassinga day
-christmas day
+africa
+ascension
+cassinga
+christmas
 daylight saving time ends
 daylight saving time starts
 day of goodwill
 december solstice
-easter day
+easter
 easter monday
 good friday
-heroes day
-independence day
-international human rights day
+heroes
+independence
+international human rights
 june solstice
 march equinox
-may day
+may
 new year
 september equinox

--- a/share/spice/holiday/countries/ne.txt
+++ b/share/spice/holiday/countries/ne.txt
@@ -1,17 +1,17 @@
-christmas day
-concord day
+christmas
+concord
 december solstice
 easter monday
 eid al adha
 eid al fitr
-fathers day
+fathers
 june solstice
-labour day
+labour
 lailat al qadr
 march equinox
 muharram
 new year
-nigerien independence day
-nigerien republic day
+nigerien independence
+nigerien republic
 september equinox
 the prophets birthday

--- a/share/spice/holiday/countries/ng.txt
+++ b/share/spice/holiday/countries/ng.txt
@@ -1,11 +1,11 @@
 al hijra
-boxing day
-childrens day
-christmas day
+boxing
+childrens
+christmas
 christmas eve
 december solstice
-democracy day
-easter day
+democracy
+easter
 easter monday
 good friday
 holy saturday
@@ -18,10 +18,10 @@ islamic new year
 june 12 commemoration
 june solstice
 march equinox
-national day
-new years day
+national
+new years
 new years eve
 september equinox
-womens day
-workers day
+womens
+workers
 workers day holiday

--- a/share/spice/holiday/countries/ni.txt
+++ b/share/spice/holiday/countries/ni.txt
@@ -1,24 +1,24 @@
-all saints day
-army day
+all saints
+army
 battle of san jacinto
-christmas day
+christmas
 december solstice
-easter day
+easter
 feast of the immaculate conception
 good friday
 holy saturday
-independence day
-indigenous resistance day
+independence
+indigenous resistance
 june solstice
-labor day
+labor
 last day of santo domingo celebrations
 march equinox
 maundy thursday
-may day
+may
 may day observed
-mothers day
-new years day
+mothers
+new years
 new years eve
 santo domingo celebrations start
 september equinox
-the sandinista revolution day
+the sandinista revolution

--- a/share/spice/holiday/countries/nl.txt
+++ b/share/spice/holiday/countries/nl.txt
@@ -1,21 +1,21 @@
-ascension day
-christmas day
+ascension
+christmas
 christmas eve
 december solstice
-easter day
+easter
 easter monday
 good friday
 june solstice
 kings birthday
-liberation day
+liberation
 march equinox
-new years day
+new years
 new years eve
-remembrance day
+remembrance
 second day of christmas
 september equinox
 sinterklaas
-st nicholas day
+st nicholas
 st nicholas eve
 whit monday
 whit sunday

--- a/share/spice/holiday/countries/no.txt
+++ b/share/spice/holiday/countries/no.txt
@@ -1,44 +1,44 @@
-17 may constitution day
-ascension day
-boxing day
+17 may constitution
+ascension
+boxing
 carnival
-christmas day
+christmas
 christmas eve
-crown prince haakons day
-crown princess mette marits day
+crown prince haakons
+crown princess mette marits
 daylight saving time ends
 daylight saving time starts
 day of liberation
 december solstice
 dissolution of union with sweden
-easter day
+easter
 easter monday
-fathers day
+fathers
 first sunday advent
 fourth sunday advent
 good friday
 halloween
 holy saturday
 june solstice
-king harald vs day
-labor day
+king harald vs
+labor
 march equinox
 maundy thursday
 midsummer eve
-mothers day
-new years day
+mothers
+new years
 new years eve
 palm sunday
 pentecost eve
-princess ingrid alexandras day
-queen sonjas day
+princess ingrid alexandras
+queen sonjas
 second sunday advent
 september equinox
-st johns day
-st olafs day
-the saami peoples day
+st johns
+st olafs
+the saami peoples
 third sunday advent
-united nations day
-valentines day
+united nations
+valentines
 whit monday
 whit sunday

--- a/share/spice/holiday/countries/np.txt
+++ b/share/spice/holiday/countries/np.txt
@@ -18,10 +18,10 @@ maha shivarati
 majdoor divas
 march equinox
 nari dibas
-national democracy day
+national democracy
 nawami
 nepali new year
 phulpati
 september equinox
-sushil koirala day
+sushil koirala
 tihar

--- a/share/spice/holiday/countries/nz.txt
+++ b/share/spice/holiday/countries/nz.txt
@@ -1,27 +1,27 @@
-anzac day
+anzac
 april fools
-boxing day
-christmas day
+boxing
+christmas
 christmas day observed
 christmas eve
-day after new years day
+day after new years
 december solstice
 deepavali
 diwali
-easter day
+easter
 easter monday
-fathers day
+fathers
 good friday
 halloween
 holy saturday
 june solstice
-labour day
+labour
 march equinox
-mothers day
-new years day
+mothers
+new years
 new years eve
 queens birthday
 september equinox
-valentines day
-waitangi day
+valentines
+waitangi
 waitangi day observed

--- a/share/spice/holiday/countries/om.txt
+++ b/share/spice/holiday/countries/om.txt
@@ -5,8 +5,8 @@ isra and miraj
 june solstice
 march equinox
 muharram
-national day
+national
 new year
-renaissance day
+renaissance
 september equinox
 the prophets birthday

--- a/share/spice/holiday/countries/pa.txt
+++ b/share/spice/holiday/countries/pa.txt
@@ -1,26 +1,26 @@
 ash wednesday
 carnival
-christmas day
+christmas
 christmas day observed
 christmas eve
-colon day
+colon
 december solstice
-easter day
-flag day
+easter
+flag
 foundation of old panama city
 good friday
 holy saturday
-independence day
+independence
 independence from spain
 june solstice
-labor day
+labor
 march equinox
-martyrs day
+martyrs
 maundy thursday
-may day
+may
 may day observed
-mother day
-new years day
+mother
+new years
 new years eve
 september equinox
 shout in villa de los santos

--- a/share/spice/holiday/countries/pe.txt
+++ b/share/spice/holiday/countries/pe.txt
@@ -1,28 +1,28 @@
-all saints day
-all souls day
-armed forces day
+all saints
+all souls
+armed forces
 battle of angamos
-christmas day
+christmas
 christmas day observed
 christmas eve
 december solstice
-easter day
-farmer day
-fathers day
+easter
+farmer
+fathers
 feast of the immaculate conception
-flag day
+flag
 good friday
-independence day
-inti raymi day
+independence
+inti raymi
 june solstice
-labor day
+labor
 march equinox
 maundy thursday
-may day
-mothers day
-new years day
+may
+mothers
+new years
 new years eve
 santa rosa de lima
 september equinox
 st peter and st paul
-the three wise men day
+the three wise men

--- a/share/spice/holiday/countries/ph.txt
+++ b/share/spice/holiday/countries/ph.txt
@@ -1,9 +1,9 @@
-all saints day
-all souls day
+all saints
+all souls
 amun jadid
-bonifacio day
-chinese lunar new years day
-christmas day
+bonifacio
+chinese lunar new years
+christmas
 christmas eve
 december solstice
 easter sunday
@@ -12,21 +12,21 @@ feast of the sacrifice
 good friday
 holy saturday
 id ul adha
-independence day
+independence
 june solstice
-labor day
+labor
 lailatul isra wal mi raj
 march equinox
 maulid un nabi
 maundy thursday
 national elections
 national heroes day holiday
-new years day
+new years
 new years eve
-ninoy aquino day
+ninoy aquino
 people power anniversary
-rizal day
+rizal
 september equinox
-special non working day
+special non working
 special non working day after new year
 the day of valor

--- a/share/spice/holiday/countries/pk.txt
+++ b/share/spice/holiday/countries/pk.txt
@@ -1,5 +1,5 @@
 chelum
-christmas day
+christmas
 christmas eve
 day after christmas
 december solstice
@@ -9,22 +9,22 @@ easter monday
 easter sunday
 eid e rizwan
 eid milad un nabi
-eid ul azha day
-eid ul fitr day
+eid ul azha
+eid ul fitr
 first day of ashura
 good friday
 holi
-independence day
-iqbal day
+independence
+iqbal
 july 1 bank holiday
 june solstice
-kashmir day
-labour day
+kashmir
+labour
 march equinox
-new years day
+new years
 new years eve
-pakistan day
-quaid e azam day
+pakistan
+quaid e azam
 second day of ashura
 september equinox
 shab e barat

--- a/share/spice/holiday/countries/pl.txt
+++ b/share/spice/holiday/countries/pl.txt
@@ -1,25 +1,25 @@
-all saints day
+all saints
 assumption of mary
-christmas day
+christmas
 christmas eve
-constitution day
+constitution
 corpus christi
 december solstice
-easter day
+easter
 easter monday
 epiphany
-fathers day
+fathers
 good friday
 holy saturday
-independence day
+independence
 june solstice
-labor day
+labor
 march equinox
-may day
-mothers day
-new years day
+may
+mothers
+new years
 new years eve
 second day of christmas
 september equinox
-valentines day
+valentines
 whit sunday

--- a/share/spice/holiday/countries/pr.txt
+++ b/share/spice/holiday/countries/pr.txt
@@ -1,27 +1,27 @@
 carnival
-christmas day
+christmas
 christmas eve
-columbus day
-constitution day
+columbus
+constitution
 december solstice
-discovery day
+discovery
 easter sunday
-emancipation day
+emancipation
 epiphany
-fathers day
+fathers
 good friday
 june solstice
-labor day
+labor
 march equinox
-martin luther king jr day
-memorial day
-mothers day
-new years day
+martin luther king jr
+memorial
+mothers
+new years
 new years eve
-presidents day
+presidents
 september equinox
 shrove tuesday
-thanksgiving day
-us independence day
-valentines day
-veterans day
+thanksgiving
+us independence
+valentines
+veterans

--- a/share/spice/holiday/countries/pt.txt
+++ b/share/spice/holiday/countries/pt.txt
@@ -1,23 +1,23 @@
-all saints day
+all saints
 assumption of mary
 carnival
-christmas day
+christmas
 christmas eve
 corpus christi
 daylight saving time ends
 daylight saving time starts
 december solstice
-easter day
+easter
 feast of the immaculate conception
 good friday
 june solstice
-labor day
-liberty day
+labor
+liberty
 march equinox
-may day
-new years day
+may
+new years
 new years eve
-portugal day
+portugal
 republic implantation
 restoration of independence
 september equinox

--- a/share/spice/holiday/countries/py.txt
+++ b/share/spice/holiday/countries/py.txt
@@ -1,6 +1,6 @@
-boqueron battle victory day
+boqueron battle victory
 chaco armistice
-christmas day
+christmas
 christmas day observed
 christmas eve
 daylight saving time ends
@@ -8,15 +8,15 @@ daylight saving time starts
 december solstice
 founding of asuncion
 good friday
-heroes day
-independence day
+heroes
+independence
 june solstice
-labor day
+labor
 march equinox
 maundy thursday
-may day
+may
 national holiday
-new years day
+new years
 new years eve
 september equinox
-virgin of caacupé day
+virgin of caacupé

--- a/share/spice/holiday/countries/qa.txt
+++ b/share/spice/holiday/countries/qa.txt
@@ -8,8 +8,8 @@ feast of sacrifice
 june solstice
 march bank holiday
 march equinox
-national day
-national sports day
-new years day
+national
+national sports
+new years
 new years eve
 september equinox

--- a/share/spice/holiday/countries/re.txt
+++ b/share/spice/holiday/countries/re.txt
@@ -1,16 +1,16 @@
 abolition of slavery
 all saints eve
-armistice day
-ascension day
+armistice
+ascension
 assumption of mary
-bastille day
-christmas day
+bastille
+christmas
 december solstice
 easter monday
 june solstice
-labour day
+labour
 march equinox
 new year
 september equinox
 whit monday
-wwii victory day
+wwii victory

--- a/share/spice/holiday/countries/ro.txt
+++ b/share/spice/holiday/countries/ro.txt
@@ -1,32 +1,32 @@
-childrens day
-christmas day
+childrens
+christmas
 christmas eve
-constantin brancusi day
-constitution day
-day after new years day
+constantin brancusi
+constitution
+day after new years
 december solstice
 dragobete
-fathers day
-flag day
+fathers
+flag
 halloween
-international womens day
+international womens
 june solstice
-labor day
+labor
 march equinox
 mărțișor
-may day
-mothers day
-national anthem day
+may
+mothers
+national anthem
 national holiday
-new years day
+new years
 new years eve
-orthodox ascension day
-orthodox easter day
+orthodox ascension
+orthodox easter
 orthodox easter monday
 orthodox pentecost
 orthodox pentecost monday
 second day of christmas
 september equinox
-st andrews day
-st marys day
-unification day
+st andrews
+st marys
+unification

--- a/share/spice/holiday/countries/rs.txt
+++ b/share/spice/holiday/countries/rs.txt
@@ -1,23 +1,23 @@
-armistice day
-christmas day
+armistice
+christmas
 december solstice
-holocaust remembrance day
+holocaust remembrance
 june solstice
 labor holiday
-labor holiday second day
+labor holiday second
 march equinox
-new years day
+new years
 new years eve
-orthodox easter day
+orthodox easter
 orthodox easter monday
 orthodox good friday
 orthodox holy saturday
 orthodox new year
-second day of new years day
+second day of new years
 september equinox
-spirituality day
+spirituality
 statehood day of the republic of serbia
-st savas day
-st vitus day
-victory day
-world war ii victims remembrance day
+st savas
+st vitus
+victory
+world war ii victims remembrance

--- a/share/spice/holiday/countries/ru.txt
+++ b/share/spice/holiday/countries/ru.txt
@@ -1,20 +1,20 @@
 december solstice
-defender of the fatherland day
-international womens day
+defender of the fatherland
+international womens
 june solstice
 march equinox
 new year holiday substitution
 new year holiday week
-new years day
+new years
 old new year
-orthodox christmas day
-orthodox easter day
-russia day
+orthodox christmas
+orthodox easter
+russia
 russia day observed
 september equinox
-special operations forces day
-spring and labor day
+special operations forces
+spring and labor
 spring and labor day observed
-unity day
-valentines day
-victory day
+unity
+valentines
+victory

--- a/share/spice/holiday/countries/rw.txt
+++ b/share/spice/holiday/countries/rw.txt
@@ -1,15 +1,15 @@
-assumption day
-boxing day
-christmas day
+assumption
+boxing
+christmas
 december solstice
 eid al fitr
 good friday
-independence day
+independence
 june solstice
-liberation day
+liberation
 march equinox
-may day
-national heroes day
+may
+national heroes
 new year
 september equinox
-tutsi genocide memorial day
+tutsi genocide memorial

--- a/share/spice/holiday/countries/sa.txt
+++ b/share/spice/holiday/countries/sa.txt
@@ -11,5 +11,5 @@ muharram
 muslim new year
 prophets birthday
 ramadan begins
-saudi national day
+saudi national
 september equinox

--- a/share/spice/holiday/countries/sc.txt
+++ b/share/spice/holiday/countries/sc.txt
@@ -1,15 +1,15 @@
 all saints eve
 assumption of mary
-christmas day
-constitution day
+christmas
+constitution
 december solstice
-easter day
+easter
 good friday
 immaculate conception
 june solstice
-labour day
-liberation day
+labour
+liberation
 march equinox
-national day
+national
 new year
 september equinox

--- a/share/spice/holiday/countries/sd.txt
+++ b/share/spice/holiday/countries/sd.txt
@@ -3,10 +3,10 @@ coptic easter
 december solstice
 eid al adha
 eid al fitr
-independence day
+independence
 june solstice
 march equinox
 muharram
-revolution day
+revolution
 september equinox
 the prophets birthday

--- a/share/spice/holiday/countries/se.txt
+++ b/share/spice/holiday/countries/se.txt
@@ -1,26 +1,26 @@
-all saints day
+all saints
 all saints eve
-ascension day
-boxing day
-christmas day
+ascension
+boxing
+christmas
 christmas eve
 daylight saving time ends
 daylight saving time starts
 december solstice
-easter day
+easter
 easter monday
 epiphany
-fathers day
+fathers
 good friday
 holy saturday
 june solstice
 march equinox
 may 1st
-midsummer day
+midsummer
 midsummer eve
-mothers day
-national day
-new years day
+mothers
+national
+new years
 new years eve
 pentecost eve
 september equinox

--- a/share/spice/holiday/countries/sg.txt
+++ b/share/spice/holiday/countries/sg.txt
@@ -1,6 +1,6 @@
-april fools day
-chinese lunar new years day
-christmas day
+april fools
+chinese lunar new years
+christmas
 christmas day observed
 christmas eve
 december solstice
@@ -9,25 +9,25 @@ diwali
 dragon boat festival
 easter saturday
 easter sunday
-fathers day
+fathers
 good friday
 hari raya haji
 hari raya puasa
-international museum day
-international womens day
+international museum
+international womens
 june solstice
-labour day
+labour
 labour day observed
 march equinox
-mothers day
-national day
-new years day
+mothers
+national
+new years
 new years eve
-racial harmony day
+racial harmony
 second day of chinese lunar new year
 september equinox
-singapore armed forces day
+singapore armed forces
 thaipusam
-total defense day
-valentines day
-vesak day
+total defense
+valentines
+vesak

--- a/share/spice/holiday/countries/sh.txt
+++ b/share/spice/holiday/countries/sh.txt
@@ -1,14 +1,14 @@
 august bank holiday
-boxing day
-christmas day
+boxing
+christmas
 december solstice
-easter day
+easter
 easter monday
 good friday
 june solstice
 march equinox
 new year
 queens birthday
-saint helenas day
+saint helenas
 september equinox
 whit monday

--- a/share/spice/holiday/countries/si.txt
+++ b/share/spice/holiday/countries/si.txt
@@ -1,23 +1,23 @@
 assumption of mary
-christmas day
+christmas
 day of uprising against occupation
 december solstice
-easter day
+easter
 easter monday
-independence and unity day
+independence and unity
 june solstice
-labor day
+labor
 labour day holiday
 march equinox
-may day
-new years day
-prešeren day
-reformation day
-remembrance day
-restoration of primorska to the motherland day
-rudolf maister day
+may
+new years
+prešeren
+reformation
+remembrance
+restoration of primorska to the motherland
+rudolf maister
 september equinox
-slovenians in prekmurje incorporated into the mother nation day
-sovereignty day
-statehood day
+slovenians in prekmurje incorporated into the mother nation
+sovereignty
+statehood
 whit sunday

--- a/share/spice/holiday/countries/sk.txt
+++ b/share/spice/holiday/countries/sk.txt
@@ -1,36 +1,36 @@
-all saints day
+all saints
 anniversary of the decease of m r ŝtefánika
 anniversary of the declaration of the slovak nation
 anniversary of the memorandum of the slovak nation
-birth of ľudovít ŝtúr day
-černová tragedy day
-christmas day
+birth of ľudovít ŝtúr
+černová tragedy
+christmas
 christmas eve
-constitution day
+constitution
 day of our lady of sorrows
 day of the declaration of slovakia as an independent ecclesiastic province
 day of the victims of holocaust and of racial violence
 december solstice
-dukla pass victims day
-easter day
+dukla pass victims
+easter
 easter monday
 end of world war ii
 epiphany
 establishment of the independent czecho slovak state
-fight for freedom and democracy day
-foreign slovaks day
-foundation of the slovak national council day
+fight for freedom and democracy
+foreign slovaks
+foundation of the slovak national council
 good friday
-independence day
+independence
 june solstice
-labor day
+labor
 march equinox
-matice slovenska day
-national uprising day
-reformation day
-republic day
+matice slovenska
+national uprising
+reformation
+republic
 september equinox
-st cyril & st methodius day
-struggle for human rights day
-st stephens day
-unfairly prosecuted persons day
+st cyril & st methodius
+struggle for human rights
+st stephens
+unfairly prosecuted persons

--- a/share/spice/holiday/countries/sl.txt
+++ b/share/spice/holiday/countries/sl.txt
@@ -1,10 +1,10 @@
-boxing day
-christmas day
+boxing
+christmas
 december solstice
 easter monday
 eid al fitr
 good friday
-independence day
+independence
 june solstice
 march equinox
 new year

--- a/share/spice/holiday/countries/sm.txt
+++ b/share/spice/holiday/countries/sm.txt
@@ -1,9 +1,9 @@
-all saints day
+all saints
 anniversary of the arengo
 anniversary of the fall of the fascist government
 assumption of mary
-boxing day
-christmas day
+boxing
+christmas
 christmas eve
 corpus christi
 daylight saving time ends
@@ -19,10 +19,10 @@ holy saturday
 investiture ceremony of the captains regent 1
 investiture ceremony of the captains regent 2
 june solstice
-labour day
+labour
 march equinox
-may day
-new years day
+may
+new years
 new years eve
 september equinox
-the feast of st marinus and republic day
+the feast of st marinus and republic

--- a/share/spice/holiday/countries/sn.txt
+++ b/share/spice/holiday/countries/sn.txt
@@ -1,17 +1,17 @@
-all saints day
-ascension day
+all saints
+ascension
 assumption of mary
-christmas day
+christmas
 december solstice
 easter monday
-fathers day
-independence day
+fathers
+independence
 june solstice
 korité
-labour day
+labour
 maouloud
 march equinox
-mothers day
+mothers
 new year
 september equinox
 tabaski

--- a/share/spice/holiday/countries/so.txt
+++ b/share/spice/holiday/countries/so.txt
@@ -2,12 +2,12 @@ ashura
 december solstice
 eid al adha
 eid al fitr
-independence day
+independence
 independence of british somaliland
 isra and miraj
 june solstice
 march equinox
-may day
+may
 muharram
 new year
 september equinox

--- a/share/spice/holiday/countries/sr.txt
+++ b/share/spice/holiday/countries/sr.txt
@@ -1,20 +1,20 @@
-boxing day
+boxing
 chinese new year
-christmas day
+christmas
 day of the maroons
 december solstice
 diwali
 easter monday
 eid al adha
 eid al fitr
-emancipation day
+emancipation
 good friday
 holi phagwa
-independence day
-indigenous peoples day
+independence
+indigenous peoples
 june solstice
-labor day
+labor
 march equinox
 new year
-revolution day
+revolution
 september equinox

--- a/share/spice/holiday/countries/ss.txt
+++ b/share/spice/holiday/countries/ss.txt
@@ -1,21 +1,21 @@
-christmas day
+christmas
 december solstice
-easter day
+easter
 eid al adha
 eid al fitr
-fathers day
-grandparents day
-independence day
-international womens day
+fathers
+grandparents
+independence
+international womens
 june solstice
 march equinox
-martyrs day
-may day
-mothers day
+martyrs
+may
+mothers
 new year
 new years eve
-peace agreement day
-republic day
+peace agreement
+republic
 september equinox
-spla day
-valentines day
+spla
+valentines

--- a/share/spice/holiday/countries/st.txt
+++ b/share/spice/holiday/countries/st.txt
@@ -1,11 +1,11 @@
-armed forces day
-christmas day
+armed forces
+christmas
 commemoration of the batepá massacre
 day of king amador
 december solstice
-independence day
+independence
 june solstice
-labour day
+labour
 march equinox
 nationalization of the roças
 new year

--- a/share/spice/holiday/countries/sv.txt
+++ b/share/spice/holiday/countries/sv.txt
@@ -1,29 +1,29 @@
-all saints day
+all saints
 celebrations of san salvador
-childrens day
-christmas day
+childrens
+christmas
 christmas day observed
 christmas eve
-columbus day
-cross day
+columbus
+cross
 december solstice
-easter day
-fathers day
+easter
+fathers
 good friday
 holy saturday
-independence day
+independence
 june solstice
-labor day
+labor
 march equinox
 maundy thursday
-may day
-mothers day
+may
+mothers
 national day of life, peace and justice
-new years day
+new years
 new years eve
 palm sunday
 september equinox
 signing of the peace accords
-soldiers day
-teachers day
-womens day
+soldiers
+teachers
+womens

--- a/share/spice/holiday/countries/sy.txt
+++ b/share/spice/holiday/countries/sy.txt
@@ -1,20 +1,20 @@
-christmas day
+christmas
 daylight saving time ends
 daylight saving time starts
 december solstice
-easter day
+easter
 eid al adha
 eid al fitr
-independence day
+independence
 june solstice
 march equinox
-martyrs day
-may day
-mothers day
+martyrs
+may
+mothers
 muharram
 new year
-october liberation day
-orthodox easter day
-revolution day
+october liberation
+orthodox easter
+revolution
 september equinox
 the prophets birthday

--- a/share/spice/holiday/countries/sz.txt
+++ b/share/spice/holiday/countries/sz.txt
@@ -1,18 +1,18 @@
-ascension day
+ascension
 birthday of king mswati iii
 birthday of the late king sobhuza
-boxing day
-christmas day
+boxing
+christmas
 december solstice
 easter monday
 good friday
-incwala day
-independence day
+incwala
+independence
 june solstice
 march equinox
-may day
-national flag day
+may
+national flag
 new year
 september equinox
-smhlolo day
+smhlolo
 umhlanga reed dance

--- a/share/spice/holiday/countries/td.txt
+++ b/share/spice/holiday/countries/td.txt
@@ -1,15 +1,15 @@
-christmas day
+christmas
 december solstice
 easter monday
 eid al adha
 eid al fitr
 end of the second world war
-fathers day
-independence day
+fathers
+independence
 june solstice
 march equinox
-may day
-mothers day
+may
+mothers
 new year
 proclamation of the republic
 september equinox

--- a/share/spice/holiday/countries/tg.txt
+++ b/share/spice/holiday/countries/tg.txt
@@ -1,16 +1,16 @@
-all saints day
+all saints
 anniversary of the failed attack on lomé
 assumption of mary
-christmas day
+christmas
 day of the martyrs
 december solstice
 easter monday
 eid al adha
 eid al fitr
-independence day
+independence
 june solstice
-labour day
-liberation day
+labour
+liberation
 march equinox
 new year
 september equinox

--- a/share/spice/holiday/countries/th.txt
+++ b/share/spice/holiday/countries/th.txt
@@ -1,33 +1,33 @@
 asalha bucha
-chakri day
-chinese lunar new years day
-christmas day
+chakri
+chinese lunar new years
+christmas
 christmas eve
-chulalongkorn day
+chulalongkorn
 chulalongkorn day observed
-constitution day
+constitution
 constitution day observed
-coronation day
+coronation
 december solstice
 extra holiday
-fathers day
+fathers
 june solstice
-labor day
+labor
 labor day observed
 makha bucha
 march equinox
 mid year bank holiday
-mothers day
-national childrens day
-new years day
+mothers
+national childrens
+new years
 new years eve
-royal ploughing ceremony day
+royal ploughing ceremony
 second day of chinese lunar new year
 september equinox
 songkran
-teachers day
+teachers
 the kings birthday
 the queens birthday
 third day of chinese lunar new year
-valentines day
+valentines
 visakha bucha

--- a/share/spice/holiday/countries/tn.txt
+++ b/share/spice/holiday/countries/tn.txt
@@ -1,16 +1,16 @@
 december solstice
 eid al adha
 eid al fitr
-evacuation day
-independence day
+evacuation
+independence
 june solstice
-labour day
+labour
 march equinox
-martyrs day
+martyrs
 muharram
 new year
-republic day
-revolution and youth day
+republic
+revolution and youth
 september equinox
 the prophets birthday
-womens and family day
+womens and family

--- a/share/spice/holiday/countries/tr.txt
+++ b/share/spice/holiday/countries/tr.txt
@@ -1,17 +1,17 @@
-ataturk memorial day
-commemoration of atatürk, youth and sports day
+ataturk memorial
+commemoration of atatürk, youth and sports
 december solstice
 june solstice
-labor and solidarity day
+labor and solidarity
 march equinox
-national sovereignty and childrens day
-new years day
+national sovereignty and childrens
+new years
 new years eve
 ramadan feast
 ramadan feast eve
-republic day
+republic
 republic day eve
 sacrifice feast
 sacrifice feast eve
 september equinox
-victory day
+victory

--- a/share/spice/holiday/countries/tt.txt
+++ b/share/spice/holiday/countries/tt.txt
@@ -1,6 +1,6 @@
-boxing day
+boxing
 carnival
-christmas day
+christmas
 christmas day observed
 christmas eve
 corpus christi
@@ -10,20 +10,20 @@ diwali
 easter monday
 easter sunday
 eid al fitr
-emancipation day
-fathers day
+emancipation
+fathers
 good friday
-independence day
-indian arrival day
+independence
+indian arrival
 june solstice
-labour day
+labour
 labour day observed
 march equinox
-mothers day
-new years day
+mothers
+new years
 new years eve
-republic day
+republic
 september equinox
 shrove tuesday
-spiritual baptist liberation day
-valentines day
+spiritual baptist liberation
+valentines

--- a/share/spice/holiday/countries/tw.txt
+++ b/share/spice/holiday/countries/tw.txt
@@ -1,50 +1,50 @@
-228 memorial day
+228 memorial
 228 memorial day observed
-arbor day
-armed forces day
+arbor
+armed forces
 buddhas birthday
 chen huangs birthday
 chi hsi festival
-childrens day
+childrens
 chinese new year holiday
-chinese new years day
+chinese new years
 chinese new years eve
-christmas day
-constitution day
+christmas
+constitution
 december solstice
 dōngzhì festival
-double ninth day
-double tenth day
+double ninth
+double tenth
 dragon boat festival
 dragon boat festival holiday
 earth gods birthday
 easter sunday
-farmers day
-fathers day
+farmers
+fathers
 ghost festival
 god of medicines birthday
 june solstice
 kuan kungs birthday
 kuan yins birthday
-labor day
+labor
 labor day observed
 lantern festival
-literary day
+literary
 march equinox
 matsus birthday
 mid autumn festival
-mothers day
-national day
-new years day
-opium suppression movement day
-overseas chinese day
-republic day
+mothers
+national
+new years
+opium suppression movement
+overseas chinese
+republic
 saisiat festival
 september equinox
 sun yat sens birthday
-taiwans retrocession day
-teachers day
-tomb sweeping day
-tourism day
-womens day
-youth day
+taiwans retrocession
+teachers
+tomb sweeping
+tourism
+womens
+youth

--- a/share/spice/holiday/countries/tz.txt
+++ b/share/spice/holiday/countries/tz.txt
@@ -1,5 +1,5 @@
-boxing day
-christmas day
+boxing
+christmas
 christmas eve
 december solstice
 easter monday
@@ -8,16 +8,16 @@ eid el fitri
 eid el hajj
 good friday
 june solstice
-karume day
+karume
 march equinox
-mothers day
-mwalimu nyerere day
-new years day
-peasants day
+mothers
+mwalimu nyerere
+new years
+peasants
 prophets birthday
-republic day
+republic
 saba saba
 september equinox
-union day
-workers day
-zanzibar revolution day
+union
+workers
+zanzibar revolution

--- a/share/spice/holiday/countries/ua.txt
+++ b/share/spice/holiday/countries/ua.txt
@@ -1,39 +1,39 @@
 april fools
-army day
+army
 baptism of kyivan rus
-christmas day
+christmas
 christmas day holiday
-constitution day
-cultural workers and folk artists day
+constitution
+cultural workers and folk artists
 daylight saving time ends
 daylight saving time starts
 december solstice
-defenders day
-dignity and freedom day
-europe day
-family day
-independence day
-international womens day
+defenders
+dignity and freedom
+europe
+family
+independence
+international womens
 june solstice
-kiev day
+kiev
 kupala night
-labor day
+labor
 labor day holiday
 march equinox
-memorial day
-mothers day
-navy day
-new years day
-orthodox easter day
+memorial
+mothers
+navy
+new years
+orthodox easter
 orthodox easter day holiday
 orthodox new year
 orthodox pentecost
 orthodox pentecost holiday
 september equinox
-special working day
-st nicholas day
-tatiana day
-teachers day
-ukrainian unity day
-valentines day
-victory day
+special working
+st nicholas
+tatiana
+teachers
+ukrainian unity
+valentines
+victory

--- a/share/spice/holiday/countries/ug.txt
+++ b/share/spice/holiday/countries/ug.txt
@@ -1,24 +1,24 @@
 amtseinführung museveni
-boxing day
-christmas day
+boxing
+christmas
 december solstice
-easter day
+easter
 easter monday
 eid al adha
 eid al fitr
-election day
-fathers day
+election
+fathers
 good friday
-independence day
-international womens day
+independence
+international womens
 june solstice
-liberation day
-local election day
+liberation
+local election
 march equinox
-martyrs day
-may day
-mothers day
-national heroes day
+martyrs
+may
+mothers
+national heroes
 new year
 remembrance of archbishop janani luwum
 september equinox

--- a/share/spice/holiday/countries/us.txt
+++ b/share/spice/holiday/countries/us.txt
@@ -1,206 +1,206 @@
-administrative professionals day
-air force birthday
-alaska day
-all saints day
-all souls day
-american eagle day
-american indian heritage day
-arbor day
-armed forces day
-ascension day
-ash wednesday
+administrative professionals
+air force birth
+alaska
+all saints
+all souls
+american eagle
+american indian heritage
+arbor
+armed forces
+ascension
+ash wednes
 assumption of mary
-bennington battle day
-black friday
-bosss day
-bunker hill day
-california admission day
-carl garner federal lands cleanup day
-casimir pulaski day
-césar chávez day
+bennington battle
+black fri
+bosss
+bunker hill
+california admission
+carl garner federal lands cleanup
+casimir pulaski
+césar chávez
 chanukah
-child health day
+child health
 chinese new year
-christmas day
+christmas
 christmas day observed
 christmas eve
 christmas eve observed
 cinco de mayo
-civil rights day
-colorado day
-columbus day
-confederate memorial day
-constitution day and citizenship day
+civil rights
+colorado
+columbus
+confederate memorial
+constitution day and citizenship
 constitution day and citizenship day observed
 corpus christi
-cyber monday
-daisy gatson bates day
-day after christmas day
+cyber mon
+d
+daisy gatson bates
+day after christmas
 daylight saving time ends
 daylight saving time starts
-d day
 december solstice
 deepavali
 diwali
-easter monday
-easter sunday
+easter mon
+easter sun
 eid al adha
 eid al fitr
-election day
-emancipation day
+election
+emancipation
 emancipation day observed
-emergency medical services for children day
-employee appreciation day
-eod day
+emergency medical services for children
+employee appreciation
+eod
 epiphany
-evacuation day
-father damien day
-fathers day
+evacuation
+father damien
+fathers
 feast of our lady of guadalupe
 feast of st francis of assisi
 feast of the immaculate conception
-first day
+first
 first day of sukkot
 first sunday of advent
-flag day
-gold star mothers day
-good friday
-groundhog day
+flag
+gold star mothers
+good fri
+groundhog
 halloween
 hanukkah
-harvey milk day
-holy saturday
-idaho human rights day
-independence day
-indigenous peoples day
+harvey milk
+holy satur
+idaho human rights
+independence
+indigenous peoples
 isra and miraj
-jefferson davis birthday
+jefferson davis birth
 june solstice
 juneteenth
-kamehameha day
+kamehameha
 kamehameha day observed
-kansas day
+kansas
 kent state shootings remembrance
 kwanzaa
-labor day
+labor
 lag baomer
 lailat al qadr
 last day of passover
 last day of sukkot
-law day
-lee jackson day
-leif erikson day
-lincolns birthday
-lincolns day
-linus pauling day
-loyalty day
-lyndon baines johnson day
+law
+lee jackson
+leif erikson
+lincolns
+lincolns birth
+linus pauling
+loyalty
+lyndon baines johnson
 march equinox
 mardi gras
-marine corps birthday
-martin luther king day
-maryland day
-maundy thursday
-memorial day
-mia recognition day
-mothers day
+marine corps birth
+martin luther king
+maryland
+maundy thurs
+memorial
+mia recognition
+mothers
 muharram
-national aviation day
+national aviation
 national day of prayer
-national defense transportation day
+national defense transportation
 national explosive ordnance disposal
-national freedom day
-national grandparents day
-national korean war veterans armistice day
-national library workers day
-national maritime day
-national missing childrens day
-national nurses day
+national freedom
+national grandparents
+national korean war veterans armistice
+national library workers
+national maritime
+national missing childrens
+national nurses
 national pow
-national tartan day
-national wear red day
-native americans day
-nevada day
-new years day
+national tartan
+national wear red
+native americans
+nevada
+new years
 new years eve
 new years eve observed
-oklahoma day
-orthodox christmas day
+oklahoma
+orthodox christmas
 orthodox easter
-orthodox easter monday
-orthodox good friday
-orthodox holy saturday
+orthodox easter mon
+orthodox good fri
+orthodox holy satur
 orthodox new year
-palm sunday
-pan american aviation day
-parents day
-pascua florida day
+palm sun
+pan american aviation
+parents
+pascua florida
 pascua florida day observed
 passover
-patriot day
-patriots day
-peace officers memorial day
-pearl harbor remembrance day
+patriot
+patriots
+peace officers memorial
+pearl harbor remembrance
 pentecost
-pioneer day
+pioneer
 pioneer day observed
-presidents day
+presidents
 primary election day indiana
 primary election day west virginia
-prince jonah kuhio kalanianaole day
+prince jonah kuhio kalanianaole
 prince jonah kuhio kalanianaole day observed
 purim
-purple heart day
+purple heart
 ramadan starts
-read across america day
+read across america
 return day delaware
-rhode island independence day
-robert e lees birthday
-rosa parks day
+rhode island independence
+robert e lees birth
+rosa parks
 rosh hashana
-san jacinto day
-senior citizens day
+san jacinto
+senior citizens
 september equinox
-sewards day
+sewards
 shavuot
 shmini atzeret
-shrove tuesday
+shrove tues
 simchat torah
-state holiday
-statehood day
+state holi
+statehood
 statehood day in arizona
 statehood day in hawaii
-st davids day
-stephen foster memorial day
-st nicholas day
-st patricks day
-susan b anthonys birthday
-take our daughters and sons to work day
-tax day
-texas independence day
-thanksgiving day
-the prophets birthday
-thomas jeffersons birthday
+st davids
+stephen foster memorial
+st nicholas
+st patricks
+susan b anthonys birth
+take our daughters and sons to work
+tax
+texas independence
+thanksgiving
+the prophets birth
+thomas jeffersons birth
 tisha bav
 town meeting day vermont
-trinity sunday
-truman day
+trinity sun
+truman
 truman day observed
 tu bishvat
 tu bshevat
 until jan 1
-us army birthday
-us coast guard birthday
-us national guard birthday
-us navy birthday
-valentines day
-veterans day
-victory day
-west virginia day
-white cane safety day
-whit monday
-womens equality day
-wright brothers day
+us army birth
+us coast guard birth
+us national guard birth
+us navy birth
+valentines
+veterans
+victory
+west virginia
+white cane safety
+whit mon
+womens equality
+wright brothers
 yom haatzmaut
 yom hashoah
 yom kippur

--- a/share/spice/holiday/countries/uy.txt
+++ b/share/spice/holiday/countries/uy.txt
@@ -1,24 +1,24 @@
-all saints day
+all saints
 battle of las piedras
 carnival
-christmas day
+christmas
 christmas eve
-columbus day
-constitution day
+columbus
+constitution
 december solstice
-easter day
+easter
 good friday
-independence day
+independence
 josé artigas birthday memorial
 june solstice
-labor day
+labor
 landing of the 33 orientals
 march equinox
 maundy thursday
-may day
-new years day
+may
+new years
 new years eve
 september equinox
 shrove tuesday
-the three wise men day
+the three wise men
 tourism week holiday

--- a/share/spice/holiday/countries/uz.txt
+++ b/share/spice/holiday/countries/uz.txt
@@ -1,15 +1,15 @@
-constitution day
+constitution
 december solstice
-defenders of the motherland day
+defenders of the motherland
 eid al adha
 eid al fitr
-extra non working day
-independence day
-international womens day
+extra non working
+independence
+international womens
 june solstice
 march equinox
 new year
 nowruz
-remembrance day
+remembrance
 september equinox
-teachers day
+teachers

--- a/share/spice/holiday/countries/va.txt
+++ b/share/spice/holiday/countries/va.txt
@@ -1,7 +1,7 @@
-all saints day
+all saints
 anniversary of the election of pope francis
 anniversary of the foundation of vatican city
-christmas day
+christmas
 christmas eve
 daylight saving time ends
 daylight saving time starts
@@ -16,11 +16,11 @@ good friday
 holy saturday
 june solstice
 march equinox
-new years day
+new years
 new years eve
 september equinox
 st georges feast
-st josephs day
-st stephens day
+st josephs
+st stephens
 the feasts of saints peter and paul
-vigil of assumption day
+vigil of assumption

--- a/share/spice/holiday/countries/ve.txt
+++ b/share/spice/holiday/countries/ve.txt
@@ -1,36 +1,36 @@
-all saints day
-all souls day
-ascension day
+all saints
+all souls
+ascension
 assumption of mary
-aviation day
+aviation
 carabobo battle
 carnival
-christmas day
+christmas
 christmas day observed
 christmas eve
 corpus christi
 december solstice
 declaration of independence
-easter day
+easter
 feast of the immaculate conception
-flags day
+flags
 friday holiday
 good friday
-independence day
-indigenous resistances day
+independence
+indigenous resistances
 june solstice
-labor day
+labor
 march equinox
 maundy thursday
-may day
-national guards day
-new years day
+may
+national guards
+new years
 new years eve
 our lady of coromoto
 palm sunday
-saint josephs day
+saint josephs
 saint peter and saint paul
 september equinox
 shrove tuesday
 simón bolívars birthday
-the three wise men day
+the three wise men

--- a/share/spice/holiday/countries/vi.txt
+++ b/share/spice/holiday/countries/vi.txt
@@ -1,30 +1,30 @@
-american independence day
-april fools day
-boxing day
-christmas day
-columbus day
+american independence
+april fools
+boxing
+christmas
+columbus
 december solstice
-easter day
+easter
 easter monday
-emancipation day
-fathers day
+emancipation
+fathers
 good friday
-hurricane supplication day
+hurricane supplication
 hurricane thanksgiving
 june solstice
-labor day
-liberty day
+labor
+liberty
 march equinox
-martin luther king jr day
+martin luther king jr
 maundy thursday
-memorial day
-mothers day
+memorial
+mothers
 new year
 new years eve
-presidents day
+presidents
 september equinox
-thanksgiving day
-three kings day
-transfer day
-veterans day
-virgin islands   puerto rico friendship day
+thanksgiving
+three kings
+transfer
+veterans
+virgin islands   puerto rico friendship

--- a/share/spice/holiday/countries/vn.txt
+++ b/share/spice/holiday/countries/vn.txt
@@ -1,22 +1,22 @@
-christmas day
+christmas
 christmas eve
 december solstice
 halloween
-independence day
-international labor day
+independence
+international labor
 international labor day observed
-international new years day
+international new years
 international new years eve
 june solstice
-liberation day
+liberation
 march equinox
-reunification day
+reunification
 reunification day observed
 september equinox
 tet holiday
-valentines day
-vietnamese family day
-vietnamese kings commemoration day
+valentines
+vietnamese family
+vietnamese kings commemoration
 vietnamese new year
 vietnamese new years eve
-vietnamese womens day
+vietnamese womens

--- a/share/spice/holiday/countries/ye.txt
+++ b/share/spice/holiday/countries/ye.txt
@@ -1,13 +1,13 @@
 december solstice
 eid al adha
 eid al fitr
-independence day
+independence
 june solstice
 march equinox
-may day
+may
 muharram
-north yemen revolution day
-revolution day
+north yemen revolution
+revolution
 september equinox
 the prophets birthday
-unity day
+unity

--- a/share/spice/holiday/countries/yt.txt
+++ b/share/spice/holiday/countries/yt.txt
@@ -1,7 +1,7 @@
 all saints eve
-ascension day
+ascension
 assumption of mary
-christmas day
+christmas
 december solstice
 easter monday
 eid al adha
@@ -9,7 +9,7 @@ eid al fitr
 end of the second world war
 french day of the republic
 june solstice
-labour day
+labour
 march equinox
 miraj
 new year

--- a/share/spice/holiday/countries/za.txt
+++ b/share/spice/holiday/countries/za.txt
@@ -1,26 +1,26 @@
-christmas day
+christmas
 christmas day observed
 christmas eve
 day of goodwill
 day of reconciliation
 december solstice
 easter sunday
-election day
-family day
-fathers day
-freedom day
+election
+family
+fathers
+freedom
 good friday
-heritage day
+heritage
 holy saturday
-human rights day
+human rights
 june solstice
 march equinox
-mothers day
-national womens day
-nelson mandela day
-new years day
+mothers
+national womens
+nelson mandela
+new years
 new years eve
 september equinox
-workers day
+workers
 workers day observed
-youth day
+youth

--- a/share/spice/holiday/countries/zm.txt
+++ b/share/spice/holiday/countries/zm.txt
@@ -1,21 +1,21 @@
-africa freedom day
-christmas day
-constitution amendment day
+africa freedom
+christmas
+constitution amendment
 december solstice
-easter day
+easter
 easter monday
-farmers day
-fathers day
+farmers
+fathers
 good friday
-half day
-heroes day
-independence day
-international womens day
+half
+heroes
+independence
+international womens
 june solstice
 march equinox
-may day
-mothers day
+may
+mothers
 new year
 september equinox
-unity day
-youth day
+unity
+youth

--- a/share/spice/holiday/countries/zw.txt
+++ b/share/spice/holiday/countries/zw.txt
@@ -1,18 +1,18 @@
-africa day
-boxing day
-christmas day
+africa
+boxing
+christmas
 december solstice
-defence forces day
-easter day
+defence forces
+easter
 easter monday
-fathers day
+fathers
 good friday
-heroes day
-independence day
+heroes
+independence
 june solstice
 march equinox
-mothers day
+mothers
 new year
 september equinox
-unity day
-workers day
+unity
+workers

--- a/share/spice/holiday/sanitize-holidays.sh
+++ b/share/spice/holiday/sanitize-holidays.sh
@@ -30,6 +30,9 @@ for country in `find ./countries -iname '*.txt' | xargs`; do
     sed -i 's/^[[:space:]]*//' $country   
     sed -i 's/[[:space:]]*$//' $country
 
+    # remove trailing suffix of "day", eg: "thanksgiving day"
+    sed -i 's/[[:space:]]day$//' $country
+
     # sort and remove duplicate entries
     sort -u -o $country $country
 


### PR DESCRIPTION
## Description of new Instant Answer, or changes
The query "when is thanksgiving" doesn't trigger this IA because the list of Holidays for "Canada" and "USA" (canada.txt, us.txt) have the name of the holiday as "thanksgiving day", so a check for "thanksgiving" does not match.

This PR removes "day" from all holidays, and strips it from the query when present to allow it to match the normalized data.


## Related Issues and Discussions
Fixes #3448 


## People to notify
CC: @sekhavati @moollaza 

---

IA Page: http://duck.co/ia/view/holiday
Maintainer: @sekhavati
