### PR TITLE
Equaldex: Fixed API URL redirect to HTTPS

### DIFF
--- a/lib/DDG/Spice/Equaldex.pm
+++ b/lib/DDG/Spice/Equaldex.pm
@@ -7,9 +7,9 @@ use Locale::Country;
 
 spice is_cached => 1;
 
-spice to => 'http://www.equaldex.com/api/region?format=json&region=$1&callback={{callback}}';
+spice to => 'https://www.equaldex.com/api/region?format=json&region=$1&callback={{callback}}';
 
-triggers startend => "lgbt", "lesbian", "gay", "bisexual", "transgender";
+triggers startend => "lgbt", "lgbtq", "lesbian", "gay", "bisexual", "transgender";
 my $guardRe = qr/(rights?|laws?) (in)?\s?/;
 
 handle remainder => sub {


### PR DESCRIPTION

<!-- 

***
DuckDuckHack is currently in Maintenance mode
Please read before submitting: https://duckduckhack.com
***

Use the appropriate format for your Pull Request title above ^^^^^:

If this is a bug fix:
{IA Name}: {Description of change}

If this is a New Instant Answer:
New {IA Name} Spice

If this is something else:
{Tests/Docs/Other}: {Short Description}

-->

## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
Currently, the Equaldex instant answer does not appear to be working. I believe this is because the API redirects to HTTPS. (Also added "lgbtq" as a synonym of "lgbt")

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->


## People to notify
<!-- Please @mention any relevant people/organizations here: -->


<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/{ID}
<!-- FILL THIS IN:                           ^^^^ -->
