### PR TITLE
Update Search.pm to add bgg as a trigger

### DIFF
--- a/lib/DDG/Spice/BoardGameGeek/Search.pm
+++ b/lib/DDG/Spice/BoardGameGeek/Search.pm
@@ -22,7 +22,7 @@ spice alt_to => {
     }
 };
 
-triggers end => 'boardgamegeek', 'board game geek', 'boardgame', 'board game', 'card game';
+triggers end => 'boardgamegeek', 'board game geek', 'boardgame', 'board game', 'card game', 'bgg';
 
 handle remainder => sub {
     return unless $_;


### PR DESCRIPTION
Could you please add 'bgg' as a end trigger for searching board game geek, please.
triggers end => 'boardgamegeek', 'board game geek', 'boardgame', 'board game', 'card game', 'bgg';

<!-- 

***
DuckDuckHack is currently in Maintenance mode
Please read before submitting: https://duckduckhack.com
***

Use the appropriate format for your Pull Request title above ^^^^^:

If this is a bug fix:
{IA Name}: {Description of change}

If this is a New Instant Answer:
New {IA Name} Spice

If this is something else:
{Tests/Docs/Other}: {Short Description}

-->

## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->


## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->


## People to notify
<!-- Please @mention any relevant people/organizations here: -->


<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/{ID}
<!-- FILL THIS IN:                           ^^^^ -->
