### PR TITLE
IsItUp: changing HTTP to HTTPS for API call

### DIFF
--- a/share/spice/is_it_up/is_it_up.js
+++ b/share/spice/is_it_up/is_it_up.js
@@ -12,7 +12,7 @@
             data: api_result,
             signal: 'high',
             meta: {
-                sourceUrl: 'http://isitup.org/' + api_result['domain'],
+                sourceUrl: 'https://isitup.org/' + api_result['domain'],
                 sourceName: 'Is it up?'
             },
             templates: {


### PR DESCRIPTION
## Description of new Instant Answer, or changes

IsItUp.org can use HTTPS for API calls.  We should use it to better protect users' security and privacy.

---

Instant Answer Page: https://duck.co/ia/view/is_it_up
