### PR TITLE
Thesaurus: Use TLS for the thesaurus

### DIFF
--- a/lib/DDG/Spice/Thesaurus.pm
+++ b/lib/DDG/Spice/Thesaurus.pm
@@ -5,7 +5,7 @@ use strict;
 use DDG::Spice;
 use Text::Trim;
 
-spice to => 'http://words.bighugelabs.com/api/2/{{ENV{DDG_SPICE_BIGHUGE_APIKEY}}}/$1/json?callback={{callback}}';
+spice to => 'https://words.bighugelabs.com/api/2/{{ENV{DDG_SPICE_BIGHUGE_APIKEY}}}/$1/json?callback={{callback}}';
 
 triggers startend => "synonyms", "synonym", "antonyms", "antonym", "thesaurus";
 

--- a/share/spice/thesaurus/thesaurus.js
+++ b/share/spice/thesaurus/thesaurus.js
@@ -66,7 +66,7 @@
             
             meta: {
                 sourceName: 'Big Huge Thesaurus',
-                sourceUrl:  'http://words.bighugelabs.com/' + query,
+                sourceUrl:  'https://words.bighugelabs.com/' + query,
             },
             
             normalize: function(words) {


### PR DESCRIPTION
## Description of new Instant Answer, or changes

Use TLS when linking to, or making request to the API that powers the thesaurus instant answer.

---

Instant Answer Page: https://duck.co/ia/view/thesaurus
