### PR TITLE
Weather IA: Add more translated triggers

### DIFF
--- a/lib/DDG/Spice/Forecast.pm
+++ b/lib/DDG/Spice/Forecast.pm
@@ -6,7 +6,7 @@ use utf8;
 use DDG::Spice;
 use Text::Trim;
 
-triggers startend => "weather", "forecast", "weather forecast", "weer", "meteo", "wetter", "clima", "tiempo", "météo", "天気", "天气";
+triggers startend => "weather", "forecast", "weather forecast", "weer", "meteo", "wetter", "clima", "tiempo", "météo", "天気", "天气", "pogoda", "vejr", "vêr", "väder", "tempo", "време", "погода", "райы", "καιρός", "tiempu", "ilm", "eguraldi", "laiks", "եղանակ", "počasie", "sää", "hava durumu";
 
 spice from => '([^/]*)/?([^/]*)';
 spice to => 'https://darksky.net/ddg?apikey={{ENV{DDG_SPICE_FORECAST_APIKEY}}}&q=$1&callback={{callback}}&lang=$2';

--- a/lib/DDG/Spice/Forecast.pm
+++ b/lib/DDG/Spice/Forecast.pm
@@ -6,7 +6,7 @@ use utf8;
 use DDG::Spice;
 use Text::Trim;
 
-triggers startend => "weather", "forecast", "weather forecast", "weer", "meteo", "wetter", "clima", "tiempo", "météo", "天気", "天气", "pogoda", "vejr", "vêr", "väder", "tempo", "време", "погода", "райы", "καιρός", "tiempu", "ilm", "eguraldi", "laiks", "եղանակ", "počasie", "sää", "hava durumu";
+triggers startend => "weather", "forecast", "weather forecast", "weer", "meteo", "wetter", "clima", "tiempo", "météo", "天気", "天气", "pogoda", "vejr", "vêr", "väder", "tempo", "време", "времето", "погода", "райы", "καιρός", "tiempu", "ilm", "eguraldi", "laiks", "եղանակ", "počasie", "sää", "hava durumu";
 
 spice from => '([^/]*)/?([^/]*)';
 spice to => 'https://darksky.net/ddg?apikey={{ENV{DDG_SPICE_FORECAST_APIKEY}}}&q=$1&callback={{callback}}&lang=$2';


### PR DESCRIPTION
<!-- 

***
DuckDuckHack is currently in Maintenance mode
Please read before submitting: https://duckduckhack.com
***

Use the appropriate format for your Pull Request title above ^^^^^:

If this is a bug fix:
{IA Name}: {Description of change}

If this is a New Instant Answer:
New {IA Name} Spice

If this is something else:
{Tests/Docs/Other}: {Short Description}

-->

## Description of new Instant Answer, or changes
Adding some more international triggers based on wikictionary: https://en.wiktionary.org/wiki/weather

I only added the ones I could verify with a translation service, though.


## Related Issues and Discussions
A quick win following up from #3520 


## People to notify
@bbraithwaite @knowak 


<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/forecast
<!-- FILL THIS IN:                           ^^^^ -->
