### PR TITLE
Foreacst: Trigger on 'current weather', 'local weather', etc.

### DIFF
--- a/lib/DDG/Spice/Forecast.pm
+++ b/lib/DDG/Spice/Forecast.pm
@@ -17,8 +17,12 @@ spice is_cached => 1;
 spice proxy_cache_valid => "200 30m";
 
 my @locs = qw (city region_name country_name );
+my @extra_words = sort { length $b <=> length $a } ("local", "near me", "nearby me", "current");
+my $extra_words_qr = join "|", @extra_words;
 
 handle remainder => sub {
+
+    s/\b$extra_words_qr\b//;
 
     return if $_;
 

--- a/lib/DDG/Spice/Forecast.pm
+++ b/lib/DDG/Spice/Forecast.pm
@@ -6,7 +6,7 @@ use utf8;
 use DDG::Spice;
 use Text::Trim;
 
-triggers start => "weather", "forecast", "weather forecast", "weer", "meteo", "wetter", "clima", "tiempo", "météo", "天気", "天气";
+triggers startend => "weather", "forecast", "weather forecast", "weer", "meteo", "wetter", "clima", "tiempo", "météo", "天気", "天气";
 
 spice from => '([^/]*)/?([^/]*)';
 spice to => 'https://darksky.net/ddg?apikey={{ENV{DDG_SPICE_FORECAST_APIKEY}}}&q=$1&callback={{callback}}&lang=$2';

--- a/lib/DDG/Spice/Maps/Places.pm
+++ b/lib/DDG/Spice/Maps/Places.pm
@@ -14,7 +14,7 @@ my $categories_re = share('categories_re')->slurp;
 my $places_re = qr/(local|near|near me|around|around me|here|locally|nearby|close|closest|nearest|locations?|restaurants?)/;
 triggers query_lc => qr/(^$places_re\b|\b$places_re$|^$categories_re\b)/s;
 
-my %skip_remainders = map {$_ => 0} ('current', 'time');
+my %skip_remainders = map {$_ => 0} ('current', 'time', 'weather', 'forecast');
 
 handle query_lc => sub {
     my $query = $_;

--- a/t/Forecast.t
+++ b/t/Forecast.t
@@ -34,6 +34,26 @@ ddg_spice_test(
     ),
 
     DDG::Request->new(
+        query_raw => 'local weather',
+        location => test_location('us'),
+    ) => test_spice(
+        "/js/spice/forecast/Phoenixville%20Pennsylvania%20United%20States/en",
+        call_type => 'include',
+        caller => 'DDG::Spice::Forecast',
+        is_cached => 0
+    ),
+
+    DDG::Request->new(
+        query_raw => 'weather near me',
+        location => test_location('us'),
+    ) => test_spice(
+        "/js/spice/forecast/Phoenixville%20Pennsylvania%20United%20States/en",
+        call_type => 'include',
+        caller => 'DDG::Spice::Forecast',
+        is_cached => 0
+    ),
+
+    DDG::Request->new(
         query_raw => 'weather',
         location => test_location('my'),
     ) => test_spice(

--- a/t/Places.t
+++ b/t/Places.t
@@ -11,11 +11,11 @@ ddg_spice_test(
         '/js/spice/maps/places/nearest%20primos',
         call_type => 'include',
         caller => 'DDG::Spice::Maps::Places',
-    is_cached => 0,
+        is_cached => 0,
     ),
     'local time' => undef,
     'local weather' => undef,
-    'weather near me' => under
+    'weather near me' => undef
 );
 
 done_testing;

--- a/t/Places.t
+++ b/t/Places.t
@@ -14,6 +14,8 @@ ddg_spice_test(
     is_cached => 0,
     ),
     'local time' => undef,
+    'local weather' => undef,
+    'weather near me' => under
 );
 
 done_testing;


### PR DESCRIPTION
## Description of new Instant Answer, or changes
- Enable triggering on queries like 'local forecast', 'current weather', 'weather near me'
- Prevent Places from triggering on weather-related queries too


---

Instant Answer Page: https://duck.co/ia/view/forecast
