### PR TITLE
Currency: Round to number of significant figures instead of number of decimal places.

### DIFF
--- a/share/spice/cryptocurrency/cryptocurrency.js
+++ b/share/spice/cryptocurrency/cryptocurrency.js
@@ -59,9 +59,14 @@
                 var left_input = $currency_input_left.val();
                 left_input = left_input.replace(/,/g, '');
                 var rightval = parseFloat(left_input) * Converter.rate;
-                var decimals = Converter.getSignificanDigits(Converter.toCurrency);
+                var numSigDigs = Converter
+                    .getSignificantDigits(Converter.toCurrency);
+                var rightValInt = Math.floor(rightval);
+                var rightValFrac = rightval % 1;
+
                 $currency_input_right.val(
-                    Number(rightval.toFixed(decimals)).toString()
+                    rightValInt.toString() +
+                    rightValFrac.toPrecision(numSigDigs).substring(1)
                 );
             } else {
                 $currency_input_right.val("");
@@ -74,9 +79,14 @@
                 var right_input = $currency_input_right.val()
                 right_input = right_input.replace(/,/g, '');
                 var leftval = parseFloat(right_input) / Converter.rate;
-                var decimals = Converter.getSignificanDigits(Converter.fromCurrency);
+                var numSigDigs = Converter
+                    .getSignificantDigits(Converter.fromCurrency);
+                var leftValInt = Math.floor(leftval);
+                var leftValFrac = leftval % 1;
+
                 $currency_input_left.val(
-                    Number(leftval.toFixed(decimals)).toString()
+                    leftValInt.toString() +
+                    leftValFrac.toPrecision(numSigDigs).substring(1)
                 );
             } else {
                 $currency_input_left.val("");
@@ -143,7 +153,7 @@
 
         // returns the amount of sig figs we need for a number.
         // crypto = 8, fiat = 2
-        getSignificanDigits: function(currency) {
+        getSignificantDigits: function(currency) {
             if($.inArray(currency, Converter.cryptoList) > -1) {
                 return 8;
             } else {
@@ -192,9 +202,15 @@
                     itemType: "Conversions"
                 },
                 normalize: function(item) {
+                    var val = queryAmount * price;
+                    var numSigDigs = Converter.getSignificantDigits(target);
+                    var valInt = Math.floor(val);
+                    var valFrac = val % 1;
+
                     return {
                         amount: queryAmount,
-                        convertedAmount: Number((queryAmount * price).toFixed(Converter.getSignificanDigits(target))).toString(),
+                        convertedAmount: valInt.toString() +
+                            valFrac.toPrecision(numSigDigs).substring(1),
                         cryptoTime: moment(item.ticker.timestamp).format("HH:mm"),
                         cryptoDate: moment(item.ticker.timestamp).format("YYYY-MM-DD")
                     };

--- a/share/spice/cryptocurrency/detail.handlebars
+++ b/share/spice/cryptocurrency/detail.handlebars
@@ -7,7 +7,7 @@
         <!-- LEFT INPUT SECTION -->
         <div class="frm clearfix">
             <div class="input__wrap input__wrap--left shadow">
-                <input class="frm__input frm__input--left" id="zci--cryptocurrency-amount-left" data-original="{{from-amount}}" data-processed="{{amount}}" value="{{amount}}">
+                <input class="frm__input frm__input--left" id="zci--cryptocurrency-amount-left" data-original="{{from-amount}}" data-processed="{{amount}}" value="{{amount}}" type="number" step="any">
                 <div class="frm__select">
                     <select class="frm__select--left zci--cryptocurrency-symbol" id="zci--cryptocurrency-symbol-left">
                         <optgroup label="Cryptocurrencies" class="crypto"></optgroup>
@@ -20,7 +20,7 @@
 
             <!-- RIGHT INPUT SECTION -->
             <div class="input__wrap input__wrap--right shadow">
-                <input class="frm__input frm__input--right" id="zci--cryptocurrency-amount-right" data-processed="{{convertedAmount}}" value="{{convertedAmount}}">
+                <input class="frm__input frm__input--right" id="zci--cryptocurrency-amount-right" data-processed="{{convertedAmount}}" value="{{convertedAmount}}" type="number" step="any">
                 <div class="frm__select">
                     <select class="frm__select--right zci--cryptocurrency-symbol" id="zci--cryptocurrency-symbol-right">
                         <optgroup label="Cryptocurrencies" class="crypto"></optgroup>

--- a/share/spice/currency/currency.js
+++ b/share/spice/currency/currency.js
@@ -250,9 +250,15 @@
                 var left_input = $currency_input_left.val();
                 left_input = left_input.replace(/,/g, '');
                 var rightval = parseFloat(left_input) * Converter.rate;
-                var decimals = Converter.getSignificantFigures(Converter.rate, rightval, Converter.to_currency);
+                var numSigFigs = Converter.getSignificantFigures(
+                    Converter.rate, rightval, Converter.to_currency
+                );
+                var rightValInt = Math.floor(rightval);
+                var rightValFrac = rightval % 1;
+
                 $currency_input_right.val(
-                    rightval.toFixed(decimals)
+                    rightValInt.toString() +
+                    rightValFrac.toPrecision(numSigFigs).substring(1)
                 );
             } else {
                 $currency_input_right.val("");
@@ -264,9 +270,15 @@
                 var right_input = $currency_input_right.val()
                 right_input = right_input.replace(/,/g, '');
                 var leftval = parseFloat(right_input) * Converter.inverseRate;
-                var decimals = Converter.getSignificantFigures(Converter.inverseRate, leftval, Converter.from_currency);
+                var numSigFigs = Converter.getSignificantFigures(
+                    Converter.inverseRate, leftval, Converter.from_currency
+                );
+                var leftValInt = Math.floor(leftval);
+                var leftValFrac = leftval % 1;
+
                 $currency_input_left.val(
-                    leftval.toFixed(decimals)
+                    leftValInt.toString() +
+                    leftValFrac.toPrecision(numSigFigs).substring(1)
                 );
             } else {
                 $currency_input_left.val("");


### PR DESCRIPTION
<!-- 

***
DuckDuckHack is currently in Maintenance mode
Please read before submitting: https://duckduckhack.com
***

Use the appropriate format for your Pull Request title above ^^^^^:

If this is a bug fix:
{IA Name}: {Description of change}

If this is a New Instant Answer:
New {IA Name} Spice

If this is something else:
{Tests/Docs/Other}: {Short Description}

-->

## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
Currently the Currency and Cryptocurrency IAs are rounding to a certain number of digits, instead of rounding to a certain number of significant figures. This causes conversions to be inaccurate.

For example, https://duckduckgo.com/?q=0.1+usd+to+eur&ia=currency currently gives `0.09 EUR`, but should be giving `0.088 EUR`. (Conversion as of Mid-Market Rates: 2018-12-08 at 17:00 UTC)

For the Cryptocurrency IA, https://duckduckgo.com/?q=1+ftc+to+usd&ia=cryptocurrency currently gives `0.02 USD`, but should be giving `0.018 USD`. (Conversion as of Market Rates: 2018-12-09 at 12:07 UTC)

This PR fixes these issues, and also fixes the issue in the inverse direction. It does so by replacing [`toFixed()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed) with [`toPrecision()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision). `toPrecision` can sometimes return a number in its exponential format (e.g. 1200 = 1.2e+3), but the HTML5 input field with type `number` will display these correctly.

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->
Fixes #3537 

## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@moollaza 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/currency
<!-- FILL THIS IN:                           ^^^^ -->
