### PR TITLE
MagicTheGathering: Change card images to use smaller files

### DIFF
--- a/share/spice/magic_the_gathering/magic_the_gathering.js
+++ b/share/spice/magic_the_gathering/magic_the_gathering.js
@@ -36,7 +36,7 @@
                 item['set_label'] = item.set;
                 delete item.set;
                 var card_image = item.image_uris
-                            ? DDG.toHTTPS(item.image_uris.png)
+                            ? DDG.toHTTPS(item.image_uris.normal)
                             : "";
                 var classify = item.type_line.split('—');
                 var type = classify[0] ? classify[0].trim() : ' ';


### PR DESCRIPTION
<!-- 

***
DuckDuckHack is currently in Maintenance mode
Please read before submitting: https://duckduckhack.com
***

Use the appropriate format for your Pull Request title above ^^^^^:

If this is a bug fix:
{IA Name}: {Description of change}

If this is a New Instant Answer:
New {IA Name} Spice

If this is something else:
{Tests/Docs/Other}: {Short Description}

-->

## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
Changes Magic the Gathering IA, so smaller images are downloaded from Scryfall. More info on Scryfall image formats can be found [here](https://scryfall.com/docs/api/images).

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->
Fixes #3570 

## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@moollaza 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/magic_the_gathering
<!-- FILL THIS IN:                           ^^^^ -->
