### PR TITLE
Relax triggering with = and ?

### DIFF
--- a/lib/DDG/Spice/Currency.pm
+++ b/lib/DDG/Spice/Currency.pm
@@ -17,7 +17,7 @@ my @topCurrencies = (
     "chf",
     "aud",
     "sek",
-    "nok", 
+    "nok",
 );
 
 # Get all the valid currencies from a text file.
@@ -161,7 +161,7 @@ handle query_lc => sub {
 
         return checkCurrencyCode(1, $from, $to);
     }
-    
+
     # if the query matches one of the lang queries, we will default to
     # 100 usd to eur
     if (/$guard/) {
@@ -188,21 +188,21 @@ handle query_lc => sub {
 
         # if only a currency symbol is present without "currency" keyword, then bail unless a top currency
         return if (
-            $amount eq '' && $to eq '' 
-            && $currencyKeyword eq '' 
-            && exists($currHash{$from}) 
+            $amount eq '' && $to eq ''
+            && $currencyKeyword eq ''
+            && exists($currHash{$from})
             && !grep(/^$from$/, @topCurrencies)
         );
 
         # for edge cases that we don't want to trigger on
-        return if $req->query_lc =~ /mop\stops?/ 
+        return if $req->query_lc =~ /mop\stops?/
                or $req->query_lc =~ m/tops?\s+?\d+/;
         return if $req->query_lc =~ /gold\scups?/;
         return if $req->query_lc =~ /^can$/;
 
         # shouldn't be a hypen between two numbers
         return if $_ =~ /\d+-\d+/;
-         
+
         my $styler = number_style_for($amount);
         return unless $styler;
 

--- a/lib/DDG/Spice/Currency.pm
+++ b/lib/DDG/Spice/Currency.pm
@@ -39,7 +39,7 @@ foreach my $currency (@currencies){
 
 # Define the regexes here.
 my $currency_qr = join('|', @currTriggers);
-my $into_qr = qr/\s(?:en|in|=(?:\s*\?\s*)?|to|in ?to|to|convert (?:in)?to)\s/i;
+my $into_qr = qr/(?:\s(?:en|in(?:\s*\?\s*)?|in ?to|to|convert (?:in)?to)\s|\s*=\s*\?*\s*)/i;
 my $vs_qr = qr/\sv(?:ersu|)s?\.?\s|\s?-\s?/i;
 my $joins_qr = qr/\s(?:and|equals)\.?\s/i;
 my $question_prefix = qr/xe|(?:convert|calculate|what (?:is|are|does)|how (?:much|many) (?:is|are))?\s?/;

--- a/t/Currency.t
+++ b/t/Currency.t
@@ -333,6 +333,49 @@ ddg_spice_test(
         caller => 'DDG::Spice::Currency',
         is_cached => 0
     ),
+    '500 USD = ?PLN' => test_spice(
+        '/js/spice/currency/500/usd/pln',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
+    '500 USD =?PLN' => test_spice(
+        '/js/spice/currency/500/usd/pln',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
+    '500USD= ? PLN' => test_spice(
+        '/js/spice/currency/500/usd/pln',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
+    '500 USD=? PLN' => test_spice(
+        '/js/spice/currency/500/usd/pln',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
+    '500USD = ?PLN' => test_spice(
+        '/js/spice/currency/500/usd/pln',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
+    '500USD=?PLN' => test_spice(
+        '/js/spice/currency/500/usd/pln',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
+    '500USD=PLN' => test_spice(
+        '/js/spice/currency/500/usd/pln',
+        call_type => 'include',
+        caller => 'DDG::Spice::Currency',
+        is_cached => 0
+    ),
+
 
     # Requirement for space between unit and currency
     '5m usd to aud' => test_spice(

--- a/t/Currency.t
+++ b/t/Currency.t
@@ -320,7 +320,6 @@ ddg_spice_test(
         caller => 'DDG::Spice::Currency',
         is_cached => 0
     ),
-
     '5 USD = AUD' => test_spice(
         '/js/spice/currency/5/usd/aud',
         call_type => 'include',
@@ -460,7 +459,7 @@ ddg_spice_test(
         call_type => 'include',
         caller => 'DDG::Spice::Currency',
         is_cached => 0
-    ),				
+    ),
     # when you don't specify the target Currency
     # check for placing currency type before amount
     'CHF 2.95 in eur' => test_spice(
@@ -598,7 +597,7 @@ ddg_spice_test(
         call_type => 'include',
         caller => 'DDG::Spice::Currency',
         is_cached => 0
-    ),  
+    ),
     '4k euro' => test_spice(
         '/js/spice/currency/4000/eur/usd',
         call_type => 'include',
@@ -642,7 +641,7 @@ ddg_spice_test(
         is_cached => 0
     ),
     # check for exchange rate, conversion rate, conversion, converter, value of and price of as keyword
-    
+
     'bitcoin exchange rate' => test_spice(
         '/js/spice/currency/1/xbt/usd',
         call_type => 'include',
@@ -774,7 +773,7 @@ ddg_spice_test(
         call_type => 'include',
         caller => 'DDG::Spice::Currency',
         is_cached => 0
-    ), 
+    ),
     'euro to au dollars' => test_spice(
         '/js/spice/currency/1/eur/aud',
         call_type => 'include',
@@ -968,7 +967,7 @@ ddg_spice_test(
         caller => 'DDG::Spice::Currency',
         is_cached => 0
     ),
-    
+
     # Numbers with with ambiguous formatting.
     'convert 2,000.1.9 cad into usd' => undef,
     # Other types of conversion
@@ -1006,7 +1005,7 @@ ddg_spice_test(
     'sda loans' => undef,
     'americas' => undef,
     'top 50' => undef,
-    
+
     # edge cases that we don't want to trigger
     'mop tops' => undef,
     'gold cup' => undef,


### PR DESCRIPTION
## Description of new Instant Answer, or changes
Relaxes currency triggering to allow more formats that are also supported by Google, I.e. :

500 USD = ?PLN
500 USD =?PLN
500USD= ? PLN
500 USD=? PLN
500USD = ?PLN
500USD=?PLN
500USD=PLN

---

Instant Answer Page: https://duck.co/ia/view/currency
